### PR TITLE
refactor(codegen): migrate set/Map hash op outer loop scaffold via crates/emit primitives

### DIFF
--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -1018,7 +1018,8 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         if (key->getType() != keyTy)
             codegenError("hasKey() key type mismatch");
         llvm::Value *idx = emitMapKeyLookup(mapPtr, key, keyTy);
-        return builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "hasKey");
+        // #2188 ([4a] = i1 result cross via emitICmpSGE; lookup already #2101).
+        return emitICmpSGE(idx, emitConstInt(i64Ty_, 0), "hasKey");
     }
 
     // checked/saturating/wrapping arithmetic dispatch

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -1128,54 +1128,55 @@ llvm::Value *CodeGen::emitMapMergeCore(llvm::Value *map1, llvm::Value *map2,
 
     // Set up header
     storeMapHeaderFields(newHeader, mf1.len, maxCap, newKeys, newVals);
-    llvm::Value *lenPtr = builder_.CreateStructGEP(mapHeaderTy_, newHeader, 0, "mg_len_ptr");
+    llvm::Value *lenPtr = emitStructGEP(mapHeaderTy_, newHeader, 0, "mg_len_ptr");
 
     // Init hash buckets
     emitBucketInit(newHeader, mapHeaderTy_, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, 16);
 
+    // #2188 ([4a] = outer loop scaffold migration; insert+rehash deferred to #2193).
     // Re-hash map1 keys into new map's buckets
     {
-        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "mg_rh_i");
-        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        llvm::Value *iVar = emitAlloca(i64Ty_, "mg_rh_i");
+        emitStore(emitConstInt(i64Ty_, 0), iVar);
         llvm::BasicBlock *rCondBB = createBB("mg.rh.cond");
         llvm::BasicBlock *rBodyBB = createBB("mg.rh.body");
         llvm::BasicBlock *rEndBB = createBB("mg.rh.end");
         emitBranchUncond(rCondBB);
         builder_.SetInsertPoint(rCondBB);
-        llvm::Value *ri = builder_.CreateLoad(i64Ty_, iVar, "mg_ri");
-        emitBranchCond(builder_.CreateICmpSLT(ri, mf1.len), rBodyBB, rEndBB);
+        llvm::Value *ri = emitLoad(i64Ty_, iVar, "mg_ri");
+        emitBranchCond(emitICmpSLT(ri, mf1.len, ""), rBodyBB, rEndBB);
         builder_.SetInsertPoint(rBodyBB);
-        llvm::Value *kp = builder_.CreateGEP(keyTy, newKeys, {ri}, "mg_rh_kp");
-        llvm::Value *kv = builder_.CreateLoad(keyTy, kp, "mg_rh_kv");
+        llvm::Value *kp = emitGEP(keyTy, newKeys, ri, "mg_rh_kp");
+        llvm::Value *kv = emitLoad(keyTy, kp, "mg_rh_kv");
         if (!keyName.empty()) propagateTypeMeta(keyName, kv);
         emitBucketInsertAndRehashCheck(newHeader, mapHeaderTy_, kMapLayout.lenIdx, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, kv, keyTy, ri);
-        builder_.CreateStore(builder_.CreateAdd(ri, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        emitStore(emitAdd(ri, emitConstInt(i64Ty_, 1), ""), iVar);
         emitBranchUncond(rCondBB);
         builder_.SetInsertPoint(rEndBB);
     }
 
     // Add/update entries from map2 (rhs-wins on key collision)
     {
-        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "mg_i2");
-        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        llvm::Value *iVar = emitAlloca(i64Ty_, "mg_i2");
+        emitStore(emitConstInt(i64Ty_, 0), iVar);
         llvm::BasicBlock *condBB = createBB("mg.add.cond");
         llvm::BasicBlock *bodyBB = createBB("mg.add.body");
         llvm::BasicBlock *endBB = createBB("mg.add.end");
         emitBranchUncond(condBB);
         builder_.SetInsertPoint(condBB);
-        llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "mg_ci");
-        emitBranchCond(builder_.CreateICmpSLT(i, mf2.len), bodyBB, endBB);
+        llvm::Value *i = emitLoad(i64Ty_, iVar, "mg_ci");
+        emitBranchCond(emitICmpSLT(i, mf2.len, ""), bodyBB, endBB);
 
         builder_.SetInsertPoint(bodyBB);
-        llvm::Value *kp = builder_.CreateGEP(keyTy, mf2.keys, {i}, "mg_kp2");
-        llvm::Value *kv = builder_.CreateLoad(keyTy, kp, "mg_kv2");
+        llvm::Value *kp = emitGEP(keyTy, mf2.keys, i, "mg_kp2");
+        llvm::Value *kv = emitLoad(keyTy, kp, "mg_kv2");
         if (!keyName.empty()) propagateTypeMeta(keyName, kv);
-        llvm::Value *vp = builder_.CreateGEP(valTy, mf2.vals, {i}, "mg_vp2");
-        llvm::Value *vv = builder_.CreateLoad(valTy, vp, "mg_vv2");
+        llvm::Value *vp = emitGEP(valTy, mf2.vals, i, "mg_vp2");
+        llvm::Value *vv = emitLoad(valTy, vp, "mg_vv2");
 
         // Check if key exists in new map
         llvm::Value *lookupIdx = emitMapKeyLookup(newHeader, kv, keyTy, keyName);
-        llvm::Value *exists = builder_.CreateICmpSGE(lookupIdx, llvm::ConstantInt::get(i64Ty_, 0), "mg_exists");
+        llvm::Value *exists = emitICmpSGE(lookupIdx, emitConstInt(i64Ty_, 0), "mg_exists");
 
         llvm::BasicBlock *updateBB = createBB("mg.update");
         llvm::BasicBlock *insertBB = createBB("mg.insert");
@@ -1184,36 +1185,39 @@ llvm::Value *CodeGen::emitMapMergeCore(llvm::Value *map1, llvm::Value *map2,
 
         // Update existing key's value
         builder_.SetInsertPoint(updateBB);
-        llvm::Value *curVals = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, newHeader, 3), "mg_cur_vals");
-        llvm::Value *updPtr = builder_.CreateGEP(valTy, curVals, {lookupIdx}, "mg_upd_ptr");
+        llvm::Value *curValsField = emitStructGEP(mapHeaderTy_, newHeader, 3, "");
+        llvm::Value *curVals = emitLoad(ptrTy_, curValsField, "mg_cur_vals");
+        llvm::Value *updPtr = emitGEP(valTy, curVals, lookupIdx, "mg_upd_ptr");
         // Release the old ARC-managed value before overwriting (#1242 leak).
         if (mgValIsArc) {
-            llvm::Value *oldVal = builder_.CreateLoad(valTy, updPtr, "mg_upd_old");
+            llvm::Value *oldVal = emitLoad(valTy, updPtr, "mg_upd_old");
             llvm::Value *oldHdr = (mgValArcKind == CollectionKind::Str)
                 ? emitStrGetHeaderFromData(oldVal) : emitArcGetHeaderFromData(oldVal);
             emitArcRelease(oldHdr, false, nullptr, nullptr);
             retainArcValue(vv);
         }
-        builder_.CreateStore(vv, updPtr);
+        emitStore(vv, updPtr);
         emitBranchUncond(nextBB);
 
         // Insert new key-value pair
         builder_.SetInsertPoint(insertBB);
-        llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "mg_cur_len");
-        llvm::Value *curKeys = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, newHeader, 2), "mg_cur_keys");
-        llvm::Value *newKeyPtr = builder_.CreateGEP(keyTy, curKeys, {curLen}, "mg_new_kp");
+        llvm::Value *curLen = emitLoad(i64Ty_, lenPtr, "mg_cur_len");
+        llvm::Value *curKeysField = emitStructGEP(mapHeaderTy_, newHeader, 2, "");
+        llvm::Value *curKeys = emitLoad(ptrTy_, curKeysField, "mg_cur_keys");
+        llvm::Value *newKeyPtr = emitGEP(keyTy, curKeys, curLen, "mg_new_kp");
         if (mgKeyIsArc) retainArcValue(kv);
-        builder_.CreateStore(kv, newKeyPtr);
-        llvm::Value *curVals2 = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, newHeader, 3), "mg_cur_vals2");
-        llvm::Value *newValPtr = builder_.CreateGEP(valTy, curVals2, {curLen}, "mg_new_vp");
+        emitStore(kv, newKeyPtr);
+        llvm::Value *curVals2Field = emitStructGEP(mapHeaderTy_, newHeader, 3, "");
+        llvm::Value *curVals2 = emitLoad(ptrTy_, curVals2Field, "mg_cur_vals2");
+        llvm::Value *newValPtr = emitGEP(valTy, curVals2, curLen, "mg_new_vp");
         if (mgValIsArc) retainArcValue(vv);
-        builder_.CreateStore(vv, newValPtr);
-        builder_.CreateStore(builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1)), lenPtr);
+        emitStore(vv, newValPtr);
+        emitStore(emitAdd(curLen, emitConstInt(i64Ty_, 1), ""), lenPtr);
         emitBucketInsertAndRehashCheck(newHeader, mapHeaderTy_, kMapLayout.lenIdx, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, kv, keyTy, curLen);
         emitBranchUncond(nextBB);
 
         builder_.SetInsertPoint(nextBB);
-        builder_.CreateStore(builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        emitStore(emitAdd(i, emitConstInt(i64Ty_, 1), ""), iVar);
         emitBranchUncond(condBB);
         builder_.SetInsertPoint(endBB);
     }

--- a/src/codegen_call_set_ops.cpp
+++ b/src/codegen_call_set_ops.cpp
@@ -108,66 +108,67 @@ llvm::Value *CodeGen::emitSetUnionCore(llvm::Value *set1, llvm::Value *set2,
 
     // Init header with len1
     storeSetHeaderFields(newHeader, sf1.len, maxLen, newData);
-    llvm::Value *lenPtr = builder_.CreateStructGEP(setHeaderTy_, newHeader, 0, "u_len_ptr");
+    llvm::Value *lenPtr = emitStructGEP(setHeaderTy_, newHeader, 0, "u_len_ptr");
 
     // Init buckets for the new set
     emitBucketInit(newHeader, setHeaderTy_, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, 16);
 
+    // #2188 ([4a] = outer loop scaffold migration; insert+rehash deferred to #2193).
     // Re-hash all elements from set1 into new set's buckets
     {
-        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "u_rehash_i");
-        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        llvm::Value *iVar = emitAlloca(i64Ty_, "u_rehash_i");
+        emitStore(emitConstInt(i64Ty_, 0), iVar);
         llvm::BasicBlock *rCondBB = createBB("u.rehash.cond");
         llvm::BasicBlock *rBodyBB = createBB("u.rehash.body");
         llvm::BasicBlock *rEndBB = createBB("u.rehash.end");
         emitBranchUncond(rCondBB);
         builder_.SetInsertPoint(rCondBB);
-        llvm::Value *ri = builder_.CreateLoad(i64Ty_, iVar, "u_ri");
-        emitBranchCond(builder_.CreateICmpSLT(ri, sf1.len), rBodyBB, rEndBB);
+        llvm::Value *ri = emitLoad(i64Ty_, iVar, "u_ri");
+        emitBranchCond(emitICmpSLT(ri, sf1.len, ""), rBodyBB, rEndBB);
         builder_.SetInsertPoint(rBodyBB);
-        llvm::Value *ep = builder_.CreateGEP(elemTy, newData, {ri}, "u_rehash_ep");
-        llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "u_rehash_ev");
+        llvm::Value *ep = emitGEP(elemTy, newData, ri, "u_rehash_ep");
+        llvm::Value *ev = emitLoad(elemTy, ep, "u_rehash_ev");
         if (!elemName.empty()) propagateTypeMeta(elemName, ev);
         emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, ev, elemTy, ri);
-        builder_.CreateStore(builder_.CreateAdd(ri, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        emitStore(emitAdd(ri, emitConstInt(i64Ty_, 1), ""), iVar);
         emitBranchUncond(rCondBB);
         builder_.SetInsertPoint(rEndBB);
     }
 
     // Add elements from set2 that are not in set1
     {
-        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "u_i2");
-        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        llvm::Value *iVar = emitAlloca(i64Ty_, "u_i2");
+        emitStore(emitConstInt(i64Ty_, 0), iVar);
         llvm::BasicBlock *condBB = createBB("u.add.cond");
         llvm::BasicBlock *bodyBB = createBB("u.add.body");
         llvm::BasicBlock *endBB = createBB("u.add.end");
         emitBranchUncond(condBB);
         builder_.SetInsertPoint(condBB);
-        llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "u_ci");
-        emitBranchCond(builder_.CreateICmpSLT(i, sf2.len), bodyBB, endBB);
+        llvm::Value *i = emitLoad(i64Ty_, iVar, "u_ci");
+        emitBranchCond(emitICmpSLT(i, sf2.len, ""), bodyBB, endBB);
         builder_.SetInsertPoint(bodyBB);
-        llvm::Value *ep = builder_.CreateGEP(elemTy, sf2.elems, {i}, "u_ep2");
-        llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "u_ev2");
+        llvm::Value *ep = emitGEP(elemTy, sf2.elems, i, "u_ep2");
+        llvm::Value *ev = emitLoad(elemTy, ep, "u_ev2");
         if (!elemName.empty())
             propagateTypeMeta(elemName, ev);
 
         // Check if already in new set
         llvm::Value *lookupIdx = emitSetElementLookup(newHeader, ev, elemTy, elemName);
-        llvm::Value *notFound = builder_.CreateICmpSLT(lookupIdx, llvm::ConstantInt::get(i64Ty_, 0), "u_not_found");
+        llvm::Value *notFound = emitICmpSLT(lookupIdx, emitConstInt(i64Ty_, 0), "u_not_found");
         llvm::BasicBlock *addBB = createBB("u.add.do");
         llvm::BasicBlock *nextBB = createBB("u.add.next");
         emitBranchCond(notFound, addBB, nextBB);
 
         builder_.SetInsertPoint(addBB);
-        llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "u_cur_len");
-        llvm::Value *storePtr = builder_.CreateGEP(elemTy, newData, {curLen}, "u_store_ptr");
-        builder_.CreateStore(ev, storePtr);
+        llvm::Value *curLen = emitLoad(i64Ty_, lenPtr, "u_cur_len");
+        llvm::Value *storePtr = emitGEP(elemTy, newData, curLen, "u_store_ptr");
+        emitStore(ev, storePtr);
         emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, ev, elemTy, curLen);
-        builder_.CreateStore(builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1)), lenPtr);
+        emitStore(emitAdd(curLen, emitConstInt(i64Ty_, 1), ""), lenPtr);
         emitBranchUncond(nextBB);
 
         builder_.SetInsertPoint(nextBB);
-        builder_.CreateStore(builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        emitStore(emitAdd(i, emitConstInt(i64Ty_, 1), ""), iVar);
         emitBranchUncond(condBB);
         builder_.SetInsertPoint(endBB);
     }
@@ -213,40 +214,41 @@ llvm::Value *CodeGen::emitSetOp_intersection(const CallExpr &e) {
         llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "is_data");
 
         storeSetHeaderFields(newHeader, llvm::ConstantInt::get(i64Ty_, 0), sf.len, newData);
-        llvm::Value *lenPtr = builder_.CreateStructGEP(setHeaderTy_, newHeader, 0, "is_len_ptr");
+        llvm::Value *lenPtr = emitStructGEP(setHeaderTy_, newHeader, 0, "is_len_ptr");
         emitBucketInit(newHeader, setHeaderTy_, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, 16);
 
-        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "is_i");
-        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        // #2188 ([4a] = outer loop scaffold migration; insert+rehash deferred to #2193).
+        llvm::Value *iVar = emitAlloca(i64Ty_, "is_i");
+        emitStore(emitConstInt(i64Ty_, 0), iVar);
         llvm::BasicBlock *condBB = createBB("is.cond");
         llvm::BasicBlock *bodyBB = createBB("is.body");
         llvm::BasicBlock *endBB = createBB("is.end");
         emitBranchUncond(condBB);
         builder_.SetInsertPoint(condBB);
-        llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "is_ci");
-        emitBranchCond(builder_.CreateICmpSLT(i, sf.len), bodyBB, endBB);
+        llvm::Value *i = emitLoad(i64Ty_, iVar, "is_ci");
+        emitBranchCond(emitICmpSLT(i, sf.len, ""), bodyBB, endBB);
         builder_.SetInsertPoint(bodyBB);
-        llvm::Value *ep = builder_.CreateGEP(elemTy, sf.elems, {i}, "is_ep");
-        llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "is_ev");
+        llvm::Value *ep = emitGEP(elemTy, sf.elems, i, "is_ep");
+        llvm::Value *ev = emitLoad(elemTy, ep, "is_ev");
         if (!elemName.empty())
             propagateTypeMeta(elemName, ev);
 
         llvm::Value *inSet2 = emitSetElementLookup(set2, ev, elemTy, elemName);
-        llvm::Value *found = builder_.CreateICmpSGE(inSet2, llvm::ConstantInt::get(i64Ty_, 0), "is_found");
+        llvm::Value *found = emitICmpSGE(inSet2, emitConstInt(i64Ty_, 0), "is_found");
         llvm::BasicBlock *addBB = createBB("is.add");
         llvm::BasicBlock *nextBB = createBB("is.next");
         emitBranchCond(found, addBB, nextBB);
 
         builder_.SetInsertPoint(addBB);
-        llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "is_cur_len");
-        llvm::Value *storePtr = builder_.CreateGEP(elemTy, newData, {curLen}, "is_store_ptr");
-        builder_.CreateStore(ev, storePtr);
+        llvm::Value *curLen = emitLoad(i64Ty_, lenPtr, "is_cur_len");
+        llvm::Value *storePtr = emitGEP(elemTy, newData, curLen, "is_store_ptr");
+        emitStore(ev, storePtr);
         emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, ev, elemTy, curLen);
-        builder_.CreateStore(builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1)), lenPtr);
+        emitStore(emitAdd(curLen, emitConstInt(i64Ty_, 1), ""), lenPtr);
         emitBranchUncond(nextBB);
 
         builder_.SetInsertPoint(nextBB);
-        builder_.CreateStore(builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        emitStore(emitAdd(i, emitConstInt(i64Ty_, 1), ""), iVar);
         emitBranchUncond(condBB);
         builder_.SetInsertPoint(endBB);
 
@@ -279,40 +281,41 @@ llvm::Value *CodeGen::emitSetOp_difference(const CallExpr &e) {
         llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "df_data");
 
         storeSetHeaderFields(newHeader, llvm::ConstantInt::get(i64Ty_, 0), sf.len, newData);
-        llvm::Value *lenPtr = builder_.CreateStructGEP(setHeaderTy_, newHeader, 0, "df_len_ptr");
+        llvm::Value *lenPtr = emitStructGEP(setHeaderTy_, newHeader, 0, "df_len_ptr");
         emitBucketInit(newHeader, setHeaderTy_, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, 16);
 
-        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "df_i");
-        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        // #2188 ([4a] = outer loop scaffold migration; insert+rehash deferred to #2193).
+        llvm::Value *iVar = emitAlloca(i64Ty_, "df_i");
+        emitStore(emitConstInt(i64Ty_, 0), iVar);
         llvm::BasicBlock *condBB = createBB("df.cond");
         llvm::BasicBlock *bodyBB = createBB("df.body");
         llvm::BasicBlock *endBB = createBB("df.end");
         emitBranchUncond(condBB);
         builder_.SetInsertPoint(condBB);
-        llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "df_ci");
-        emitBranchCond(builder_.CreateICmpSLT(i, sf.len), bodyBB, endBB);
+        llvm::Value *i = emitLoad(i64Ty_, iVar, "df_ci");
+        emitBranchCond(emitICmpSLT(i, sf.len, ""), bodyBB, endBB);
         builder_.SetInsertPoint(bodyBB);
-        llvm::Value *ep = builder_.CreateGEP(elemTy, sf.elems, {i}, "df_ep");
-        llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "df_ev");
+        llvm::Value *ep = emitGEP(elemTy, sf.elems, i, "df_ep");
+        llvm::Value *ev = emitLoad(elemTy, ep, "df_ev");
         if (!elemName.empty())
             propagateTypeMeta(elemName, ev);
 
         llvm::Value *inSet2 = emitSetElementLookup(set2, ev, elemTy, elemName);
-        llvm::Value *notFound = builder_.CreateICmpSLT(inSet2, llvm::ConstantInt::get(i64Ty_, 0), "df_not_found");
+        llvm::Value *notFound = emitICmpSLT(inSet2, emitConstInt(i64Ty_, 0), "df_not_found");
         llvm::BasicBlock *addBB = createBB("df.add");
         llvm::BasicBlock *nextBB = createBB("df.next");
         emitBranchCond(notFound, addBB, nextBB);
 
         builder_.SetInsertPoint(addBB);
-        llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "df_cur_len");
-        llvm::Value *storePtr = builder_.CreateGEP(elemTy, newData, {curLen}, "df_store_ptr");
-        builder_.CreateStore(ev, storePtr);
+        llvm::Value *curLen = emitLoad(i64Ty_, lenPtr, "df_cur_len");
+        llvm::Value *storePtr = emitGEP(elemTy, newData, curLen, "df_store_ptr");
+        emitStore(ev, storePtr);
         emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, ev, elemTy, curLen);
-        builder_.CreateStore(builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1)), lenPtr);
+        emitStore(emitAdd(curLen, emitConstInt(i64Ty_, 1), ""), lenPtr);
         emitBranchUncond(nextBB);
 
         builder_.SetInsertPoint(nextBB);
-        builder_.CreateStore(builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        emitStore(emitAdd(i, emitConstInt(i64Ty_, 1), ""), iVar);
         emitBranchUncond(condBB);
         builder_.SetInsertPoint(endBB);
 
@@ -347,39 +350,40 @@ llvm::Value *CodeGen::emitSetOp_symmetric_difference(const CallExpr &e) {
         llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "sd_data");
 
         storeSetHeaderFields(newHeader, llvm::ConstantInt::get(i64Ty_, 0), maxLen, newData);
-        llvm::Value *lenPtr = builder_.CreateStructGEP(setHeaderTy_, newHeader, 0, "sd_len_ptr");
+        llvm::Value *lenPtr = emitStructGEP(setHeaderTy_, newHeader, 0, "sd_len_ptr");
         emitBucketInit(newHeader, setHeaderTy_, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, 16);
 
-        // Add elements from set1 not in set2
+        // #2188 ([4a] = outer loop scaffold migration; insert+rehash deferred to #2193).
+        // Add elements from set1 not in set2 (and set2 not in set1 via the second call).
         auto emitSetDiffLoop = [&](llvm::Value *srcData, llvm::Value *srcLen, llvm::Value *otherSet, const std::string &prefix) {
-            llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, prefix + "_i");
-            builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+            llvm::Value *iVar = emitAlloca(i64Ty_, (prefix + "_i").c_str());
+            emitStore(emitConstInt(i64Ty_, 0), iVar);
             llvm::BasicBlock *cBB = createBBInFn((prefix + ".cond").c_str(), fn_);
             llvm::BasicBlock *bBB = createBBInFn((prefix + ".body").c_str(), fn_);
             llvm::BasicBlock *eBB = createBBInFn((prefix + ".end").c_str(), fn_);
             emitBranchUncond(cBB);
             builder_.SetInsertPoint(cBB);
-            llvm::Value *ci = builder_.CreateLoad(i64Ty_, iVar, prefix + "_ci");
-            emitBranchCond(builder_.CreateICmpSLT(ci, srcLen), bBB, eBB);
+            llvm::Value *ci = emitLoad(i64Ty_, iVar, (prefix + "_ci").c_str());
+            emitBranchCond(emitICmpSLT(ci, srcLen, ""), bBB, eBB);
             builder_.SetInsertPoint(bBB);
-            llvm::Value *ePtr = builder_.CreateGEP(elemTy, srcData, {ci}, prefix + "_ep");
-            llvm::Value *eVal = builder_.CreateLoad(elemTy, ePtr, prefix + "_ev");
+            llvm::Value *ePtr = emitGEP(elemTy, srcData, ci, (prefix + "_ep").c_str());
+            llvm::Value *eVal = emitLoad(elemTy, ePtr, (prefix + "_ev").c_str());
             if (!elemName.empty())
                 propagateTypeMeta(elemName, eVal);
             llvm::Value *inOther = emitSetElementLookup(otherSet, eVal, elemTy, elemName);
-            llvm::Value *notInOther = builder_.CreateICmpSLT(inOther, llvm::ConstantInt::get(i64Ty_, 0), prefix + "_nf");
+            llvm::Value *notInOther = emitICmpSLT(inOther, emitConstInt(i64Ty_, 0), (prefix + "_nf").c_str());
             llvm::BasicBlock *aBB = createBBInFn((prefix + ".add").c_str(), fn_);
             llvm::BasicBlock *nBB = createBBInFn((prefix + ".next").c_str(), fn_);
             emitBranchCond(notInOther, aBB, nBB);
             builder_.SetInsertPoint(aBB);
-            llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, prefix + "_cl");
-            llvm::Value *sp = builder_.CreateGEP(elemTy, newData, {curLen}, prefix + "_sp");
-            builder_.CreateStore(eVal, sp);
+            llvm::Value *curLen = emitLoad(i64Ty_, lenPtr, (prefix + "_cl").c_str());
+            llvm::Value *sp = emitGEP(elemTy, newData, curLen, (prefix + "_sp").c_str());
+            emitStore(eVal, sp);
             emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, eVal, elemTy, curLen);
-            builder_.CreateStore(builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1)), lenPtr);
+            emitStore(emitAdd(curLen, emitConstInt(i64Ty_, 1), ""), lenPtr);
             emitBranchUncond(nBB);
             builder_.SetInsertPoint(nBB);
-            builder_.CreateStore(builder_.CreateAdd(ci, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+            emitStore(emitAdd(ci, emitConstInt(i64Ty_, 1), ""), iVar);
             emitBranchUncond(cBB);
             builder_.SetInsertPoint(eBB);
         };

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -67,8 +67,10 @@ llvm::Value *CodeGen::emitStrOp_contains(const CallExpr &e) {
             codegenError("contains() element type mismatch");
         std::string cElemName = getSetElemName(s);
         validateSetElemType(cElemName, elem, "contains()");
+        // #2188 ([4a] = i1 result cross via emitICmpSGE on both Set/Map branches
+        // below; lookup itself already #2101).
         llvm::Value *idx = emitSetElementLookup(s, elem, setElemTy, cElemName);
-        return builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "set_contains");
+        return emitICmpSGE(idx, emitConstInt(i64Ty_, 0), "set_contains");
     }
 
     if (llvm::Type *mapKeyTy = getMapKeyType(s)) {
@@ -78,7 +80,7 @@ llvm::Value *CodeGen::emitStrOp_contains(const CallExpr &e) {
         if (key->getType() != mapKeyTy)
             codegenError("contains() key type mismatch");
         llvm::Value *idx = emitMapKeyLookup(s, key, mapKeyTy);
-        return builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "map_contains");
+        return emitICmpSGE(idx, emitConstInt(i64Ty_, 0), "map_contains");
     }
 
     llvm::Value *sub = emitExpr(*e.args[1]);


### PR DESCRIPTION
## Summary

- Pilot C (#2101) settled the hash-table **lookup** capability but explicitly deferred the "op bodies on top of lookup" to a follow-on sweep (boundary doc L401). This PR migrates that scope's first half.
- 5 loop-bearing functions (`emitSetUnionCore`, `emitSetOp_intersection`/`_difference`/`_symmetric_difference`, `emitMapMergeCore`) plus 3 trivial cleanups (`emitStrOp_contains` Set/Map intercepts, `hasKey`) now go through `emit*` C++ wrappers (= `crates/emit` ABI primitives).
- Single principle across all 5 loops: **in-loop = everything except `emitBucketInsertAndRehashCheck`; pre-loop new-collection construction stays C++-side** per #2095 precedent.

## Scope boundary

In-scope (migrated): outer loop scaffold (alloca/load/store/GEP/StructGEP/ICmp/Add/branch), addBB lookup-then-conditional-insert flow, and the `lenPtr` StructGEP.

Out-of-scope carve-outs (each tracked):

- `emitBucketInsertAndRehashCheck` — **#2193** (insert+rehash capability)
- `emitBucketInit` / `storeSetHeaderFields` / `storeMapHeaderFields` / `loadSetHeader` / `loadMapHeader` — header init/store/load capability (follow-on)
- `builder_.CreateCall(mallocFn|memcpyFn|freeFn)` + `CreateMul` for sizing — libc + ARC alloc capability (follow-on)
- `emitCollOp_get` / `keys` / `values` / `items` — **already migrated** in #2094 / #2095
- `isDisjoint` — not implemented in Ry stdlib (issue mention was aspirational; separate follow-on if added)

## Verification

- IR bit-exact `--emit-llvm-ir` diff (ASLR-normalized) empty across union / intersection / difference / symmetricDifference / map merge (incl. `mgValIsArc` branch via `Map<str, List<int>>`) / contains / hasKey.
- Per-op loop markers (`is.*` / `df.*` / `u.*` / `sd*.*` / `mg_*`) and shared lookup markers (`ht_lookup_idx`, `slin_cp`, `slin.any.eq`, `key_ext`) grep-confirmed in baseline before trusting the diff (#2026 false-pass discipline).

## Test plan

- [x] `./build-rust/ry_tests` — 2795/2795 pass
- [x] `./build-rust/ry test -p` — 207 files / 0 failures
- [x] ASan + UBSan — clean
- [x] TSan — clean
- [x] clang-tidy + cppcheck + scan-build — No bugs found
- [x] IR bit-exact diff verified empty for every migrated op (incl. ARC-value Map branch)

Closes #2188
Refs #2101, #2094, #2095, #2187, #2197, #2191 (audit), #2193 (next capability)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored internal code generation for map, set, and string operations to use unified helper functions, improving code consistency and maintainability across core data structure implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->