### PR TITLE
refactor(codegen): migrate arith intrinsic+aggregate ops via crates/emit primitives (#2189)

### DIFF
--- a/crates/emit/src/abi/primitive.rs
+++ b/crates/emit/src/abi/primitive.rs
@@ -491,6 +491,24 @@ pub unsafe extern "C" fn ry_emit_or(
     intern(c, to_ry_value(v.0))
 }
 
+/// Emit `xor lhs, rhs`. NULL ctx / operand → 0.
+#[no_mangle]
+pub unsafe extern "C" fn ry_emit_xor(
+    ctx: *mut RyEmitCtx,
+    lhs_id: RyValueId,
+    rhs_id: RyValueId,
+    name: *const c_char,
+) -> RyValueId {
+    let Some(c) = checked_cx(ctx) else {
+        return 0;
+    };
+    let (Some(lhs), Some(rhs)) = (resolve_value(c, lhs_id), resolve_value(c, rhs_id)) else {
+        return 0;
+    };
+    let v = c.build_xor(lhs, rhs, name_or_empty(name));
+    intern(c, to_ry_value(v.0))
+}
+
 /// Emit `add lhs, rhs`. NULL ctx / operand → 0.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_add(

--- a/crates/emit/src/primitive/ops.rs
+++ b/crates/emit/src/primitive/ops.rs
@@ -359,6 +359,16 @@ impl EmitCtx {
         ValueRef(LLVMBuildOr(self.builder, lhs.0, rhs.0, name))
     }
 
+    // `xor lhs, rhs`.
+    pub(crate) unsafe fn build_xor(
+        &mut self,
+        lhs: ValueRef,
+        rhs: ValueRef,
+        name: *const c_char,
+    ) -> ValueRef {
+        ValueRef(LLVMBuildXor(self.builder, lhs.0, rhs.0, name))
+    }
+
     // `add lhs, rhs`.
     pub(crate) unsafe fn build_add(
         &mut self,

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -2102,6 +2102,7 @@ public:
     llvm::Value *emitICmpULE(llvm::Value *lhs, llvm::Value *rhs, const char *name);
     llvm::Value *emitAnd(llvm::Value *lhs, llvm::Value *rhs, const char *name);
     llvm::Value *emitOr(llvm::Value *lhs, llvm::Value *rhs, const char *name);
+    llvm::Value *emitXor(llvm::Value *lhs, llvm::Value *rhs, const char *name);
     llvm::Value *emitAdd(llvm::Value *lhs, llvm::Value *rhs, const char *name);
     llvm::Value *emitSub(llvm::Value *lhs, llvm::Value *rhs, const char *name);
     // mul / sdiv added for #2096 (string-build op migration): str * n /

--- a/include/ry/llvm_emit/api.h
+++ b/include/ry/llvm_emit/api.h
@@ -1165,6 +1165,10 @@ RyValueId ry_emit_and(RyEmitCtx *ctx, RyValueId lhs_id, RyValueId rhs_id,
                       const char *name);
 RyValueId ry_emit_or(RyEmitCtx *ctx, RyValueId lhs_id, RyValueId rhs_id,
                      const char *name);
+// `xor` added for #2189 (saturating-mul migration): the sign_xor of operands
+// determines the clamp direction (INT_MIN vs INT_MAX) on signed overflow.
+RyValueId ry_emit_xor(RyEmitCtx *ctx, RyValueId lhs_id, RyValueId rhs_id,
+                      const char *name);
 RyValueId ry_emit_add(RyEmitCtx *ctx, RyValueId lhs_id, RyValueId rhs_id,
                       const char *name);
 RyValueId ry_emit_sub(RyEmitCtx *ctx, RyValueId lhs_id, RyValueId rhs_id,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -275,6 +275,12 @@ llvm::Value *CodeGen::emitOr(llvm::Value *lhs, llvm::Value *rhs, const char *nam
     return ry::llvm_emit::asLlvmValue(
         ry_emit_resolve(emit_ctx_, ry_emit_or(emit_ctx_, l, r, name)));
 }
+llvm::Value *CodeGen::emitXor(llvm::Value *lhs, llvm::Value *rhs, const char *name) {
+    RyValueId l = ry_emit_intern(emit_ctx_, ry::llvm_emit::asRyValue(lhs));
+    RyValueId r = ry_emit_intern(emit_ctx_, ry::llvm_emit::asRyValue(rhs));
+    return ry::llvm_emit::asLlvmValue(
+        ry_emit_resolve(emit_ctx_, ry_emit_xor(emit_ctx_, l, r, name)));
+}
 llvm::Value *CodeGen::emitAdd(llvm::Value *lhs, llvm::Value *rhs, const char *name) {
     RyValueId l = ry_emit_intern(emit_ctx_, ry::llvm_emit::asRyValue(lhs));
     RyValueId r = ry_emit_intern(emit_ctx_, ry::llvm_emit::asRyValue(rhs));

--- a/src/codegen_arith.cpp
+++ b/src/codegen_arith.cpp
@@ -59,10 +59,9 @@ llvm::Value *CodeGen::emitCheckedArithmetic(const std::string &callee,
     else if (op == "sub") id = isUnsigned ? llvm::Intrinsic::usub_with_overflow : llvm::Intrinsic::ssub_with_overflow;
     else id = isUnsigned ? llvm::Intrinsic::umul_with_overflow : llvm::Intrinsic::smul_with_overflow;
 
-    llvm::Function *intrinsic = llvm::Intrinsic::getOrInsertDeclaration(mod_.get(), id, {lhs->getType()});
-    llvm::Value *result = builder_.CreateCall(intrinsic, {lhs, rhs}, "checked");
-    llvm::Value *value = builder_.CreateExtractValue(result, 0, "checked_val");
-    llvm::Value *overflow = builder_.CreateExtractValue(result, 1, "overflow");
+    llvm::Value *result = emitIntrinsicCall(id, {lhs->getType()}, {lhs, rhs}, "checked");
+    llvm::Value *value = emitExtractValue(result, 0, "checked_val");
+    llvm::Value *overflow = emitExtractValue(result, 1, "overflow");
 
     // Build Result<T, Error>
     llvm::StructType *resTy = getResultType(lhs->getType(), errorTy_);
@@ -89,34 +88,31 @@ llvm::Value *CodeGen::emitSaturatingArithmetic(const std::string &callee,
         if (op == "add") id = isUnsigned ? llvm::Intrinsic::uadd_sat : llvm::Intrinsic::sadd_sat;
         else id = isUnsigned ? llvm::Intrinsic::usub_sat : llvm::Intrinsic::ssub_sat;
 
-        llvm::Function *intrinsic = llvm::Intrinsic::getOrInsertDeclaration(mod_.get(), id, {lhs->getType()});
-        result = builder_.CreateCall(intrinsic, {lhs, rhs}, "sat");
+        result = emitIntrinsicCall(id, {lhs->getType()}, {lhs, rhs}, "sat");
     } else {
         // No LLVM intrinsic for saturating mul — use overflow detection + clamp
         llvm::Intrinsic::ID ovId = isUnsigned ? llvm::Intrinsic::umul_with_overflow
                                                : llvm::Intrinsic::smul_with_overflow;
-        llvm::Function *intrinsic = llvm::Intrinsic::getOrInsertDeclaration(mod_.get(), ovId, {lhs->getType()});
-        llvm::Value *mulResult = builder_.CreateCall(intrinsic, {lhs, rhs}, "satmul");
-        llvm::Value *value = builder_.CreateExtractValue(mulResult, 0, "satmul_val");
-        llvm::Value *overflow = builder_.CreateExtractValue(mulResult, 1, "satmul_ov");
+        llvm::Value *mulResult = emitIntrinsicCall(ovId, {lhs->getType()}, {lhs, rhs}, "satmul");
+        llvm::Value *value = emitExtractValue(mulResult, 0, "satmul_val");
+        llvm::Value *overflow = emitExtractValue(mulResult, 1, "satmul_ov");
 
         llvm::Type *ty = lhs->getType();
         unsigned bits = ty->getIntegerBitWidth();
 
         if (isUnsigned) {
             // Unsigned: clamp to UINT_MAX
-            llvm::Value *maxVal = llvm::ConstantInt::get(ty, llvm::APInt::getMaxValue(bits));
-            result = builder_.CreateSelect(overflow, maxVal, value, "satmul_res");
+            llvm::Value *maxVal = emitConstInt(ty, llvm::APInt::getMaxValue(bits).getZExtValue());
+            result = emitSelect(overflow, maxVal, value, "satmul_res");
         } else {
             // Signed: clamp to INT_MAX or INT_MIN based on sign of operands.
             // XOR of operands has MSB=1 iff signs differ → product would be negative.
-            llvm::Value *xorVal = builder_.CreateXor(lhs, rhs, "sign_xor");
-            llvm::Value *isNeg = builder_.CreateICmpSLT(xorVal,
-                llvm::ConstantInt::get(ty, 0), "sign_neg");
-            llvm::Value *minVal = llvm::ConstantInt::get(ty, llvm::APInt::getSignedMinValue(bits));
-            llvm::Value *maxVal = llvm::ConstantInt::get(ty, llvm::APInt::getSignedMaxValue(bits));
-            llvm::Value *clampVal = builder_.CreateSelect(isNeg, minVal, maxVal, "satmul_clamp");
-            result = builder_.CreateSelect(overflow, clampVal, value, "satmul_res");
+            llvm::Value *xorVal = emitXor(lhs, rhs, "sign_xor");
+            llvm::Value *isNeg = emitICmpSLT(xorVal, emitConstInt(ty, 0), "sign_neg");
+            llvm::Value *minVal = emitConstInt(ty, llvm::APInt::getSignedMinValue(bits).getZExtValue());
+            llvm::Value *maxVal = emitConstInt(ty, llvm::APInt::getSignedMaxValue(bits).getZExtValue());
+            llvm::Value *clampVal = emitSelect(isNeg, minVal, maxVal, "satmul_clamp");
+            result = emitSelect(overflow, clampVal, value, "satmul_res");
         }
     }
 


### PR DESCRIPTION
## Summary

Pilot D (#2102) で確立した「LLVM intrinsic + aggregate result `{T, i1}`」capability の続編。`src/codegen_arith.cpp` の以下3関数を `crates/emit` 境界経由に移植:

- `emitCheckedArithmetic`: `*_with_overflow` + extract×2 → `emitIntrinsicCall` + `emitExtractValue`
- `emitSaturatingArithmetic` add/sub 経路: `*_sat` scalar → `emitIntrinsicCall`
- `emitSaturatingArithmetic` mul 経路: intrinsic + extract×2 + xor + icmp + const + select×2 → 境界 helper

新規境界 `ry_emit_xor` を 5-layer (primitive/ops.rs, abi/primitive.rs, api.h, codegen.hpp, codegen.cpp) に追加。`emitOr` と完全同型。

**対象外 (明示)**:
- `emitIntOverflowCheck` の constant-fold 経路 (#2102 でカーブアウト済み)
- `emitWrappingArithmetic` (intrinsic を使わない別形状)

Closes #2189

## Test plan

- [x] IR bit-exact diff: 3 probe (sat_addsub / checked / satmul) すべて空
- [x] ABI 静的ゲート (`check-emit-abi-no-ir.sh`, `check-llvm-emit-abi-header.sh`, `check-emit-composite-no-primitive.sh`)
- [x] Rust lint (rustfmt + clippy)
- [x] Static analysis (clang-tidy + cppcheck + scan-build: No bugs found)
- [x] C++ unit tests (2795 tests)
- [x] Ry self-tests (207 files, 0 failures)
- [x] ASan + UBSan (207 files, 0 failures)
- [x] TSan (207 files, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bitwise XOR operation support to the code generation system.

* **Refactor**
  * Refactored overflow checking and saturating arithmetic operations to use shared code generation helpers, improving maintainability and consistency across arithmetic operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->