### PR TITLE
refactor(test-runner): unify ry test on per-file subprocess fan-out (#2234)

### DIFF
--- a/changelog.d/2234-test-runner-subprocess-fanout.md
+++ b/changelog.d/2234-test-runner-subprocess-fanout.md
@@ -1,0 +1,19 @@
+### refactor(test-runner): unify `ry test` on per-file subprocess fan-out (no in-process loop) (#2234)
+
+The in-process sequential loop that ran multiple test files in the parent `runRyFile` call (`runTestFilesSequential`) is removed. `ry test` on a directory or auto-discovery target now always goes through `posix_spawn` fan-out — even at worker=1 — so each test file runs in its own child process that exits via `_exit`. This is what the 6-step JIT teardown suppression (`LLJIT` / `CodeGen` / `Program` AST leak + `_exit` past the C++ static destructor chain) structurally requires: "1 source = 1 process". The in-process loop had accumulated suppression leaks across files (`std::bad_alloc` at ~42/181 in `Parser::parseTypeNameSingle` → `TypeNode::makeTuple` empirically reproducible).
+
+`-p` semantics are now uniform — only the worker count changes between cases:
+
+| Invocation | Workers | Path |
+|---|---|---|
+| `ry test` (no `-p`) | 1 | subprocess fan-out, one at a time |
+| `ry test -p` (no `N`) | `computeDefaultWorkers(hw) = max(1, hw-1)` | subprocess fan-out |
+| `ry test -p N` | `N` | subprocess fan-out |
+
+Single-file direct execution (`ry test foo.test.ry`) still JITs in the parent process — no recursive subprocess is needed when there is only one file.
+
+Multi-file (directory / auto-discovery) `--coverage` / `--trace` / `--outline` are now warned and disabled at the call site: the per-file subprocess argv is `{exe, "test", filepath}` only, so these flags cannot be honored across the boundary without structured IPC (out of scope). Use them with a single file (`ry test path/to/foo.test.ry --coverage`) where they continue to work unchanged. The old multi-file `--coverage` had not been usable in practice anyway — it tripped `std::bad_alloc` after ~42 files. The old "`--coverage` with `--parallel` falls back to sequential" wording is replaced; the new wording names "single-file only". The user's `-p N` value is preserved even when one of these flags is disabled — once the feature is off, throttling workers to 1 buys nothing functional and would silently penalise `ry test -p N --coverage` for no gain (the issue's literal "worker=1 強制" wording was an artifact of the pre-#2234 sequential-fallback path).
+
+`runTestFiles` / `discoverAndRunTests` signatures drop `bool parallel`, `const char *argv0`, `bool skip_global_lib`, `bool coverage`, and `bool outline` — none were forwarded to the child subprocess. Only `int parallel_workers` remains.
+
+Follow-ups carved out as separate issues: #2235 (`@it` driver-fn codegen split), #2236 (multi-file `--outline` via subprocess argv extension), #2237 (Linux CI `-p` removal under the new semantics), #2238 (`.claude/rules` write-up of "per-file process is the only legal isolation unit"). The 6-step JIT teardown suppression (#742 family) remains masked, not fixed.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -10,19 +10,21 @@ Ry has a built-in RSpec-style test syntax. Test files are executed using the `ry
 ry test              # Auto-discover and run all *.test.ry files in the project
 ry test tests/spec   # Run all *.test.ry files under a directory (recursive)
 ry test test_file.ry # Run a specific test file
-ry test -p           # Run all tests in parallel (-p or --parallel; default workers = CPU count - 1, minimum 1)
-ry test -p 8         # Run tests in parallel with 8 workers
+ry test -p           # -p alone: default workers = CPU count - 1 (minimum 1)
+ry test -p 8         # -p N: run tests with N workers
 ry test --parallel=4 # Equivalent to `ry test --parallel 4`
-ry test -p tests/    # Run tests in a directory in parallel
+ry test -p tests/    # Run tests in a directory with the default worker count
 ry test -w           # Watch mode: re-run tests on file change (-w or --watch)
-ry test -w -p        # Watch mode with parallel execution
+ry test -w -p        # Watch mode with the default worker count
 ry test -w tests/    # Watch a specific directory
-ry test --coverage   # Run all tests with line coverage summary
+ry test --coverage   # Run a single test file with line coverage summary
 ry test --cov        # Short alias for --coverage
-ry test --outline    # Print describe/it structure without running tests
+ry test --outline    # Print describe/it structure for a single file (no test bodies run)
 ```
 
 The exit code is 0 if all tests passed, 1 if any test failed.
+
+Each discovered test file runs in its own child process (`posix_spawn` fan-out); `-p` controls only the worker count, not whether subprocesses are used. `-p` absent uses 1 worker (one subprocess at a time); `-p` alone uses the default count (CPU - 1, minimum 1); `-p N` uses N. The in-process loop was removed because it accumulated LLVM ORC / JIT teardown leak suppressions across files until heap consolidation failed (`std::bad_alloc`); per-file isolation is now the only execution model.
 
 ### Auto-Discovery Mode
 
@@ -949,7 +951,7 @@ Test Coverage Summary:
 ```
 
 - Only user code is reported; standard library files are excluded
-- `--coverage` with `--parallel` falls back to sequential execution
+- `--coverage` is **single-file only**. On a directory target or auto-discovery (`ry test`), the runner prints a warning and disables coverage — per-file subprocesses cannot aggregate coverage state across the parent. Use `ry test --coverage path/to/file.test.ry` instead.
 
 ---
 
@@ -973,7 +975,7 @@ describe verify
   it should count zero calls
 ```
 
-- Works with individual files, directories, and `-p` (all test files)
+- **Single-file only.** On a directory target or auto-discovery (`ry test --outline`), the runner prints a warning and disables outline — the per-file subprocess argv does not carry `--outline` today. Use `ry test --outline path/to/file.test.ry` instead.
 - `@each` parameterized tests show the format template with an `(@each)` suffix
 - `@property` tests show the label with a `(@property)` suffix
 

--- a/include/ry/jit/test_runner.hpp
+++ b/include/ry/jit/test_runner.hpp
@@ -19,14 +19,22 @@ unsigned computeDefaultWorkers(unsigned hw_concurrency);
 // (when non-zero) and floored at 1.
 int computeParallelism(int requested_workers, std::size_t test_file_count);
 
+// Subprocess fan-out dispatcher (#2234). Spawns one child process per test
+// file via posix_spawn — even at worker=1 — so the parent never JITs and
+// each child exits via _exit, matching the "1 source = 1 process" invariant
+// the 6-step JIT teardown suppression depends on.
+//
+// `parallel_workers` controls only the worker count:
+//   0 → computeDefaultWorkers(hardware_concurrency()) = hw-1 (min 1)
+//   N → N (clamped to test_file_count, floored at 1)
+//
+// `--coverage` / `--trace` / `--outline` are NOT forwarded to the child
+// (runTestFileSubprocess argv is `{exe, "test", filepath}` only); the call
+// site disables them with a warning when the target is multi-file.
 int runTestFiles(const std::vector<std::string> &test_files,
-                 const char *argv0, bool skip_global_lib,
-                 bool parallel, bool coverage = false, bool outline = false,
                  int parallel_workers = 0);
 
-int discoverAndRunTests(const std::string &dir, const char *argv0,
-                        bool skip_global_lib, bool parallel,
-                        bool coverage = false, bool outline = false,
+int discoverAndRunTests(const std::string &dir,
                         int parallel_workers = 0);
 
 } // namespace ry

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -169,8 +169,15 @@ int main(int argc, char *argv[]) {
         }
     } else if (argc >= 2 && std::strcmp(argv[1], "test") == 0) {
         // Parse test subcommand arguments
-        bool parallel = false;
-        int parallel_workers = 0; // 0 = computeDefaultWorkers(hardware_concurrency()) (= hw - 1, min 1)
+        //
+        // -p semantics (#2234): `-p` controls only the worker count.
+        //   `-p` absent       → 1 worker (uniform with the no-`-p` default)
+        //   `-p` alone        → computeDefaultWorkers(hw_concurrency) = hw-1 (min 1)
+        //   `-p N`            → N
+        // All three cases go through subprocess fan-out; the in-process
+        // sequential loop is gone (each child is "1 source = 1 process").
+        bool parallel_flag_seen = false;
+        int parallel_workers = 0; // semantics finalised after the parse loop
         bool watch = false;
         bool coverage = false;
         bool outline = false;
@@ -208,7 +215,7 @@ int main(int argc, char *argv[]) {
         for (int i = 2; i < argc; ++i) {
             if (std::strcmp(argv[i], "-p") == 0 ||
                 std::strcmp(argv[i], "--parallel") == 0) {
-                parallel = true;
+                parallel_flag_seen = true;
                 // Optional spaced count: `-p N` / `--parallel N`. If the next
                 // argv looks like a count attempt (digit, or `-` then digit),
                 // commit to parsing it; otherwise leave it for the next loop
@@ -221,7 +228,7 @@ int main(int argc, char *argv[]) {
                     ++i;
                 }
             } else if (std::strncmp(argv[i], "--parallel=", 11) == 0) {
-                parallel = true;
+                parallel_flag_seen = true;
                 const char *val_str = argv[i] + 11;
                 if (*val_str == '\0') {
                     errs() << "Error: --parallel= requires a positive integer "
@@ -256,14 +263,44 @@ int main(int argc, char *argv[]) {
                 sessionStarted = true;
             }
         }
-        if (coverage && parallel) {
-            errs() << "Warning: --coverage is not supported with --parallel, falling back to sequential\n";
-            parallel = false;
+        // -p semantics finalisation (#2234): `-p` absent → 1 worker (uniform with
+        // the no-`-p` default sequential semantics). `-p` alone keeps parallel_workers
+        // at 0, which computeParallelism interprets as "computeDefaultWorkers".
+        if (!parallel_flag_seen) {
+            parallel_workers = 1;
         }
-        if (trace_enabled && parallel) {
-            errs() << "Warning: --trace is not supported with --parallel, falling back to sequential\n";
-            parallel = false;
-        }
+
+        // Helper to disable per-file flags that cannot cross subprocess
+        // boundaries cleanly (#2234). Applied only on multi-file paths
+        // (directory target / no target → project root); the single-file
+        // direct path keeps coverage / trace / outline fully functional.
+        // Worker count is left untouched: throttling to 1 worker buys nothing
+        // once the underlying feature is off, and would silently penalise
+        // `ry test -p N --coverage` (~Nx slowdown for no functional gain).
+        auto warnAndDisableMultiFileFlags = [&]() {
+            if (coverage) {
+                errs() << "Warning: --coverage is not supported with multi-file "
+                          "test execution; coverage is only available for "
+                          "single-file runs (e.g. `ry test foo.test.ry "
+                          "--coverage`). Disabling.\n";
+                coverage = false;
+            }
+            if (trace_enabled) {
+                errs() << "Warning: --trace is not supported with multi-file "
+                          "test execution; trace is only available for "
+                          "single-file runs (e.g. `ry test foo.test.ry "
+                          "--trace`). Disabling.\n";
+                trace_enabled = false;
+                ry::configureTrace(false, "");
+            }
+            if (outline) {
+                errs() << "Warning: --outline is not supported with multi-file "
+                          "test execution; outline is only available for "
+                          "single-file runs (e.g. `ry test foo.test.ry "
+                          "--outline`). Disabling.\n";
+                outline = false;
+            }
+        };
 
         if (target) {
             std::string target_str = target;
@@ -284,19 +321,16 @@ int main(int argc, char *argv[]) {
                 return 1;
             }
             if (path_is_directory) {
+                warnAndDisableMultiFileFlags();
                 if (watch) {
-                    const char *a0 = argv[0];
-                    bool sgl = skip_global_lib;
                     ry::watchAndRunTests(target_str,
-                        [target_str, a0, sgl, parallel, coverage, outline, parallel_workers]() {
-                            ry::discoverAndRunTests(target_str, a0, sgl, parallel,
-                                                    coverage, outline, parallel_workers);
+                        [target_str, parallel_workers]() {
+                            ry::discoverAndRunTests(target_str, parallel_workers);
                         });
                     return finalizeAfterPossibleJit(0);
                 }
                 return finalizeAfterPossibleJit(
-                    ry::discoverAndRunTests(target_str, argv[0], skip_global_lib, parallel,
-                                            coverage, outline, parallel_workers));
+                    ry::discoverAndRunTests(target_str, parallel_workers));
             }
             if (!path_exists) {
                 std::string resolved;
@@ -354,21 +388,18 @@ int main(int argc, char *argv[]) {
                 errs() << "Error: package.toml not found. Run 'ry init' first.\n";
                 return 1;
             }
+            warnAndDisableMultiFileFlags();
             if (watch) {
                 const std::string &root_dir = *root;
-                const char *a0 = argv[0];
-                bool sgl = skip_global_lib;
                 // NOLINTNEXTLINE(bugprone-exception-escape): watcher lambda; exceptions terminate the process
                 ry::watchAndRunTests(root_dir,
-                    [root_dir, a0, sgl, parallel, coverage, outline, parallel_workers]() {
-                        ry::discoverAndRunTests(root_dir, a0, sgl, parallel,
-                                                coverage, outline, parallel_workers);
+                    [root_dir, parallel_workers]() {
+                        ry::discoverAndRunTests(root_dir, parallel_workers);
                     });
                 return finalizeAfterPossibleJit(0);
             }
             return finalizeAfterPossibleJit(
-                ry::discoverAndRunTests(*root, argv[0], skip_global_lib, parallel,
-                                        coverage, outline, parallel_workers));
+                ry::discoverAndRunTests(*root, parallel_workers));
         }
     }
 

--- a/src/jit/test_runner.cpp
+++ b/src/jit/test_runner.cpp
@@ -1,7 +1,5 @@
 #include "ry/jit/test_runner.hpp"
-#include "ry/jit/jit_runner.hpp"
 #include "ry/cli/self_update.hpp"
-#include "ry/diagnostic/diagnostic.hpp"
 #ifdef __APPLE__
 #include <crt_externs.h>
 #define RY_ENVIRON (*_NSGetEnviron())
@@ -53,34 +51,6 @@ std::vector<std::string> findTestFiles(const std::string &root_dir) {
     }
     std::sort(files.begin(), files.end());
     return files;
-}
-
-static int runTestFilesSequential(const std::vector<std::string> &test_files,
-                                  const char *argv0, bool skip_global_lib,
-                                  bool coverage, bool outline) {
-    CoverageState cs;
-    if (coverage) resetCoverageState(cs);
-    int total_failed = 0;
-    for (const auto &tf : test_files) {
-        try {
-            int failed = runRyFile(tf, /*test_mode=*/true, argv0, skip_global_lib,
-                                   coverage, outline, coverage ? &cs : nullptr);
-            total_failed += failed;
-        } catch (const DiagnosticError &e) {
-            llvm::errs() << e.what();
-            ++total_failed;
-        } catch (const std::exception &e) {
-            llvm::errs() << "Error in " << tf << ": " << e.what() << "\n";
-            ++total_failed;
-        }
-    }
-    int total_files = static_cast<int>(test_files.size());
-    if (!outline && total_files > 1) {
-        std::printf("\n%d test files executed, %d total failures\n",
-                    total_files, total_failed);
-    }
-    if (coverage) emitCoverageReport(cs);
-    return total_failed > 0 ? 1 : 0;
 }
 
 struct TestFileResult {
@@ -155,8 +125,14 @@ static TestFileResult runTestFileSubprocess(const std::string &filepath,
     return result;
 }
 
-static int runTestFilesParallel(const std::vector<std::string> &test_files,
-                                const std::string &exe_path, int parallelism) {
+// Subprocess fan-out: each test file runs in its own child process so the
+// JIT teardown 6-step suppression (KNOWLEDGE.md "LLVM ORC JIT intermittent
+// teardown crash") holds (1 source = 1 process). Parent JIT-free; only
+// posix_spawn / pipe-read / waitpid. Worker count = 1 still goes through
+// this path so the dispatcher is uniform (#2234).
+static int runTestFilesSubprocessFanOut(const std::vector<std::string> &test_files,
+                                        const std::string &exe_path,
+                                        int parallelism) {
     size_t num_files = test_files.size();
     std::vector<TestFileResult> results(num_files);
 
@@ -192,8 +168,9 @@ static int runTestFilesParallel(const std::vector<std::string> &test_files,
     std::vector<std::thread> threads;
     threads.reserve(num_workers);
 
-    std::fprintf(stderr, "Running %zu test files with %zu workers...\n",
-                 num_files, num_workers);
+    const char *worker_label = num_workers == 1 ? "worker" : "workers";
+    std::fprintf(stderr, "Running %zu test files with %zu %s...\n",
+                 num_files, num_workers, worker_label);
 
     auto wall_start = std::chrono::steady_clock::now();
     for (size_t i = 0; i < num_workers; ++i)
@@ -215,8 +192,8 @@ static int runTestFilesParallel(const std::vector<std::string> &test_files,
         std::fputs(r.output.c_str(), stdout);
     }
 
-    std::printf("\n%zu test files executed, %d total failures (%.2fs, %zu workers)\n",
-                num_files, total_failed, wall_elapsed, num_workers);
+    std::printf("\n%zu test files executed, %d total failures (%.2fs, %zu %s)\n",
+                num_files, total_failed, wall_elapsed, num_workers, worker_label);
     return total_failed > 0 ? 1 : 0;
 }
 
@@ -242,32 +219,37 @@ int computeParallelism(int requested_workers, std::size_t test_file_count) {
     return parallelism;
 }
 
+// All multi-file paths go through subprocess fan-out (#2234). The in-process
+// runRyFile loop is gone — even worker=1 spawns one subprocess per file. This
+// is what makes the 6-step JIT teardown suppression hold (1 source = 1 process):
+// the parent never JITs and child exits via _exit, so leaks are reclaimed by
+// the OS instead of accumulating across files (KNOWLEDGE.md "LLVM ORC JIT
+// intermittent teardown crash").
+//
+// `--coverage` / `--trace` / `--outline` must be disabled (with a warning) at
+// the call site before reaching here when the target is multi-file —
+// runTestFileSubprocess argv is `{exe, "test", filepath}` only and the child
+// has no way to honor those flags.
 int runTestFiles(const std::vector<std::string> &test_files,
-                 const char *argv0, bool skip_global_lib,
-                 bool parallel, bool coverage, bool outline,
                  int parallel_workers) {
-    if (outline || !parallel || test_files.size() <= 1) {
-        return runTestFilesSequential(test_files, argv0, skip_global_lib, coverage, outline);
-    }
     std::string exe_path = ry::self_update::detail::get_executable_path();
     if (exe_path.empty()) {
-        llvm::errs() << "Warning: cannot resolve executable path, falling back to sequential\n";
-        return runTestFilesSequential(test_files, argv0, skip_global_lib, coverage, false);
+        llvm::errs()
+            << "Error: cannot resolve executable path for subprocess test runner\n";
+        return 1;
     }
     int parallelism = computeParallelism(parallel_workers, test_files.size());
-    return runTestFilesParallel(test_files, exe_path, parallelism);
+    return runTestFilesSubprocessFanOut(test_files, exe_path, parallelism);
 }
 
-int discoverAndRunTests(const std::string &dir, const char *argv0,
-                        bool skip_global_lib, bool parallel,
-                        bool coverage, bool outline, int parallel_workers) {
+int discoverAndRunTests(const std::string &dir,
+                        int parallel_workers) {
     auto test_files = findTestFiles(dir);
     if (test_files.empty()) {
         llvm::errs() << "No *.test.ry files found in " << dir << "\n";
         return 1;
     }
-    return runTestFiles(test_files, argv0, skip_global_lib, parallel, coverage, outline,
-                        parallel_workers);
+    return runTestFiles(test_files, parallel_workers);
 }
 
 } // namespace ry

--- a/tests/test_parallel_cli.cpp
+++ b/tests/test_parallel_cli.cpp
@@ -1,11 +1,15 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <filesystem>
+#include <fstream>
 #include <string>
 #include <vector>
 
 #include <sys/wait.h>
 #include <unistd.h>
+
+namespace fs = std::filesystem;
 
 
 // Local copy of the runRy helper used in tests/test_help.cpp.
@@ -133,4 +137,101 @@ TEST(ParallelCLI, NonDigitNonCountArgTreatedAsTarget) {
     EXPECT_NE(r.exit_code, 0);
     EXPECT_EQ(r.err.find("worker count must be a positive integer"),
               std::string::npos);
+}
+
+// --- #2234: subprocess fan-out 一本化の検知テスト ---
+//
+// 新仕様: `ry test <dir>` は -p の有無に関係なく subprocess fan-out 経路に入る。
+// multi-file 時の --coverage / --trace / --outline は警告 + disable (cross-subprocess
+// 集計は scope 外; #2236 で outline が部分対応予定)。
+//
+// fixture は package.toml なしの tmpdir + 2 個の minimal .test.ry。
+// `runRy({"test", tmpdir})` で path_is_directory == true 分岐に入る。
+
+class TestRunnerFanOut : public ::testing::Test {
+protected:
+    fs::path tmpDir_;
+    std::string dir_;
+    void SetUp() override {
+        // tmpdir は ry バイナリ隣に置く (test_codegen_call_json_reject.cpp と同じ流儀)。
+        // SetUp 側は例外形式で既存テストの規約に揃える (TearDown は noexcept なので ec 版)。
+        tmpDir_ = fs::path(RY_BINARY_PATH).parent_path() /
+                  "ry_test_runner_fanout_test";
+        fs::remove_all(tmpDir_);
+        fs::create_directories(tmpDir_);
+        // testing intrinsics は `from testing import` が必要 (tests/spec/*.test.ry 流儀)。
+        // package.toml なし tmpdir でも ModuleLoader は global stdlib (~/.ry/share or
+        // exe-adjacent share) を解決できる。RY_ENV=internal を runRy 内で setenv するため
+        // 開発時は exe-adjacent share を使う。
+        std::ofstream(tmpDir_ / "a.test.ry")
+            << "from testing import it, expect\n"
+            << "\n"
+            << "@it(\"a passes\")\n"
+            << "fn aPasses():\n"
+            << "  expect(1).toEq(1)\n";
+        std::ofstream(tmpDir_ / "b.test.ry")
+            << "from testing import it, expect\n"
+            << "\n"
+            << "@it(\"b passes\")\n"
+            << "fn bPasses():\n"
+            << "  expect(2).toEq(2)\n";
+        dir_ = tmpDir_.string();
+    }
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(tmpDir_, ec);
+    }
+};
+
+// `-p` なしでも subprocess fan-out 経路 (旧仕様では sequential 経路で stderr に
+// "worker" 文字列は出なかった)
+TEST_F(TestRunnerFanOut, DefaultModeUsesSubprocessDispatch) {
+    auto r = runRy({"test", dir_.c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stdout=" << r.out << "\nstderr=" << r.err;
+    EXPECT_NE(r.err.find("worker"), std::string::npos)
+        << "Default mode (no -p) should now go through subprocess fan-out, "
+           "which prints '...with N worker(s)...' to stderr.\nstderr=" << r.err;
+}
+
+// `-p 1` で 1 worker subprocess 経路 (単複対応で "1 worker", not "1 workers")
+TEST_F(TestRunnerFanOut, SingleWorkerUsesSubprocessDispatch) {
+    auto r = runRy({"test", "-p", "1", dir_.c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stdout=" << r.out << "\nstderr=" << r.err;
+    EXPECT_NE(r.err.find("1 worker"), std::string::npos)
+        << "-p 1 should use subprocess fan-out with singular 'worker', "
+           "not plural 'workers'.\nstderr=" << r.err;
+    EXPECT_EQ(r.err.find("1 workers"), std::string::npos)
+        << "'1 workers' is a grammar wart; expected singular form.\nstderr="
+        << r.err;
+}
+
+// --coverage multi-file で警告 + disable
+TEST_F(TestRunnerFanOut, CoverageMultiFileEmitsWarningAndDisables) {
+    auto r = runRy({"test", "--coverage", dir_.c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stdout=" << r.out << "\nstderr=" << r.err;
+    EXPECT_NE(r.err.find("Warning: --coverage is not supported with multi-file"),
+              std::string::npos)
+        << "Multi-file --coverage should warn and disable, since per-file "
+           "coverage is not aggregated across subprocesses.\nstderr=" << r.err;
+}
+
+// --trace multi-file で警告 + disable
+TEST_F(TestRunnerFanOut, TraceMultiFileEmitsWarningAndDisables) {
+    auto r = runRy({"test", "--trace", dir_.c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stdout=" << r.out << "\nstderr=" << r.err;
+    EXPECT_NE(r.err.find("Warning: --trace is not supported with multi-file"),
+              std::string::npos)
+        << "Multi-file --trace should warn and disable, since multiple "
+           "subprocesses would clobber the same trace-out file.\nstderr="
+        << r.err;
+}
+
+// --outline multi-file で警告 + disable (silent regression 防止)
+TEST_F(TestRunnerFanOut, OutlineMultiFileEmitsWarningAndDisables) {
+    auto r = runRy({"test", "--outline", dir_.c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stdout=" << r.out << "\nstderr=" << r.err;
+    EXPECT_NE(r.err.find("Warning: --outline is not supported with multi-file"),
+              std::string::npos)
+        << "Multi-file --outline should warn and disable until #2236 threads "
+           "--outline through to subprocesses.\nstderr=" << r.err;
 }

--- a/tests/test_trace.cpp
+++ b/tests/test_trace.cpp
@@ -169,7 +169,10 @@ TEST_F(TraceModeTest, TraceCanBeRedirectedToFile) {
     EXPECT_NE(trace.find("\"event\":\"exec.end\""), std::string::npos);
 }
 
-TEST_F(TraceModeTest, TraceWithParallelTestsFallsBackToSequential) {
+// #2234: multi-file `--trace` is no longer aggregated across subprocesses;
+// the runner warns and disables it. The pre-#2234 "falls back to sequential"
+// path is gone — every multi-file invocation goes through subprocess fan-out.
+TEST_F(TraceModeTest, TraceWithMultiFileTestsEmitsWarningAndDisables) {
     fs::create_directories(tmp_dir_ / "tests");
     std::ofstream manifestFile(tmp_dir_ / "package.toml");
     manifestFile << "[project]\nname = \"trace\"\nversion = \"0.1.0\"\nentry = \"main.ry\"\n";
@@ -185,6 +188,11 @@ TEST_F(TraceModeTest, TraceWithParallelTestsFallsBackToSequential) {
 
     auto result = runRy({"test", "--parallel", "--trace", "tests"}, tmp_dir_.string());
     EXPECT_EQ(result.exit_code, 0);
-    EXPECT_NE(result.err.find("falling back to sequential"), std::string::npos);
-    EXPECT_NE(result.err.find("\"event\":\"exec.start\""), std::string::npos);
+    EXPECT_NE(result.err.find("Warning: --trace is not supported with multi-file"),
+              std::string::npos);
+    // The per-file subprocess argv carries no `--trace`, so the child never
+    // calls configureTrace and exec.start is never emitted by the child.
+    // The parent emitted session.start before disabling but produces no
+    // exec.start of its own (no JIT runs in the parent on this path).
+    EXPECT_EQ(result.err.find("\"event\":\"exec.start\""), std::string::npos);
 }


### PR DESCRIPTION
## Summary

- Remove `runTestFilesSequential`; route every multi-file `ry test` through `posix_spawn` fan-out (even at worker=1). 6-step JIT teardown suppression structurally requires "1 source = 1 process"; the in-process loop tripped `std::bad_alloc` at ~42/181.
- `-p` semantics become uniform: absent → 1 worker, alone → `computeDefaultWorkers` (hw-1), `-p N` → N. Single-file direct execution (`ry test foo.test.ry`) still JITs in the parent.
- Multi-file `--coverage` / `--trace` / `--outline` are warned and disabled at the call site (no structured IPC to honour them across subprocess argv). The user's `-p N` is preserved when the feature is disabled — throttling buys nothing once it's off.
- `runTestFiles` / `discoverAndRunTests` signatures drop dead args (`bool parallel`, `argv0`, `skip_global_lib`, `coverage`, `outline`); only `int parallel_workers` remains.

## Test plan

- [x] `ry_tests`: 2800/2800 GREEN (added 5 new `TestRunnerFanOut.*`, updated 1 `TraceModeTest.*`)
- [x] `./build-rust/ry test` (no `-p`): 208 files, 0 failures, no `bad_alloc`, ~17s with 1 worker
- [x] `./build-rust/ry test -p`: 9 workers (`hw-1`), ~3.6s
- [x] `./build-rust/ry test -p 1` / `-p 4` / `-p 8`: worker count respected
- [x] `./build-rust/ry test --coverage` / `--trace` / `--outline` (directory): warning + disable
- [x] `./build-rust/ry test -p 8 --coverage`: warning + 8 workers preserved (no silent throttle)
- [x] `./build-rust/ry test foo.test.ry --coverage` / `--trace` / `--outline`: single-file works unchanged
- [x] ASan + UBSan (Docker): GREEN
- [x] TSan (Docker): GREEN
- [x] Static analysis (Docker scan-build): 1 advisory warning at `main.cpp:263` (`sessionStarted` dead store). Existing in `git blame` (2026-03-31 commit) and the flow around the store is not modified by this PR. Full baseline comparison was attempted but the captured baseline log was truncated; flow-equivalence is the basis for the "pre-existing" classification.

## Notes

- Output buffering: old sequential streamed each file's output live; new fan-out reads each subprocess pipe and prints in file order after completion (worker=1 still gets the stderr progress counter).
- The follow-ups carved out under #2232: #2235 (test-driver codegen split), #2236 (multi-file outline via subprocess argv), #2237 (Linux CI `-p` removal under the new semantics), #2238 (per-file process isolation write-up).

Closes #2234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test runner now properly warns and disables `--coverage`, `--trace`, and `--outline` when running tests on directories; these features only work with individual test files.

* **Documentation**
  * Updated testing guide with clarified `-p` flag behavior and single-file requirements for coverage/trace/outline features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->