### PR TITLE
refactor(codegen): split @it/@describe into fn + driver fragment (#2235)

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1578,6 +1578,15 @@ public:
     void emitStmt(std::unique_ptr<FnStmt> &s);
     void emitStmt(std::unique_ptr<UsingStmt> &s);
     void forwardDeclareFunctions(Program &prog);
+    void collectAndSpliceFileLifecycleHooks(Program &prog);
+    // Shared between file-level (collectAndSpliceFileLifecycleHooks) and
+    // describe-level (emitDescribeFn) hook pre-scan loops (#2235). Rejects
+    // a second hook of the same name in the same scope, validates shape +
+    // body, and moves the body into `dest`. `scopeLabel` is interpolated
+    // into the duplicate-declaration error ("file" / "@describe block").
+    void extractLifecycleHook(std::unique_ptr<FnStmt> &fn, const char *hookName,
+                              const char *scopeLabel,
+                              std::vector<StmtNode> &dest, std::string &destName);
     llvm::Function *declareFunction(
         const std::string &name,
         std::vector<llvm::Type*> &paramTypes,
@@ -1611,6 +1620,17 @@ public:
     void markFieldAllocaArcManaged(llvm::AllocaInst *tmp, llvm::Type *ty, const std::string &typeSig);
     llvm::SmallVector<llvm::Value*, 4> loadCapturedArgs(const OverloadEntry &entry, const std::string &directive);
     void emitItDirective(std::unique_ptr<FnStmt> &s);
+    // Shared fn-emission phase for @it (basic / @timeout / @each /
+    // @property) (#2235): strip the given directives, emit the body as
+    // an ordinary fn, and return its OverloadEntry. emitItDriverFragment
+    // is the basic / @timeout driver synthesis (it_begin → hook cascade
+    // → call → hook cascade → it_end, or sigsetjmp variant on timeout).
+    const OverloadEntry &emitItFn(std::unique_ptr<FnStmt> &s,
+                                   std::initializer_list<const char *> stripList,
+                                   const char *directiveLabel);
+    void emitItDriverFragment(llvm::Value *descVal,
+                              const OverloadEntry &entry,
+                              int64_t timeoutMs);
     void emitEachItDirective(std::unique_ptr<FnStmt> &s);
     void emitPropertyItDirective(std::unique_ptr<FnStmt> &s);
     // Per-test @timeout(ms) directive (#1688, #1781). Emits two sigsetjmp
@@ -1633,6 +1653,12 @@ public:
                            std::vector<StmtNode> *describeAfterEachBody,
                            std::vector<StmtNode> *fileAfterEachBody);
     void emitDescribeDirective(std::unique_ptr<FnStmt> &s);
+    // Phases of @describe normal-mode emission (#2235): fn emission
+    // (hook splice + emit) and driver fragment synthesis
+    // (describe_begin/call/end). Outline mode bypasses both.
+    const OverloadEntry &emitDescribeFn(std::unique_ptr<FnStmt> &s);
+    void emitDescribeDriverFragment(llvm::Value *descVal,
+                                    const OverloadEntry &entry);
 
     // Lifecycle hooks (#1686): @beforeEach / @afterEach / @beforeAll /
     // @afterAll. Pre-scanned and AST-rewritten inside emitDescribeDirective —

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1432,86 +1432,8 @@ llvm::orc::ThreadSafeModule CodeGen::compile(Program &prog) {
         }
     }
 
-    // File-top-level lifecycle hook pre-scan (#1780). Mirrors the in-describe
-    // extract loop in emitDescribeDirective: walk prog linearly, validate
-    // each @beforeAll/@beforeEach/@afterEach/@afterAll FnStmt, steal its
-    // body, and erase the FnStmt so the defense-in-depth handlers
-    // (emitBeforeEachDirective et al. in src/codegen_test.cpp) are never
-    // reached for file-level hooks. @beforeEach/@afterEach bodies live on
-    // CodeGen until emitItDirective inlines them; @beforeAll/@afterAll
-    // bodies are spliced back into prog around the first/last test anchor.
-    std::vector<StmtNode> fileBeforeAllBody, fileAfterAllBody;
-    std::string fileBeforeAllName, fileAfterAllName,
-                fileBeforeEachName, fileAfterEachName;
     if (test_mode_) {
-        auto extractFileHook = [&](std::unique_ptr<FnStmt> &fn, const char *hookName,
-                                   std::vector<StmtNode> &dest, std::string &destName) {
-            if (!destName.empty())
-                codegenError(std::string("@") + hookName +
-                    " can be declared at most once per file (fn '" +
-                    destName + "' already declared)");
-            validateLifecycleHookFnShape(fn, hookName);
-            validateLifecycleHookBody(fn->body, hookName);
-            destName = fn->name;
-            dest = std::move(fn->body);
-        };
-
-        for (auto it = prog.begin(); it != prog.end(); ) {
-            auto *fnPtr = std::get_if<std::unique_ptr<FnStmt>>(&*it);
-            if (!fnPtr) { ++it; continue; }
-            auto &fn = *fnPtr;
-            bool consumed = false;
-            if (hasDirective(fn->directives, "beforeEach")) {
-                extractFileHook(fn, "beforeEach", file_before_each_body_, fileBeforeEachName);
-                consumed = true;
-            } else if (hasDirective(fn->directives, "afterEach")) {
-                extractFileHook(fn, "afterEach", file_after_each_body_, fileAfterEachName);
-                consumed = true;
-            } else if (hasDirective(fn->directives, "beforeAll")) {
-                extractFileHook(fn, "beforeAll", fileBeforeAllBody, fileBeforeAllName);
-                consumed = true;
-            } else if (hasDirective(fn->directives, "afterAll")) {
-                extractFileHook(fn, "afterAll", fileAfterAllBody, fileAfterAllName);
-                consumed = true;
-            }
-            if (consumed) it = prog.erase(it);
-            else          ++it;
-        }
-
-        // Splice @beforeAll body before the first test anchor (@it OR
-        // @describe at file top level) and @afterAll body after the last
-        // such anchor. Mixed @it / @describe layouts are supported because
-        // file-level hooks must wrap every test in the file regardless of
-        // whether it lives at top level or inside a @describe. No anchor
-        // means the file contains no tests; bodies are silently dropped to
-        // match the in-describe behaviour (see emitDescribeDirective's
-        // "If the describe contains no direct @it" comment).
-        auto isFileTestStmt = [](const StmtNode &stmt) {
-            const auto *fnp = std::get_if<std::unique_ptr<FnStmt>>(&stmt);
-            if (!fnp) return false;
-            return hasDirective((*fnp)->directives, "it") ||
-                   hasDirective((*fnp)->directives, "describe");
-        };
-        size_t firstTestIdx = prog.size();
-        size_t lastTestIdx = 0;
-        bool sawTest = false;
-        for (size_t i = 0; i < prog.size(); ++i) {
-            if (isFileTestStmt(prog[i])) {
-                if (!sawTest) { firstTestIdx = i; sawTest = true; }
-                lastTestIdx = i;
-            }
-        }
-        if (sawTest && !fileBeforeAllBody.empty()) {
-            prog.insert(prog.begin() + static_cast<std::ptrdiff_t>(firstTestIdx),
-                        std::make_move_iterator(fileBeforeAllBody.begin()),
-                        std::make_move_iterator(fileBeforeAllBody.end()));
-            lastTestIdx += fileBeforeAllBody.size();
-        }
-        if (sawTest && !fileAfterAllBody.empty()) {
-            prog.insert(prog.begin() + static_cast<std::ptrdiff_t>(lastTestIdx + 1),
-                        std::make_move_iterator(fileAfterAllBody.begin()),
-                        std::make_move_iterator(fileAfterAllBody.end()));
-        }
+        collectAndSpliceFileLifecycleHooks(prog);
     }
 
     runCyclicTypeAnalysis(typeGraph, allTypes);
@@ -1559,6 +1481,95 @@ llvm::orc::ThreadSafeModule CodeGen::compile(Program &prog) {
         codegenError("IR verify error: " + err);
 
     return llvm::orc::ThreadSafeModule(std::move(mod_), std::move(ctx_));
+}
+
+// Shared between file-level and describe-level hook pre-scan (#2235).
+// Mirrors the per-scope at-most-once enforcement plus shape/body
+// validation, then transfers the hook fn's body into the destination
+// slot. Caller still owns erasing the consumed FnStmt from its container.
+void CodeGen::extractLifecycleHook(std::unique_ptr<FnStmt> &fn, const char *hookName,
+                                    const char *scopeLabel,
+                                    std::vector<StmtNode> &dest, std::string &destName) {
+    if (!destName.empty())
+        codegenError(std::string("@") + hookName +
+            " can be declared at most once per " + scopeLabel + " (fn '" +
+            destName + "' already declared)");
+    validateLifecycleHookFnShape(fn, hookName);
+    validateLifecycleHookBody(fn->body, hookName);
+    destName = fn->name;
+    dest = std::move(fn->body);
+}
+
+// File-top-level lifecycle hook pre-scan (#1780, extracted #2235).
+// Mirrors the in-describe extract loop in emitDescribeFn: walk prog
+// linearly, validate each @beforeAll/@beforeEach/@afterEach/@afterAll
+// FnStmt, steal its body, and erase the FnStmt so the defense-in-depth
+// handlers (emitBeforeEachDirective et al. in src/codegen_test.cpp) are
+// never reached for file-level hooks. @beforeEach/@afterEach bodies
+// live on CodeGen until emitItDriverFragment inlines them;
+// @beforeAll/@afterAll bodies are spliced back into prog around the
+// first/last test anchor.
+void CodeGen::collectAndSpliceFileLifecycleHooks(Program &prog) {
+    std::vector<StmtNode> fileBeforeAllBody, fileAfterAllBody;
+    std::string fileBeforeAllName, fileAfterAllName,
+                fileBeforeEachName, fileAfterEachName;
+
+    for (auto it = prog.begin(); it != prog.end(); ) {
+        auto *fnPtr = std::get_if<std::unique_ptr<FnStmt>>(&*it);
+        if (!fnPtr) { ++it; continue; }
+        auto &fn = *fnPtr;
+        bool consumed = false;
+        if (hasDirective(fn->directives, "beforeEach")) {
+            extractLifecycleHook(fn, "beforeEach", "file", file_before_each_body_, fileBeforeEachName);
+            consumed = true;
+        } else if (hasDirective(fn->directives, "afterEach")) {
+            extractLifecycleHook(fn, "afterEach", "file", file_after_each_body_, fileAfterEachName);
+            consumed = true;
+        } else if (hasDirective(fn->directives, "beforeAll")) {
+            extractLifecycleHook(fn, "beforeAll", "file", fileBeforeAllBody, fileBeforeAllName);
+            consumed = true;
+        } else if (hasDirective(fn->directives, "afterAll")) {
+            extractLifecycleHook(fn, "afterAll", "file", fileAfterAllBody, fileAfterAllName);
+            consumed = true;
+        }
+        if (consumed) it = prog.erase(it);
+        else          ++it;
+    }
+
+    // Splice @beforeAll body before the first test anchor (@it OR
+    // @describe at file top level) and @afterAll body after the last
+    // such anchor. Mixed @it / @describe layouts are supported because
+    // file-level hooks must wrap every test in the file regardless of
+    // whether it lives at top level or inside a @describe. No anchor
+    // means the file contains no tests; bodies are silently dropped to
+    // match the in-describe behaviour (see emitDescribeFn's
+    // "If the describe contains no direct @it" comment).
+    auto isFileTestStmt = [](const StmtNode &stmt) {
+        const auto *fnp = std::get_if<std::unique_ptr<FnStmt>>(&stmt);
+        if (!fnp) return false;
+        return hasDirective((*fnp)->directives, "it") ||
+               hasDirective((*fnp)->directives, "describe");
+    };
+    size_t firstTestIdx = prog.size();
+    size_t lastTestIdx = 0;
+    bool sawTest = false;
+    for (size_t i = 0; i < prog.size(); ++i) {
+        if (isFileTestStmt(prog[i])) {
+            if (!sawTest) { firstTestIdx = i; sawTest = true; }
+            lastTestIdx = i;
+        }
+    }
+    if (sawTest && !fileBeforeAllBody.empty()) {
+        prog.insert(prog.begin() + static_cast<std::ptrdiff_t>(firstTestIdx),
+                    std::make_move_iterator(fileBeforeAllBody.begin()),
+                    std::make_move_iterator(fileBeforeAllBody.end()));
+        lastTestIdx += fileBeforeAllBody.size();
+    }
+    if (sawTest && !fileAfterAllBody.empty()) {
+        prog.insert(prog.begin() + static_cast<std::ptrdiff_t>(lastTestIdx + 1),
+                    std::make_move_iterator(fileAfterAllBody.begin()),
+                    std::make_move_iterator(fileAfterAllBody.end()));
+    }
 }
 
 llvm::AllocaInst *CodeGen::getOrCreateVar(const std::string &name, llvm::Type *ty) {

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -496,18 +496,39 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     if (!s->params.empty())
         codegenError("@it: fn '" + s->name + "' has parameters but no @each or @property directive");
 
-    // Strip @it / @only / @timeout (no runtime effect once dispatch is decided)
-    // and emit the function normally, then emit it_begin/call/it_end (or the
-    // timeout-aware variant when @timeout is present).
-    stripDirectives(s->directives, {"it", "only", "timeout"});
-    emitStmt(s);
+    const auto &entry = emitItFn(s, {"it", "only", "timeout"}, "@it");
+    llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+    emitItDriverFragment(descVal, entry, timeoutMs);
+}
 
+// Strip the given test-specific directives, emit the @it body as an
+// ordinary fn through the standard fn codegen path, and look up the
+// resulting OverloadEntry. Shared between basic / @timeout / @each /
+// @property paths (#2235). The returned reference is valid as long as
+// no further function registration intervenes before the caller emits
+// its driver fragment.
+const CodeGen::OverloadEntry &CodeGen::emitItFn(
+    std::unique_ptr<FnStmt> &s,
+    std::initializer_list<const char *> stripList,
+    const char *directiveLabel) {
+    stripDirectives(s->directives, stripList);
+    emitStmt(s);
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
-        codegenError("@it: internal error — fn '" + s->name + "' not found after emit");
-    const auto &entry = overloads->back();
+        codegenError(std::string(directiveLabel) +
+                     ": internal error — fn '" + s->name + "' not found after emit");
+    return overloads->back();
+}
 
-    llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+// Phase 2 of the basic / @timeout @it path (#2235): synthesize the
+// driver fragment that wraps the user fn in the test runtime cascade.
+// Hook layers are resolved from class members at the current emit point
+// (file_before_each_body_ / file_after_each_body_ / describe_hook_stack_).
+// timeoutMs == 0 selects the normal in-place inline cascade; > 0 routes
+// through emitItWithTimeout for the sigsetjmp two-pad variant.
+void CodeGen::emitItDriverFragment(llvm::Value *descVal,
+                                    const OverloadEntry &entry,
+                                    int64_t timeoutMs) {
     // Hook cascade (#1780): file-level hooks wrap describe-level hooks
     // around every @it. Order is file BE → describe BE → @it → describe AE
     // → file AE on the normal path. Either layer may be absent (top-level
@@ -526,7 +547,7 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
         (!describe_hook_stack_.empty() && !describe_hook_stack_.back().afterEach.empty())
             ? &describe_hook_stack_.back().afterEach
             : nullptr;
-    if (hasTimeout) {
+    if (timeoutMs > 0) {
         // All four hook layers are inlined inside emitItWithTimeout's
         // normalBB between begin and end, so hook failures attribute to the
         // current @it via __ry_test_record_fail. The SIGALRM siglongjmp path
@@ -734,13 +755,7 @@ void CodeGen::emitEachItDirective(std::unique_ptr<FnStmt> &s) {
         codegenError("@each: tuple arity (" + std::to_string(numFields) +
                      ") doesn't match function parameter count (" + std::to_string(s->params.size()) + ")");
 
-    stripDirectives(s->directives, {"it", "each", "only"});
-    emitStmt(s);
-
-    auto *overloads = findFunction(s->name);
-    if (!overloads || overloads->empty())
-        codegenError("@each @it: internal error — fn '" + s->name + "' not found after emit");
-    const auto &entry = overloads->back();
+    const auto &entry = emitItFn(s, {"it", "each", "only"}, "@each @it");
     auto capturedVals = loadCapturedArgs(entry, "@each @it");
     emitEachItLoop(listPtr, elemTy, numFields, fmtStr, entry.func,
                    std::vector<llvm::Value*>(capturedVals.begin(), capturedVals.end()));
@@ -775,13 +790,7 @@ void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
         paramNames.push_back(p.name);
     }
 
-    stripDirectives(s->directives, {"it", "property", "only"});
-    emitStmt(s);
-
-    auto *overloads = findFunction(s->name);
-    if (!overloads || overloads->empty())
-        codegenError("@property @it: internal error — fn '" + s->name + "' not found after emit");
-    const auto &entry = overloads->back();
+    const auto &entry = emitItFn(s, {"it", "property", "only"}, "@property @it");
     auto capturedVals = loadCapturedArgs(entry, "@property @it");
     llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
     emitPropertyItLoop(entry.func, descVal, paramTypes, paramNames, count,
@@ -944,6 +953,19 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
         return;
     }
 
+    const auto &entry = emitDescribeFn(s);
+    emitDescribeDriverFragment(descVal, entry);
+}
+
+// Phase 1 of @describe normal-mode path (#2235): pre-scan and consume
+// lifecycle hooks from s->body, splice @beforeAll/@afterAll into the
+// describe-local body around the first/last @it, push the
+// @beforeEach/@afterEach hook frame onto describe_hook_stack_, strip
+// the @describe directive, emit the describe fn through the ordinary fn
+// codegen path, pop the hook frame, and look up the resulting
+// OverloadEntry. The returned reference is valid in the caller's scope
+// until additional function registrations intervene.
+const CodeGen::OverloadEntry &CodeGen::emitDescribeFn(std::unique_ptr<FnStmt> &s) {
     // ----- Pre-scan: extract lifecycle hooks from s->body -----
     //
     // Walk linearly; for each FnStmt carrying a hook directive, validate,
@@ -957,33 +979,22 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
     std::vector<StmtNode> afterEachBody;
     std::string beforeAllName, afterAllName, beforeEachName, afterEachName;
 
-    auto extractHook = [&](std::unique_ptr<FnStmt> &fn, const char *hookName,
-                           std::vector<StmtNode> &dest, std::string &destName) {
-        if (!destName.empty())
-            codegenError(std::string("@") + hookName + " can be declared at most once per @describe block (fn '" +
-                         destName + "' already declared)");
-        validateLifecycleHookFnShape(fn, hookName);
-        validateLifecycleHookBody(fn->body, hookName);
-        destName = fn->name;
-        dest = std::move(fn->body);
-    };
-
     for (auto it = s->body.begin(); it != s->body.end(); ) {
         auto *fnPtr = std::get_if<std::unique_ptr<FnStmt>>(&*it);
         if (!fnPtr) { ++it; continue; }
         auto &fn = *fnPtr;
         bool consumed = false;
         if (hasDirective(fn->directives, "beforeEach")) {
-            extractHook(fn, "beforeEach", beforeEachBody, beforeEachName);
+            extractLifecycleHook(fn, "beforeEach", "@describe block", beforeEachBody, beforeEachName);
             consumed = true;
         } else if (hasDirective(fn->directives, "afterEach")) {
-            extractHook(fn, "afterEach", afterEachBody, afterEachName);
+            extractLifecycleHook(fn, "afterEach", "@describe block", afterEachBody, afterEachName);
             consumed = true;
         } else if (hasDirective(fn->directives, "beforeAll")) {
-            extractHook(fn, "beforeAll", beforeAllBody, beforeAllName);
+            extractLifecycleHook(fn, "beforeAll", "@describe block", beforeAllBody, beforeAllName);
             consumed = true;
         } else if (hasDirective(fn->directives, "afterAll")) {
-            extractHook(fn, "afterAll", afterAllBody, afterAllName);
+            extractLifecycleHook(fn, "afterAll", "@describe block", afterAllBody, afterAllName);
             consumed = true;
         }
         if (consumed) it = s->body.erase(it);
@@ -1049,9 +1060,17 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
         codegenError("@describe: internal error — fn '" + s->name + "' not found after emit");
-    const auto &entry = overloads->back();
-    auto capturedArgs = loadCapturedArgs(entry, "@describe");
+    return overloads->back();
+}
 
+// Phase 2 of @describe normal-mode path (#2235): emit the
+// describe_begin → call describe_fn → describe_end driver fragment at
+// builder_'s current position. The describe fn body is already emitted
+// (with the in-place @it driver fragments inside) by emitDescribeFn;
+// this fragment only wraps the call in the describe_begin / _end pair.
+void CodeGen::emitDescribeDriverFragment(llvm::Value *descVal,
+                                         const OverloadEntry &entry) {
+    auto capturedArgs = loadCapturedArgs(entry, "@describe");
     auto [descBeginFn, descEndFn] = getTestDescribeFunctions();
     builder_.CreateCall(descBeginFn, {descVal});
     builder_.CreateCall(entry.func, capturedArgs);

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -2854,3 +2854,61 @@ TEST_F(DirectiveTest, FullNineStepCascadeOrdering) {
     }
 }
 
+// --- Regression guards for #2235 (refactor: emit @it as ordinary fns
+// + synthesize sequential driver main) ---
+//
+// The refactor splits emitItDirective / emitDescribeDirective into "fn
+// emission" and "driver fragment synthesis" phases, and extracts the
+// file-level lifecycle hook pre-scan into a helper. These two tests pin
+// the in-place driver fragment ordering invariant: source order between
+// top-level non-fn statements and @describe groups must be preserved,
+// and describe-level @beforeEach must observably run before the @it body.
+//
+// Both tests pass against pre-refactor code and must continue to pass
+// across every intermediate cycle. If either regresses, the driver
+// fragment was reordered relative to top-level emission or the hook
+// inline sequence was broken.
+
+// Mirrors any.test.ry:1149 — a module-level binding declared BETWEEN
+// two top-level @describe blocks must be initialized before the second
+// @describe's @it body observes it.
+TEST_F(DirectiveTest, InterleavedBindingBetweenDescribesPreservesOrder) {
+    const std::string output = runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"first block\")\n"
+        "fn firstBlock():\n"
+        "    @it(\"dummy\")\n"
+        "    fn dummy():\n"
+        "        expect(1).toEq(1)\n"
+        "sharedVal: int = 42\n"
+        "@describe(\"second block uses sharedVal\")\n"
+        "fn secondBlock():\n"
+        "    @it(\"should see sharedVal = 42\")\n"
+        "    fn checkShared():\n"
+        "        expect(sharedVal).toEq(42)\n"
+    ));
+    EXPECT_NE(output.find("2 passed, 0 failed"), std::string::npos)
+        << "interleaved binding must be initialized before the second @describe runs: "
+        << output;
+}
+
+// Mirrors the describe-level @beforeEach inline-ordering invariant.
+// The hook body must execute before the @it body observes captured state.
+// If emitItDriverFragment is extracted incorrectly (e.g. begin/end emitted
+// before the @beforeEach inline), this regresses to "0 passed, 1 failed".
+TEST_F(DirectiveTest, DescribeBeforeEachRunsBeforeItBody) {
+    const std::string output = runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"hook ordering\")\n"
+        "fn d():\n"
+        "    counter = 0\n"
+        "    @beforeEach\n"
+        "    fn setup():\n"
+        "        counter = counter + 1\n"
+        "    @it(\"sees counter incremented by beforeEach\")\n"
+        "    fn checkCounter():\n"
+        "        expect(counter).toEq(1)\n"
+    ));
+    EXPECT_NE(output.find("1 passed, 0 failed"), std::string::npos)
+        << "describe-level @beforeEach must observably run before the @it body: "
+        << output;
+}
+


### PR DESCRIPTION
## Summary

- `emitItDirective` / `emitDescribeDirective` を「fn 化」(`emitItFn` / `emitDescribeFn`) と「driver fragment synthesis」(`emitItDriverFragment` / `emitDescribeDriverFragment`) に分割。`@each` / `@property` パスも共通の `emitItFn` 経由に統合。
- ファイルレベルのライフサイクルフック splice を `collectAndSpliceFileLifecycleHooks` helper に集約。`extractLifecycleHook` で file / describe スコープ共通化。
- `compile()` 内の `test_mode_` ブロック行数を ~78 → ~10 (88% 減)、関数全体も ~140 → 63 行 (55% 減)。

## Behavior preservation

振る舞いは現状と完全一致 (Plan の不変条件):
- 168 DirectiveTest + 208 spec files (`ry test -p`) 全 green
- ASan + TSan + scan-build (advisory) 全 green
- `ry test -p tests/spec` の before/after 出力 diff は timing 行 (`3.33s → 3.29s`) のみ
- 41 filecheck IR ファイルはバイト完全一致 (`diff -rq` 空)

## Test plan

- [x] `./build-rust/ry_tests` 全 green (2802 tests)
- [x] `./build-rust/ry test -p tests/spec` 全 green (208 files)
- [x] ASan + UBSan (Docker) 全 green
- [x] TSan (Docker) 全 green
- [x] Before/after `ry test -p` 出力 diff zero (timing 除く)
- [x] FileCheck IR diff zero (41 ファイル)
- [x] `compile()` 内 `test_mode_` ブロックの行数縮減を実測

Closes #2235