### PR TITLE
ci: drop -p from Linux Ry self-tests (#2237)

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -680,3 +680,37 @@ CI. This is the "new tool added to image" path in
 (`/pre-commit-checklist`). Lint policy is declared in
 `[workspace.lints]` (root `Cargo.toml`); FFI carve-outs stay as
 crate-level `#![allow(...)]` in `lib.rs`.
+
+### Linux Ry self-test: pass no `-p`
+
+**Source**: #2237 (2026-06-18); blocker #2234 (subprocess fan-out
+unification, v0.0.29), background #2232 (design verdict)
+**Tags**: ci, github-actions, ry-test, jit-leak, isolation, worker-count
+
+**Rule**: Every Linux CI job in `.github/workflows/ci.yml` that
+invokes `ry test` must omit `-p` (currently: `test`, `asan`, `tsan`).
+The `macos-smoke-rust` job continues to pass `-p` as the local fast
+path.
+
+**Why**: After #2234, `ry test` always dispatches via per-file
+subprocess fan-out (`-p` controls only worker count, #2216). worker=1
+gives:
+
+- Interleave-free output (crash localisation is straightforward).
+- The same per-file isolation that defeats the 6-step JIT teardown
+  leak accumulation (KNOWLEDGE.md「LLVM ORC JIT intermittent
+  teardown crash」), which previously hit `bad_alloc` at ~42/181
+  spec files in the legacy in-process sequential path on Linux CI
+  (~7GB).
+
+**How to apply**:
+
+- Linux `test` / `asan` / `tsan` jobs use `./<build-dir>/ry test`
+  (no `-p`).
+- `macos-smoke-rust` keeps `./build/ry test -p` as the local fast
+  path. Do not propagate the rule there.
+
+**How to verify**:
+`grep -nE '\bry test\b' .github/workflows/ci.yml | grep -- '-p'`
+must match exactly the `macos-smoke-rust` job line — every other
+`ry test` invocation should be `-p`-free.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Test (C++)
         run: ./build/ry_tests
       - name: Test (Ry self-tests)
-        run: ./build/ry test -p
+        run: ./build/ry test
       - name: Bundle distribution (Linux)
         # Exercise the #2005 packaging path on every PR/push: release.yml is
         # tag-driven and cannot be dry-run, so the bundling + rpath rewrite is
@@ -366,7 +366,7 @@ jobs:
         env:
           ASAN_OPTIONS: detect_container_overflow=0:detect_leaks=0:halt_on_error=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-        run: ./build-asan/ry test -p
+        run: ./build-asan/ry test
 
   tsan:
     runs-on: ubuntu-24.04
@@ -432,7 +432,7 @@ jobs:
         continue-on-error: true
         env:
           TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
-        run: ./build-tsan/ry test -p
+        run: ./build-tsan/ry test
 
   macos-smoke-rust:
     # macOS build/link smoke for the emit Rust cdylib.


### PR DESCRIPTION
## Summary

- Drops `-p` from Linux CI Ry self-test invocations (`test` / `asan` / `tsan` jobs). After #2234 unified `ry test` dispatch on per-file subprocess fan-out, no `-p` means worker=1 sequential subprocess loop — interleave-free output + the same per-file isolation that defeats the 6-step JIT teardown leak accumulation (KNOWLEDGE.md「LLVM ORC JIT intermittent teardown crash」).
- `macos-smoke-rust` continues to pass `-p` as the local fast path.
- Adds the matching invariant rule to `.claude/rules/ci-workflows.md`.

## Test plan

- [x] `grep -nE '\bry test\b' .github/workflows/ci.yml | grep -- '-p'` matches only the `macos-smoke-rust` line.
- [x] `bash scripts/check-prompt-refs.sh` — clean.
- [x] Local `./build-rust/ry test` (worker=1, no `-p`): 208 files, 0 failures, 13.32s.
- [ ] Linux CI `test` / `asan` / `tsan` jobs pass with clean (non-interleaved) log.

## Skipped pre-commit categories (rationale)

| Skipped | Reason |
|---|---|
| run-tests / asan / tsan / static-analysis / rust-lint / tree-sitter / fuzz | No C++/Rust/parser code changes; only CI config + rule doc. |
| `changelog.d/` fragment | No user-visible behavior change (`ry` binary unaffected; impact is CI log layout + Linux self-test stability). |

Closes #2237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow test configurations for Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->