### PR TITLE
chore(emit): document NUL-free invariant on cname_pfx/cname3 via make_cstring

### DIFF
--- a/crates/emit/src/primitive/util.rs
+++ b/crates/emit/src/primitive/util.rs
@@ -3,6 +3,17 @@
 
 use std::ffi::{c_char, CStr, CString};
 
+// Wrap a byte vector as a `CString`. Inputs must not contain interior NUL
+// bytes; otherwise the `CString::new(...).unwrap()` panic unwinds across the
+// `unsafe extern "C" fn` boundary (UB). All callers (`cname_*`) uphold this
+// structurally — inputs are static literals or `cstr_bytes` returns
+// (NUL-stripped by construction).
+#[inline]
+fn make_cstring(v: Vec<u8>) -> CString {
+    debug_assert!(!v.contains(&0), "interior NUL in cname input");
+    CString::new(v).unwrap()
+}
+
 // Build a NUL-terminated CString name from a prefix + suffix (for SSA names
 // like "{prefix}_idx").
 #[inline]
@@ -10,7 +21,7 @@ pub(crate) fn cname_pfx(prefix: &[u8], suffix: &[u8]) -> CString {
     let mut v = Vec::with_capacity(prefix.len() + suffix.len());
     v.extend_from_slice(prefix);
     v.extend_from_slice(suffix);
-    CString::new(v).unwrap()
+    make_cstring(v)
 }
 
 // Three-part CString name (e.g. "cow_" + tag + "_len_ptr") for the CoW retain
@@ -21,7 +32,7 @@ pub(crate) fn cname3(a: &[u8], b: &[u8], c: &[u8]) -> CString {
     v.extend_from_slice(a);
     v.extend_from_slice(b);
     v.extend_from_slice(c);
-    CString::new(v).unwrap()
+    make_cstring(v)
 }
 
 // Borrow C-string bytes without the NUL (empty slice on NULL). A pure `CStr`


### PR DESCRIPTION
## Summary

- `crates/emit/src/primitive/util.rs` に private helper `make_cstring(v: Vec<u8>) -> CString` を追加し、`debug_assert!(!v.contains(&0), ...)` と契約コメントを一箇所に集約
- `cname_pfx` / `cname3` を `make_cstring(v)` 経由に変更。`CString::new(v).unwrap()` のパニックが `unsafe extern "C" fn` 境界を越えると UB なので、debug ビルドで早期検出する保険
- 既存呼び出し元はすべて静的バイトリテラルか `cstr_bytes` 戻り値（NUL-stripped）で構造的に invariant が成立 — 実害ゼロの防御的契約文書化
- Release ビルドでは `debug_assert!` がコンパイル除去されるため emit IR は bit-identical

Closes #2252

## Test plan

- [x] `cmake --build build-rust --target ry ry_tests`
- [x] `./build-rust/ry_tests` (2805 tests passed)
- [x] `./build-rust/ry test -p` (209 test files, 0 failures)
- [x] `./.claude/skills/pre-commit-checklist/run-rust-lint.sh` (fmt + clippy + abi-no-IR)
- [x] `./.claude/skills/pre-commit-checklist/run-static-analysis-all.sh` (cppcheck + scan-build: no bugs)
- [x] `./.claude/skills/pre-commit-checklist/run-asan.sh`
- [x] `./.claude/skills/pre-commit-checklist/run-tsan.sh`

Skipped: fuzz (not parser-family), prompt-refs / tree-sitter (no relevant changes), docs / changelog (no user-visible behavior change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to enhance maintainability and consolidate string handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->