### PR TITLE
docs(rules): codify per-file process as the only valid test isolation unit (#2238)

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -684,7 +684,8 @@ crate-level `#![allow(...)]` in `lib.rs`.
 ### Linux Ry self-test: pass no `-p`
 
 **Source**: #2237 (2026-06-18); blocker #2234 (subprocess fan-out
-unification, v0.0.29), background #2232 (design verdict)
+unification, v0.0.29), background #2232 (design verdict);
+policy invariant #2238 (code-side guard)
 **Tags**: ci, github-actions, ry-test, jit-leak, isolation, worker-count
 
 **Rule**: Every Linux CI job in `.github/workflows/ci.yml` that
@@ -714,3 +715,6 @@ gives:
 `grep -nE '\bry test\b' .github/workflows/ci.yml | grep -- '-p'`
 must match exactly the `macos-smoke-rust` job line — every other
 `ry test` invocation should be `-p`-free.
+
+**See also**: `.claude/rules/test-runner-isolation.md` — the
+implementation-side guard this CI default is paired with.

--- a/.claude/rules/test-runner-isolation.md
+++ b/.claude/rules/test-runner-isolation.md
@@ -1,0 +1,125 @@
+---
+paths:
+  - "src/jit/test_runner.cpp"
+  - "include/ry/jit/test_runner.hpp"
+  - "src/jit/jit_runner.cpp"
+  - "src/app/main.cpp"
+---
+
+# Test Runner Isolation
+
+### Per-file subprocess is the only legitimate `ry test` orchestration
+
+**Source**: #2238 (formalising the #2232 design verdict on top of
+the #2234 subprocess fan-out unification)
+**Tags**: testing, jit, llvm, orc, isolation, design-invariant,
+runtime, parent-process
+
+**Rule**: `ry test` must dispatch every discovered `*.test.ry`
+through the `runTestFiles` → `runTestFilesSubprocessFanOut` →
+`runTestFileSubprocess` chain in `src/jit/test_runner.cpp`. The
+parent process must not JIT. Specifically banned:
+
+- Reviving any `runTestFilesSequential` (or moral equivalent) that
+  walks `runRySource` / `runRyFile` for multiple files inside the
+  parent process. The function was removed in #2234; do not
+  reintroduce it under a new name.
+- Adding any new code path under the `test` subcommand in
+  `src/app/main.cpp` that calls `runRySource` / `runRyFile` more
+  than once per parent process.
+- Sharing an `LLJIT` instance across files within one process.
+
+**Why**: The six-step ORC teardown suppression (KNOWLEDGE.md
+「LLVM ORC JIT intermittent teardown crash」) deliberately leaks
+`LLJIT`, `CodeGen`, and the parsed `Program` AST; process exit is
+the *only* path that reclaims this memory. Walking multiple files
+in one process therefore accumulates the leak — the legacy
+in-process sequential path hit `bad_alloc` at ~42 of 181 spec
+files (~7 GB RSS) on Linux CI before #2234 reunified everything on
+subprocess fan-out. Until the six-step suppression itself can be
+removed (see "When this rule can be revisited" below), per-file
+subprocess isolation is structurally required, not merely
+preferred.
+
+**How to apply**:
+
+- Orchestration changes belong in
+  `runTestFilesSubprocessFanOut`. `-p N` controls worker count
+  only; `-p` is not the dimension that bounds memory.
+- New verbs that need to "run several files" (outline, watch
+  mode, etc.) must spawn one child per file, exactly as
+  `runTestFileSubprocess` does. See the multi-file `--outline`
+  pattern in #2236 for a worked example.
+- The operational counterpart on the CI side
+  (`.claude/rules/ci-workflows.md` "Linux Ry self-test: pass no
+  `-p`") encodes the worker-count default this rule depends on.
+  Keep the two in sync.
+
+### Sub-file (`@it` / `@describe`) granularity parallelism is forbidden
+
+**Source**: #2238 (#2232 design verdict)
+**Tags**: testing, jit, parallelism, lifecycle, isolation,
+design-invariant
+
+**Rule**: Do not introduce a runner, runtime API, or CLI flag
+that parallelises *within* a single `.test.ry` file at `@it` or
+`@describe` granularity. Parallelism stays at the
+one-file-per-process boundary that
+`runTestFilesSubprocessFanOut` already provides.
+
+**Why**: File-level `@beforeAll` / `@afterAll` lifecycle hooks
+are defined to bracket one source file's worth of work — they
+own setup and teardown state that lives in the JIT'd module of
+that file. Parallelising `@it` blocks would either run hooks
+multiple times against the same in-process state (corrupting
+test ordering semantics) or serialise around them (defeating
+the parallelism). The semantics are incompatible by design, not
+by accident of the current implementation.
+
+**How to apply**:
+
+- Treat any "make `@it` blocks run concurrently" proposal as a
+  request to break the hook contract. Reject and link to this
+  rule plus the design discussion in #2232.
+- If a user is hitting per-file wall-clock pain, the answer is
+  to split the source file into smaller `.test.ry` files (so the
+  existing subprocess fan-out picks up more parallelism), not to
+  parallelise inside one file.
+
+### When this rule can be revisited
+
+**Source**: #2238
+**Tags**: testing, jit, llvm, orc, isolation, future-work,
+rust-migration
+
+**Rule**: The two rules above are absolute as long as the
+six-step ORC teardown suppression is required. They become
+revisitable — not automatically relaxed — when *either* of the
+following lands:
+
+- A root-cause fix for the LLVM ORC / JITLink teardown heap
+  corruption tracked at #742, allowing the C++ teardown chain
+  to run normally without the leak-and-`_exit` workaround.
+- The JIT-runner Rust migration (#1949 / #1950 / #1993) takes
+  over ownership of `LLJIT` / `CodeGen` / module lifetimes with
+  explicit `Drop` order replacing the C++ teardown ordering
+  bug.
+
+**Why**: Both rules are workarounds derived from a specific
+upstream/teardown defect, not architectural preferences. If the
+defect goes away, the structural requirement for per-file
+process boundaries also goes away — at which point in-process
+parallelism (including sub-file granularity) becomes an
+implementation choice subject to the usual cost/benefit
+analysis rather than a hard prohibition.
+
+**How to apply**:
+
+- Until one of the conditions above lands, treat any proposal to
+  relax these rules as out of scope and link the proposer here.
+- Once a candidate condition lands, this rule and the matching
+  KNOWLEDGE.md entry should be re-read together before any
+  in-process orchestration is reintroduced — `_Exit` of the JIT
+  process, leak-on-purpose of `LLJIT` / `CodeGen` / `Program`,
+  and the `finalizeAfterPossibleJit` bypass in `src/app/main.cpp`
+  are interlocked and were proven required only as a set.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -277,6 +277,19 @@ regression.
 
 **Subprocess-runner perturbation note (#2236)**: changes to `src/jit/test_runner.cpp` / `include/ry/jit/test_runner.hpp` / the `main.cpp` `test`-subcommand dispatch can **modulate** the #1895 fire rate by perturbing per-spawn allocation, even when the diff never touches the JIT or the failing test's code path. Empirical example from #2236: building outline argv as `std::vector<const char *>` instead of a stack `const char *argv[]` raised the fail rate to ~31% (9/29) on macOS — far above the 5–10% documented band. Switching back to a stack array brought it down to ~8% (8/100), within the documented baseline; origin/main's 0/53 sample at the same time is within sampling noise of that baseline too (P(0/53) at p=5% ≈ 0.07). So the actionable modulation is "heap churn in the spawn path amplifies #1895"; there is no measured residual above baseline once the heap churn is eliminated. Sanitizers stay clean (ASan 208/208, TSan 208/208 in #2236) because the underlying mechanism is teardown timing, not a fresh UAF. **How to apply**: PRs that touch the test-runner subprocess dispatch should run a baseline comparison (`for i in $(seq 1 30); do ./build-rust/ry test -p; done` against origin/main) and report main vs branch fail counts in the PR description; "I didn't touch JIT, so it's unrelated" is contradicted by the modulation data when a 30-run sample lands outside the documented band. Stack-allocate the argv buffer at `runTestFileSubprocess` (don't introduce per-spawn `std::vector` / `std::string` constructions) — that is the only mitigation available short of an upstream fix.
 
+**Policy enforcement (#2238)**: the per-file process boundary this suppression structurally requires is encoded as a code-side guard rule in `.claude/rules/test-runner-isolation.md` — see the sibling entry below for the policy summary.
+
+#### Test execution isolation: per-file process is the only valid unit until the six-step suppression is removed
+
+**Source**: #2238 (formalising the #2232 design verdict on top of the #2234 subprocess fan-out unification)
+**Tags**: testing, jit, llvm, orc, isolation, design-invariant
+
+**Rule**: `ry test` の隔離単位は per-file subprocess のみ。in-process sequential loop（削除済み `runTestFilesSequential` の形）の復活、parent process 内での `runRySource` / `runRyFile` ループ、`@it` / `@describe` 粒度の並列化はすべて禁止。
+
+**Why**: the six-step ORC teardown suppression (sibling entry above) deliberately leaks `LLJIT` / `CodeGen` / `Program` AST, so process `_exit` is the only memory-reclaim path — "1 source file = 1 process" is a structural requirement, not a preference. Sub-file granularity additionally violates the `@beforeAll` / `@afterAll` lifecycle contract, which is defined per source file. Code-side enforcement and per-bullet rationale: `.claude/rules/test-runner-isolation.md`.
+
+**Workaround status**: revisitable when #742's root-cause fix or the Rust JIT migration (#1949 / #1950 / #1993) lands — re-read this entry together with the code-side rule before any in-process orchestration is reintroduced.
+
 #### LLVM 17+ source build: `compiler-rt` belongs in `LLVM_ENABLE_RUNTIMES`, not `LLVM_ENABLE_PROJECTS`
 
 **Source**: #1505 follow-up (2026-05-02)


### PR DESCRIPTION
## Summary

- Add `.claude/rules/test-runner-isolation.md` to codify the test-runner orchestration invariants established in #2232 and operationally enforced by #2234 / #2237: per-file subprocess fan-out only, no in-process sequential loops, no sub-file (`@it` / `@describe`) parallelism, until the six-step ORC teardown suppression can be removed (root cause #742 / Rust JIT migration #1949–#1993).
- Add a paired `####` entry to `KNOWLEDGE.md` under `### ASan`, cross-linked from the existing "LLVM ORC JIT intermittent teardown crash" entry. Keep the canonical rationale in the rule file; the KNOWLEDGE entry is summary + pointer.
- Update `.claude/rules/ci-workflows.md` "Linux Ry self-test: pass no `-p`" to reference #2238 as the policy invariant and to point at the new rule as the implementation-side counterpart.

## Test plan

- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` — clean
- [x] `rg '\*\*Tags\*\*:.*testing' .claude KNOWLEDGE.md` — new entry and rule sections are surfaced
- [x] `rg -n '#2238' KNOWLEDGE.md .claude/rules` — bidirectional cross-links present
- [x] Term consistency: "six-step" used uniformly across all newly authored content

Closes #2238