### PR TITLE
fix(thread): surface worker return value for threadSpawn variable-reference workers (#2262)

### DIFF
--- a/changelog.d/2262-thread-spawn-named-fn-return.md
+++ b/changelog.d/2262-thread-spawn-named-fn-return.md
@@ -1,0 +1,5 @@
+### fix(thread): `threadSpawn(workerFn)` now returns the worker's value for int/float/bool and rejects unsupported return types up front (#2262)
+
+`threadSpawn(myFn)` に named function (`fn worker() -> T:`) や変数に束縛された lambda / closure を直接渡したとき、`T ∈ {int, float, bool}` は silent に `0`/`false` を返し、`T = any` は `std::thread` 内部の `__thread_proxy` で SIGSEGV していた (inline lambda `threadSpawn(() => 42)` は正しく動いていた)。`src/codegen_call_thread.cpp` の `emitThreadSpawn` 内 variable-reference 経路 (no-captures / with-captures いずれも) の trampoline thunk で `callTy` が `void(...)` 固定だったため worker の戻り値が捨てられ、さらに `workerRetTy` が `nullptr` のまま `setTypeMeta(TypeMeta::ThreadResult, ...)` をスキップして `threadJoin` 側が Unit パスに流れ込んでいたのが原因。
+
+両分岐を inline-lambda 経路と同じ ABI に揃え、`FnTypeInfo::returnType` から worker の実際の戻り型を取り出して `Unit` / `int` / `float` / `bool` の値を `result_buf` に store するようにした。`any` / ARC 型 / sum 型は MVP (#828) と同じ文言で codegen error として明示的に reject する。

--- a/docs/reference/thread.md
+++ b/docs/reference/thread.md
@@ -70,7 +70,7 @@ case threadJoin(t2):
 
 - **Return type.** Workers may return `Unit`, `int`, `float`, or `bool`. ARC-managed types (`str`, `List`, `Map`, `Set`, records) and sum types (`Option`, `Result`, enums) are not yet supported; passing such a worker produces a codegen error pointing at a follow-up issue.
 - **Lambda body shape.** Only expression-bodied lambdas (`() => <expr>`) may return a value. Block-bodied lambdas can still be used for `Unit` workers but cannot carry a non-`Unit` return value yet.
-- **Variable-reference workers.** `threadSpawn(myFn)` still treats `myFn` as a `Unit` worker; reading its return value requires the inline-lambda form for now.
+- **Variable-reference workers.** Passing a function value (named `fn`, a lambda bound to a variable, or a closure with captured outer variables) is supported for the same return types as the inline-lambda form (`Unit` / `int` / `float` / `bool`) and `threadJoin` surfaces the returned value. ARC-managed and sum types remain rejected at codegen time, matching the **Return type** limitation above.
 - **Panics.** A runtime panic inside the worker (e.g. division by zero, array out-of-bounds, contract violation) terminates the entire process. It does not currently surface as `Err` from `threadJoin` — this requires a separate refactor of Ry's panic mechanism and is tracked as a follow-up issue.
 
 ## Lock (Mutex)

--- a/src/codegen_call_thread.cpp
+++ b/src/codegen_call_thread.cpp
@@ -112,13 +112,45 @@ static std::unordered_set<std::string> collectReferencedVars(const LambdaExpr &l
 
 // ===== Thread custom emitters =====
 
+// Reject worker return types that don't fit the 8-byte ThreadHandle slot.
+// MVP (#828): only Unit / int / float / bool are supported. void passes
+// through (Unit worker); other shapes (any / ARC / sum types) would either
+// silently corrupt the slot or trip an sret ABI mismatch.
+static void rejectIfUnsupportedThreadReturn(CodeGen &cg, llvm::Type *retTy) {
+    if (!retTy->isVoidTy() &&
+        retTy != cg.i64Ty_ &&
+        retTy != cg.f64Ty_ &&
+        retTy != cg.i1Ty_) {
+        cg.codegenError(
+            "threadSpawn() MVP (#828) supports only () -> Unit, int, float, "
+            "or bool return types; ARC-managed types (str, List, Map, Set, "
+            "records) are tracked in #877, sum types (Option, Result, enum) "
+            "are tracked in #878");
+    }
+}
+
+// Write the worker's return value into the ThreadHandle's 8-byte result slot.
+// i1 is widened to i64 so the full slot is initialised; threadJoin reads back
+// as i64 and truncates to i1. No-op for void workers (Unit).
+static void emitStoreThreadResult(CodeGen &cg, llvm::Value *retVal,
+                                  llvm::Type *workerRetTy,
+                                  llvm::Value *resultRaw) {
+    if (workerRetTy->isVoidTy())
+        return;
+    llvm::Value *toStore = retVal;
+    if (workerRetTy == cg.i1Ty_)
+        toStore = cg.emitZExt(retVal, cg.i64Ty_, "thread_ret_bool_ext");
+    cg.emitStore(toStore, resultRaw);
+}
+
 static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
     cg.requireArgs(e, 1);
 
     llvm::Value *envPtr = nullptr;
     llvm::Function *thunk = nullptr;
-    // MVP scope for #828: inline lambda may return int/float/bool/Unit.
-    // Variable-reference worker is always treated as Unit (follow-up issue).
+    // MVP scope (#828): supported worker return types are Unit / int / float
+    // / bool. The set is enforced uniformly via rejectIfUnsupportedThreadReturn
+    // across inline-lambda and variable-reference workers.
     llvm::Type *workerRetTy = nullptr;
     int64_t resultSize = 0;
 
@@ -149,17 +181,8 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
         //     are rejected early so the user gets the MVP error without
         //     walking the body first.
         if (lam.expr_body && lam.return_type) {
-            llvm::Type *annotated = cg.resolveType(lam.return_type->toString());
-            if (annotated && !annotated->isVoidTy() &&
-                annotated != cg.i64Ty_ &&
-                annotated != cg.f64Ty_ &&
-                annotated != cg.i1Ty_) {
-                cg.codegenError(
-                    "threadSpawn() MVP (#828) supports only () -> Unit, int, float, "
-                    "or bool return types; ARC-managed types (str, List, Map, Set, "
-                    "records) are tracked in #877, sum types (Option, Result, enum) "
-                    "are tracked in #878");
-            }
+            if (llvm::Type *annotated = cg.resolveType(lam.return_type->toString()))
+                rejectIfUnsupportedThreadReturn(cg, annotated);
         }
 
         auto referencedVars = collectReferencedVars(lam);
@@ -240,23 +263,8 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                 // for several callable shapes (see codegen_lambda.cpp:578),
                 // which would silently mis-tag bool/float callbacks.
                 workerRetTy = val->getType();
-                if (!workerRetTy->isVoidTy()) {
-                    if (workerRetTy != cg.i64Ty_ &&
-                        workerRetTy != cg.f64Ty_ &&
-                        workerRetTy != cg.i1Ty_) {
-                        cg.codegenError(
-                            "threadSpawn() MVP (#828) supports only () -> Unit, int, float, "
-                            "or bool return types; ARC-managed types (str, List, Map, Set, "
-                            "records) are tracked in #877, sum types (Option, Result, enum) "
-                            "are tracked in #878");
-                    }
-                    llvm::Value *toStore = val;
-                    // Widen i1 → i64 so the full 8-byte slot is initialized;
-                    // the join side reads back as i64 and truncates to i1.
-                    if (workerRetTy == cg.i1Ty_)
-                        toStore = cg.emitZExt(val, cg.i64Ty_, "thread_ret_bool_ext");
-                    cg.emitStore(toStore, resultRaw);
-                }
+                rejectIfUnsupportedThreadReturn(cg, workerRetTy);
+                emitStoreThreadResult(cg, val, workerRetTy, resultRaw);
             } else {
                 // Block-bodied inline lambda: always Unit (the non-Unit
                 // annotation case was rejected above).
@@ -288,16 +296,24 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
         }
 
     } else {
-        // Case 2: variable reference (named function or variable holding fn() -> Unit)
-        // MVP: always treated as Unit (resultSize remains 0). Supporting
-        // non-Unit return types via variable-reference worker is a follow-up
-        // issue because it requires writing the wrapped fn's return into the
-        // ThreadHandle slot from a trampoline.
+        // Case 2: variable reference (named function or variable holding a
+        // fn value). Both the capturing and non-capturing sub-branches surface
+        // the worker's return value through the thread result slot, matching
+        // Case 1's ABI; supported return types match Case 1's MVP set.
         llvm::Value *fnVal = cg.emitExpr(*e.args[0]);
         const llvm::DataLayout &dl = cg.mod_->getDataLayout();
 
         auto *fnInfoPtr = cg.lookupFnTypeInfo(fnVal);
         bool hasCaps = fnInfoPtr && !fnInfoPtr->capturedVars.empty();
+
+        // Derive the worker's return type from FnTypeInfo. Named fns and
+        // function references carry a statically-known return type via
+        // codegen_expr.cpp's getOrCreateMeta() population. Fall back to Unit
+        // when type info is unavailable (e.g. opaque function pointers).
+        workerRetTy = (fnInfoPtr && fnInfoPtr->returnType)
+            ? fnInfoPtr->returnType
+            : llvm::Type::getVoidTy(*cg.ctx_);
+        rejectIfUnsupportedThreadReturn(cg, workerRetTy);
 
         llvm::FunctionType *thunkTy = llvm::FunctionType::get(
             llvm::Type::getVoidTy(*cg.ctx_), {cg.ptrTy_, cg.ptrTy_}, false);
@@ -339,10 +355,13 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                 llvm::BasicBlock *entryBB = cg.createBBInFn("entry", thunk);
                 cg.builder_.SetInsertPoint(entryBB);
 
-                // Thunk signature is now (env, result_buf); result_buf is
-                // unused for variable-reference workers (Unit only in MVP).
+                // Thunk signature is (env, result_buf). For non-Unit workers
+                // we write the return value into result_buf; Unit workers
+                // leave it untouched.
                 llvm::Value *envRaw = cg.emitGetParam(thunk, 0);
                 envRaw->setName("env_raw");
+                llvm::Value *resultRaw = cg.emitGetParam(thunk, 1);
+                resultRaw->setName("result_raw");
 
                 llvm::Value *loadedFnPtr = cg.emitLoad(
                     cg.ptrTy_,
@@ -362,8 +381,9 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                 }
 
                 llvm::FunctionType *callTy = llvm::FunctionType::get(
-                    llvm::Type::getVoidTy(*cg.ctx_), allParamTypes, false);
-                cg.emitCallIndirect(callTy, loadedFnPtr, callArgs, "");
+                    workerRetTy, allParamTypes, false);
+                llvm::Value *callRet = cg.emitCallIndirect(callTy, loadedFnPtr, callArgs, "");
+                emitStoreThreadResult(cg, callRet, workerRetTy, resultRaw);
                 cg.emitRet(nullptr);
             }
         } else {
@@ -382,20 +402,31 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                 llvm::BasicBlock *entryBB = cg.createBBInFn("entry", thunk);
                 cg.builder_.SetInsertPoint(entryBB);
 
-                // Thunk signature is now (env, result_buf); result_buf unused.
+                // Thunk signature is (env, result_buf). For non-Unit workers
+                // we write the worker's return value into result_buf so the
+                // matching threadJoin can unwrap it; Unit workers leave
+                // result_buf untouched.
                 llvm::Value *envRaw = cg.emitGetParam(thunk, 0);
                 envRaw->setName("env_raw");
+                llvm::Value *resultRaw = cg.emitGetParam(thunk, 1);
+                resultRaw->setName("result_raw");
 
                 llvm::Value *fnPtrField = cg.emitStructGEP(
                     envTy, envRaw, 0, "tramp.fn_ptr");
                 llvm::Value *loadedFn = cg.emitLoad(cg.ptrTy_, fnPtrField, "tramp.fn");
 
+                // Build the indirect call type from the worker's actual
+                // return type so non-void returns land in a register
+                // (sret-shaped returns have already been rejected by
+                // rejectIfUnsupportedThreadReturn above).
                 llvm::FunctionType *callTy = llvm::FunctionType::get(
-                    llvm::Type::getVoidTy(*cg.ctx_), {}, false);
-                cg.emitCallIndirect(callTy, loadedFn, {}, "");
+                    workerRetTy, {}, false);
+                llvm::Value *callRet = cg.emitCallIndirect(callTy, loadedFn, {}, "");
+                emitStoreThreadResult(cg, callRet, workerRetTy, resultRaw);
                 cg.emitRet(nullptr);
             }
         }
+        resultSize = workerRetTy->isVoidTy() ? 0 : 8;
     }
 
     // Call __ry_thread_spawn(thunk, env, result_size).

--- a/tests/spec/thread.test.ry
+++ b/tests/spec/thread.test.ry
@@ -282,6 +282,104 @@ fn threadspawnReturnValuesMvp828Tests():
       Err(e):
         fail("expected Ok but got Err: " + e.message)
 
+@describe("threadSpawn variable-reference workers (#2262)")
+fn threadspawnVariableReferenceWorkers2262Tests():
+  @it("should return int from a named-fn worker")
+  fn shouldReturnIntFromANamedFnWorker():
+    fn intWorker() -> int:
+      return 42
+    t = threadSpawn(intWorker)
+    case threadJoin(t):
+      Ok(v):
+        expect(v).toEq(42)
+      Err(e):
+        fail("expected Ok but got Err: " + e.message)
+
+  @it("should return float from a named-fn worker")
+  fn shouldReturnFloatFromANamedFnWorker():
+    fn floatWorker() -> float:
+      return 3.14
+    t = threadSpawn(floatWorker)
+    case threadJoin(t):
+      Ok(v):
+        expect(v).toEq(3.14)
+      Err(e):
+        fail("expected Ok but got Err: " + e.message)
+
+  @it("should return bool from a named-fn worker")
+  fn shouldReturnBoolFromANamedFnWorker():
+    fn boolWorker() -> bool:
+      return true
+    t = threadSpawn(boolWorker)
+    case threadJoin(t):
+      Ok(v):
+        expect(v).toBeTrue()
+      Err(e):
+        fail("expected Ok but got Err: " + e.message)
+
+  @it("should run a named-fn Unit worker (regression)")
+  fn shouldRunANamedFnUnitWorker():
+    flag = atomicIntNew(0)
+    fn unitWorker() -> Unit:
+      atomicIntAdd(flag, 1)
+    t = threadSpawn(unitWorker)
+    expect(threadJoin(t)).toBeOk()
+    expect(atomicIntLoad(flag)).toEq(1)
+
+  @it("should return int from a variable-bound no-capture lambda")
+  fn shouldReturnIntFromAVariableBoundNoCaptureLambda():
+    f = () => 42
+    t = threadSpawn(f)
+    case threadJoin(t):
+      Ok(v):
+        expect(v).toEq(42)
+      Err(e):
+        fail("expected Ok but got Err: " + e.message)
+
+  @it("should return int from a variable-bound capturing closure")
+  fn shouldReturnIntFromAVariableBoundCapturingClosure():
+    x = 10
+    f = () => x
+    t = threadSpawn(f)
+    case threadJoin(t):
+      Ok(v):
+        expect(v).toEq(10)
+      Err(e):
+        fail("expected Ok but got Err: " + e.message)
+
+  @it("should return expression of captured int from a variable-bound closure")
+  fn shouldReturnExpressionOfCapturedIntFromAVariableBoundClosure():
+    x = 7
+    f = () => x * x + 1
+    t = threadSpawn(f)
+    case threadJoin(t):
+      Ok(v):
+        expect(v).toEq(50)
+      Err(e):
+        fail("expected Ok but got Err: " + e.message)
+
+  @it("should return bool from a variable-bound capturing closure")
+  fn shouldReturnBoolFromAVariableBoundCapturingClosure():
+    flag = true
+    f = () => flag
+    t = threadSpawn(f)
+    case threadJoin(t):
+      Ok(v):
+        expect(v).toBeTrue()
+      Err(e):
+        fail("expected Ok but got Err: " + e.message)
+
+  @it("should return float from a variable-bound capturing closure")
+  fn shouldReturnFloatFromAVariableBoundCapturingClosure():
+    pi = 3.14
+    f = () => pi
+    t = threadSpawn(f)
+    case threadJoin(t):
+      Ok(v):
+        expect(v).toEq(3.14)
+      Err(e):
+        fail("expected Ok but got Err: " + e.message)
+
 @describe("threadJoin error paths (MVP, #828)")
 fn threadjoinErrorPathsMvp828Tests():
   @it("should return Err when joining an already-joined thread")

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -400,6 +400,22 @@ TEST_F(CodeGenTest, HelperReturnRejectsMissingAndPresentThreadResultMetadataMix)
         "returns incompatible Thread result metadata across branches");
 }
 
+// #2262 regression: a named-fn variable-reference worker whose return type
+// is outside the MVP set (Unit / int / float / bool) must be rejected at
+// codegen time. The check lives in rejectIfUnsupportedThreadReturn and is
+// shared with the inline-lambda path, so this one test pins the contract
+// for the entire Case 2 (variable-reference) branch.
+TEST_F(CodeGenTest, ThreadSpawnRejectsNamedFnReturningStrAsVariableReferenceWorker) {
+    expectCompileError(
+        "@native(\"thread\")\n"
+        "fn threadSpawn(body: fn() -> any) -> Thread\n"
+        "fn strWorker() -> str:\n"
+        "  return \"x\"\n"
+        "fn doSpawn() -> Thread:\n"
+        "  return threadSpawn(strWorker)\n",
+        "threadSpawn() MVP (#828) supports only");
+}
+
 // ============================================================
 // Generic inference for container parameters (#823).
 // An empty container literal yields no information for the


### PR DESCRIPTION
## Summary

- `threadSpawn(myFn)` で named function / variable-bound lambda / capturing closure を渡したとき、戻り型が `int`/`float`/`bool` だと **silent に `0`/`false`** を返し、`any` では `std::thread` 内部の `__thread_proxy` で **SIGSEGV** していたバグを修正。
- `emitThreadSpawn` Case 2 (variable-reference) trampoline の `callTy` が `void(...)` 固定で worker 戻り値が捨てられ、`workerRetTy=nullptr` のまま `setTypeMeta(ThreadResult)` もスキップして `threadJoin` 側が Unit パスに流れ込んでいたのが根本原因。
- Case 2 (hasCaps=true / hasCaps=false 両ブランチ) を Case 1 inline-lambda と同じ ABI に揃え、`FnTypeInfo::returnType` から worker の戻り型を取得して `result_buf` に store するようにした。`any` / ARC / sum 型は MVP (#828) と同じ codegen error 文言で reject。
- 同形コードを 4 箇所共有する小さな file-scope helper (`rejectIfUnsupportedThreadReturn`, `emitStoreThreadResult`) を導入し、Case 1 の既存重複も置き換えてある。

Closes #2262

## Test plan

- [x] `tests/spec/thread.test.ry` に新 `@describe("threadSpawn variable-reference workers (#2262)")` を追加 (9 件: named-fn × int/float/bool/Unit-with-counter、variable-bound no-capture lambda × int、variable-bound capturing closure × int/expr/bool/float)
- [x] `./build-rust/ry test tests/spec/thread.test.ry` — 31/31 pass (3 連続実行で安定確認)
- [x] `./build-rust/ry test -p` — 209 files / 0 failures
- [x] `./build-rust/ry_tests` — 2806 tests pass
- [x] ASan (Docker) — 209 files / 0 fail
- [x] TSan (Docker) — 209 files / 0 fail
- [x] 静的解析 (clang-tidy + cppcheck + scan-build) — No bugs found
- [x] Issue minimum repro 3 件:
  - A `fn worker() -> int: return 42` + `threadSpawn(worker)` → **`42`** (修正前は `0`)
  - B `fn worker() -> any: return 42` + `threadSpawn(worker)` → **codegen error reject** (修正前は SIGSEGV)
  - C `fn worker() -> Unit: print("inside")` + `threadSpawn(worker)` → `inside` / `after` (regression なし)
- [x] `docs/reference/thread.md` の MVP 制限文面を更新 (named fn / variable-bound lambda / closure いずれも int/float/bool/Unit をサポートする旨を反映)
- [x] `changelog.d/2262-thread-spawn-named-fn-return.md` を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * `threadSpawn` with variable-reference workers (named functions, lambdas, closures) now correctly returns values for `Unit`, `int`, `float`, and `bool`
  * `threadJoin` now reliably surfaces the spawned worker’s return value
  * Unsupported worker return types are rejected up front

* **Documentation**
  * Updated the thread module “Limitations (MVP)” to reflect supported return types for variable-reference workers

* **Tests**
  * Added regression coverage for variable-reference return values and rejection of unsupported types
<!-- end of auto-generated comment: release notes by coderabbit.ai -->