### PR TITLE
fix(parser): reject 'weak T' as fn/lambda return type (#2266)

### DIFF
--- a/changelog.d/2266-weak-fn-return-rejected.md
+++ b/changelog.d/2266-weak-fn-return-rejected.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `fn` および lambda の return type に `weak T` を書くことを parse 時に reject するようになった。これまでは `fn make() -> weak str:` のような宣言が通り、呼出側で型推論が `str` に倒れて weak ref semantics（`case` での auto-upgrade、`None` 化）が消失していた。根本原因は単なる metadata 伝搬問題ではなく lifetime 問題で、`return weak xs` の `xs` (唯一の strong owner) が return 直前に die するため、呼出側に届く weak ref は構造的に dangling になる。ry には borrow-checking がなく param/struct-field-source の sound pattern を区別できないため、宣言を一律 reject する方針を採用。ローカル `w: weak T = weak src` の正規パターンは引き続き使える。型 alias 経由（`type W = weak str; fn make() -> W:`）と wrapped return type (`List<weak T>` 等) は parser-only check のため検出されないが、使用時の動作は undefined であることを docs に明記。 (#2266)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -88,6 +88,10 @@ fn flexible(x: any) -> any:
     return x    # can return int, float, str, etc.
 ```
 
+### Restricted Return Types
+
+`weak T` cannot appear as a function or lambda return type. The returned weak reference would point to a value whose strong owner has just gone out of scope, making it immediately dangling. See [Restrictions in types.md](types.md#restrictions) for the rationale and the workaround pattern.
+
 ---
 
 ## Nested Functions

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -346,7 +346,7 @@ Weak references are automatically released when they go out of scope. If both st
 `weak T` cannot appear as a function or lambda return type. The strong owner that keeps the referent alive is typically a local variable inside the function body; it would be released when the function returns, making the returned `weak T` immediately dangling. Bind the `weak` reference at the call site instead, where the strong owner is in scope:
 
 ```ry
-# Compile error: fn return type cannot be 'weak T'
+# Compile error: return type cannot be 'weak T'
 fn make() -> weak str:
   return weak "hi"
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -341,6 +341,30 @@ The upgrade operation uses a compare-and-swap (CAS) loop internally, making it s
 
 Weak references are automatically released when they go out of scope. If both strong and weak reference counts reach zero, the ARC header is freed.
 
+### Restrictions
+
+`weak T` cannot appear as a function or lambda return type. The strong owner that keeps the referent alive is typically a local variable inside the function body; it would be released when the function returns, making the returned `weak T` immediately dangling. Bind the `weak` reference at the call site instead, where the strong owner is in scope:
+
+```ry
+# Compile error: fn return type cannot be 'weak T'
+fn make() -> weak str:
+  return weak "hi"
+
+# Bind weak at the call site where the strong owner stays alive
+s = "hi"
+w: weak str = weak s
+```
+
+The same restriction applies to lambdas (`(x: str) -> weak str => x` is rejected).
+
+The check is a parser-level syntax check on the outermost return-type node, so the following deferred shapes are **not diagnosed at parse time** today:
+
+- Type aliases that hide a `weak T` (`type W = weak str; fn make() -> W: ...`).
+- Wrapped return types (`fn make() -> List<weak str>:`, `fn make() -> Option<weak str>:`, etc.).
+- Function-type annotations (`f: fn() -> weak str = ...`).
+
+These shapes compile but reproduce the same latent behavior the parser-level check exists to prevent — the returned weak reference loses its `weak T` static type on the caller side and behaves as a plain `T` (e.g. `str`-fallback), with no `case`-based auto-upgrade to `Option<T>`. The lifetime soundness is not enforced by the compiler; whether the referent is alive at access time depends on incidental ARC retains that may or may not exist.
+
 ---
 
 ## F-String (String Interpolation)

--- a/include/ry/parser/parser.hpp
+++ b/include/ry/parser/parser.hpp
@@ -102,6 +102,7 @@ private:
     StmtNode parseForStatement();
     StmtNode parseUsingStatement();
     StmtNode parseFnStatement(const std::vector<Directive> &directives, bool is_async = false);
+    void checkReturnTypeNotWeak(const TypeNodePtr &returnType, int line);
     StmtNode parseDirectiveDefStatement(const Directive *dirAnnot,
                                         std::vector<Directive> directives);
     StmtNode parseRecordStatement();

--- a/src/parser/parser_decl.cpp
+++ b/src/parser/parser_decl.cpp
@@ -208,9 +208,9 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
     lex_.next(); // consume ')'
 
     if (lex_.peek().kind == TokenKind::Arrow) {
-        lex_.next(); // consume '->'
+        Token arrowTok = lex_.next(); // consume '->'
         fnStmt->return_type = parseTypeName();
-        checkReturnTypeNotWeak(fnStmt->return_type, fnTok.line);
+        checkReturnTypeNotWeak(fnStmt->return_type, arrowTok.line);
     } else {
         fnStmt->return_type = nullptr;
     }
@@ -323,7 +323,7 @@ void Parser::checkReturnTypeNotWeak(const TypeNodePtr &returnType, int line) {
     // and wrapped forms are deferred (see docs/reference/types.md).
     if (std::get_if<WeakType>(&returnType->data))
         parseError(line,
-            "fn return type cannot be 'weak T': weak references are scope-local and "
+            "return type cannot be 'weak T': weak references are scope-local and "
             "cannot safely outlive the function body; use a local binding "
             "('w: weak T = weak src') inside the caller instead");
 }

--- a/src/parser/parser_decl.cpp
+++ b/src/parser/parser_decl.cpp
@@ -210,6 +210,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
     if (lex_.peek().kind == TokenKind::Arrow) {
         lex_.next(); // consume '->'
         fnStmt->return_type = parseTypeName();
+        checkReturnTypeNotWeak(fnStmt->return_type, fnTok.line);
     } else {
         fnStmt->return_type = nullptr;
     }
@@ -314,6 +315,17 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         lex_.next(); // consume Dedent
 
     return fnStmt;
+}
+
+void Parser::checkReturnTypeNotWeak(const TypeNodePtr &returnType, int line) {
+    // #2266: weak T as a fn / lambda return type would outlive the strong
+    // owner that keeps it alive. Reject at the outermost node only; alias
+    // and wrapped forms are deferred (see docs/reference/types.md).
+    if (std::get_if<WeakType>(&returnType->data))
+        parseError(line,
+            "fn return type cannot be 'weak T': weak references are scope-local and "
+            "cannot safely outlive the function body; use a local binding "
+            "('w: weak T = weak src') inside the caller instead");
 }
 
 // Parse a directive definition statement (#708):

--- a/src/parser/parser_expr.cpp
+++ b/src/parser/parser_expr.cpp
@@ -1146,8 +1146,9 @@ ExprPtr Parser::parseParenLambdaExpr() {
     }
 
     if (lex_.peek().kind == TokenKind::Arrow) {
-        lex_.next(); // consume '->'
+        Token arrowTok = lex_.next(); // consume '->'
         lambda->return_type = parseTypeName();
+        checkReturnTypeNotWeak(lambda->return_type, arrowTok.line);
     } else {
         lambda->return_type = nullptr;
     }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -4966,3 +4966,42 @@ TEST(ParserTest, EnumConstructorWithGenericTypeStillWorks) {
     Program prog = parseStr("x = MyOption<int>::MySome(42)");
     ASSERT_EQ(prog.size(), 1u);
 }
+
+// #2266 — weak T return type rejected at parse time (see docs/reference/types.md Restrictions)
+
+TEST(ParserTest, WeakReturnTypeTopLevelFnRejected) {
+    EXPECT_THROW(parseStr("fn make() -> weak str:\n    return \"x\"\n"),
+                 std::runtime_error);
+}
+
+TEST(ParserTest, WeakReturnTypeLambdaRejected) {
+    EXPECT_THROW(parseStr("f = (x: str) -> weak str => x\n"),
+                 std::runtime_error);
+}
+
+TEST(ParserTest, WeakReturnTypeGenericFnRejected) {
+    EXPECT_THROW(parseStr("fn wrap<T>(x: T) -> weak T:\n    return x\n"),
+                 std::runtime_error);
+}
+
+TEST(ParserTest, WeakReturnTypeMethodStyleFnRejected) {
+    // ry uses UFCS, so record methods are regular fns parsed by the same
+    // parseFnStatement path. The check at L212 covers them uniformly.
+    EXPECT_THROW(parseStr("fn get(self: Rec) -> weak List<int>:\n    return self.xs\n"),
+                 std::runtime_error);
+}
+
+TEST(ParserTest, WeakReturnTypeNativeFnRejected) {
+    // @native fns have no body but the annotation still establishes an
+    // unsound API surface; reject consistently with declared fns.
+    EXPECT_THROW(parseStr("@native(\"core\")\nfn opaque() -> weak str\n"),
+                 std::runtime_error);
+}
+
+TEST(ParserTest, WeakReturnTypeWrappedInListAccepted) {
+    // The check fires only when WeakType is the OUTERMOST node of the
+    // return type AST. Wrapped forms like `List<weak T>` are out of scope
+    // for #2266 (deferred to a follow-up issue requiring AST walk).
+    Program prog = parseStr("fn make() -> List<weak str>:\n    return []\n");
+    ASSERT_EQ(prog.size(), 1u);
+}


### PR DESCRIPTION
## Summary

- A function returning `weak T` is structurally dangling — the only strong owner that keeps the referent alive is a local in the fn body and dies at return. ry has no borrow checker to distinguish the sound param/struct-field cases, so reject at parse time via a shared `Parser::checkReturnTypeNotWeak()` helper covering both `parseFnStatement` and `parseParenLambdaExpr`.
- Alias-hiding (`type W = weak str`) and wrapped shapes (`List<weak T>`, `Option<weak T>`, ...) are not diagnosed at parse time; documented as deferred limitations in `docs/reference/types.md`.

## Test plan
- [x] New negative tests in `tests/test_parser.cpp` for top-level fn / lambda / generic / method-style / @native / `List<weak T>` deferred shape
- [x] `./build-rust/ry_tests` (2813/2813 PASS)
- [x] `./build-rust/ry test -p` (210 files, 0 failures — existing `weak_ref.test.ry` 9 cases still pass)
- [x] ASan/UBSan, TSan, fuzz (parser/json/utf8/io_open), scan-build all clean
- [x] Smoke `./build-rust/ry -c` on issue repros A/B/C reject with the documented error; legitimate local `w: weak T = weak src` pattern still works

Closes #2266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Functions and lambdas now reject `weak T` as an outermost return type during parsing to prevent unsound weak-reference behavior.
* **Documentation**
  * Added “Restricted Return Types” coverage, including recommended safe patterns and notes on shapes that may not be diagnosed immediately (e.g., through aliases or wrapper types).
* **Tests**
  * Expanded parser test coverage to confirm rejection for `fn`, lambdas, generics, UFCS-style definitions, and `@native`, while allowing `weak` nested inside wrapper return types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->