### PR TITLE
fix(codegen): tuple element splitter で nested '<>' depth を追跡 (#2264)

### DIFF
--- a/changelog.d/2264-tuple-nested-generic.md
+++ b/changelog.d/2264-tuple-nested-generic.md
@@ -1,0 +1,3 @@
+### fix(codegen): tuple element splitter tracks both `<>` and `()` depth (#2264)
+
+tuple type の要素位置に内部 `,` を持つ 2 引数 generic (`Map<K, V>` / `Result<T, E>`) を書くと `unknown type: Map<str` 等のコンパイルエラーが出ていた問題を修正した (例: `xs: List<(int, Map<str, int>)> = []`)。`src/codegen_type.cpp` の tuple 要素分割が `(` `)` のみで depth を追跡し `<` `>` を無視していたため、内側 generic の `,` を tuple 要素区切りと誤認していた。canonical な `ry::util::splitTupleTypeName` (内部で `splitTopLevelCommas` を使い `<>`/`()`/`[]` を追跡) に置き換えて修正。List / Set / bare tuple / fn return / type alias / Result-in-tuple の全パターンを spec test で検証。

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -139,29 +139,15 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
         }
     }
 
-    // Tuple type: "(int, float)"
+    // Tuple type: use splitTupleTypeName so nested '<>' depth is tracked (#2264).
     if (!typeName.empty() && typeName.front() == '(') {
-        // Parse element types from "(T1, T2, ...)"
-        std::string inner = typeName.substr(1, typeName.size() - 2); // strip parens
+        std::vector<std::string> parts;
+        if (!ry::util::splitTupleTypeName(typeName, parts))
+            codegenError("malformed tuple type: " + typeName);
         std::vector<llvm::Type*> elementTypes;
-        elementTypes.reserve(static_cast<size_t>(std::count(inner.begin(), inner.end(), ',')) + 1);
-        size_t depth = 0;
-        size_t start = 0;
-        for (size_t i = 0; i <= inner.size(); ++i) {
-            if (i < inner.size() && inner[i] == '(') ++depth;
-            else if (i < inner.size() && inner[i] == ')') --depth;
-            else if ((i == inner.size() || inner[i] == ',') && depth == 0) {
-                std::string elem = inner.substr(start, i - start);
-                // trim leading/trailing spaces
-                size_t s = elem.find_first_not_of(' ');
-                size_t e = elem.find_last_not_of(' ');
-                if (s != std::string::npos)
-                    elem = elem.substr(s, e - s + 1);
-                if (elem.empty()) continue; // trailing comma
-                elementTypes.push_back(resolveType(elem));
-                start = i + 1;
-            }
-        }
+        elementTypes.reserve(parts.size());
+        for (auto &elem : parts)
+            elementTypes.push_back(resolveType(elem));
         return llvm::StructType::get(*ctx_, elementTypes);
     }
 

--- a/tests/spec/tuple_nested_generic_2264.test.ry
+++ b/tests/spec/tuple_nested_generic_2264.test.ry
@@ -1,0 +1,78 @@
+from testing import it, describe, expect, fail
+
+# Issue #2264: tuple element に内部 `,` を持つ 2 引数 generic を書くと
+# codegen の tuple splitter が `<>` depth を無視して "unknown type: Map<str"
+# を出していた。issue の全 repro variants と Result-in-tuple 予測をカバー。
+
+type TupleMap2264 = (int, Map<str, int>)
+
+@describe("tuple type with nested 2-arg generic (#2264)")
+fn tupleTypeNestedGeneric2264Tests():
+
+  @it("Empty List<(int, Map<str, int>)> compiles (issue minimum repro)")
+  fn emptyListOfTupleMap():
+    xs: List<(int, Map<str, int>)> = []
+    expect(len(xs)).toEq(0)
+
+  @it("List of tuple with Map at position 1, populated literal")
+  fn listOfTupleMapAtPos1():
+    xs: List<(int, Map<str, int>)> = [(10, {"a": 1, "b": 2})]
+    expect(len(xs)).toEq(1)
+    expect(xs[0].0).toEq(10)
+    expect(xs[0].1["a"]).toEq(1)
+    expect(xs[0].1["b"]).toEq(2)
+
+  @it("List of tuple with Map at position 0")
+  fn listOfTupleMapAtPos0():
+    xs: List<(Map<str, int>, int)> = [({"x": 7, "y": 9}, 99)]
+    expect(len(xs)).toEq(1)
+    expect(xs[0].0["x"]).toEq(7)
+    expect(xs[0].0["y"]).toEq(9)
+    expect(xs[0].1).toEq(99)
+
+  @it("Set declaration of tuple with Map element type compiles")
+  fn setOfTupleMapDeclares():
+    # Map は hashable でないため要素 add は検証しない。
+    # 本テストの目的は型注釈のコンパイル成功確認。
+    s: Set<(int, Map<str, int>)> = {}
+    expect(len(s)).toEq(0)
+
+  @it("Bare tuple variable with inner Map")
+  fn bareTupleWithInnerMap():
+    t: (int, Map<str, int>) = (42, {"k": 100})
+    expect(t.0).toEq(42)
+    expect(t.1["k"]).toEq(100)
+
+  @it("Function return type is tuple with inner Map compiles and is callable")
+  fn fnReturnTupleWithMap():
+    # .1 アクセスは独立した fn-return metadata propagation gap のため省略。
+    fn build() -> (int, Map<str, int>):
+      return (7, {"a": 1, "b": 2})
+    r = build()
+    expect(r.0).toEq(7)
+
+  @it("Type alias expanding to tuple with inner Map compiles")
+  fn typeAliasExpandsToTupleWithMap():
+    # alias 経由の .1 アクセスは独立した metadata gap のため省略。
+    xs: List<TupleMap2264> = [(3, {"k": 1})]
+    expect(len(xs)).toEq(1)
+    expect(xs[0].0).toEq(3)
+
+  @it("List of tuple with Result at position 1 (unverified prediction in #2264)")
+  fn listOfTupleResultAtPos1():
+    ok: Result<str, str> = Ok("hello")
+    xs: List<(int, Result<str, str>)> = [(1, ok)]
+    expect(len(xs)).toEq(1)
+    expect(xs[0].0).toEq(1)
+    elem = xs[0]
+    case elem.1:
+      Ok(v): expect(v).toEq("hello")
+      Err(e): fail("expected Ok, got Err: " + e)
+
+  @it("Iterate over List<(int, Map<str, int>)> via for-in")
+  fn iterateListOfTupleMap():
+    xs: List<(int, Map<str, int>)> = [(1, {"a": 10}), (2, {"b": 20})]
+    total = 0
+    for elem in xs:
+      total = total + elem.0
+    expect(total).toEq(3)


### PR DESCRIPTION
## Summary

- tuple type の要素位置に内部 `,` を持つ 2 引数 generic (`Map<K, V>` / `Result<T, E>`) を入れると `unknown type: Map<str` 等のコンパイルエラーが出ていたバグを修正 (例: `xs: List<(int, Map<str, int>)> = []`)
- `src/codegen_type.cpp` の inline tuple splitter が `(` `)` のみで depth を追跡し `<` `>` を無視していたため、内側 generic の `,` を tuple 要素区切りと誤認していた
- canonical な `ry::util::splitTupleTypeName` (内部で `splitTopLevelCommas` を使い `<>`/`()`/`[]` を全追跡) に置き換え

## Test plan

- [x] 新規 `tests/spec/tuple_nested_generic_2264.test.ry` 9 ケース (空 List repro / Map at pos 1 / Map at pos 0 / Set declare / bare tuple / fn return / type alias / Result-in-tuple / for-in iterate) Green
- [x] `./build-rust/ry_tests` 2813 unit tests / 0 failures
- [x] `./build-rust/ry test -p` 212 spec files / 0 failures
- [x] ASan / TSan: docker preset で 212 spec files / 0 failures
- [x] Static analysis (clang-tidy + cppcheck + scan-build): "No bugs found"
- [x] `/simplify` で受けた cleanup を適用 (dead guard 削除、コメント verbosity 削減)

### Side findings (本 PR scope 外、別 issue 推奨)

同 `src/codegen_type.cpp` に類似の string-based splitter の depth-tracking gap が 2 箇所残存:

- **`codegen_type.cpp` Result<V, E> splitter** — `<>` のみ追跡。`Result<(int, str), Error>` で同質バグ
- **`codegen_type.cpp` parseFnTypeAnnotation** — `()` のみ追跡。`fn(Map<K, V>, str)` で同質バグ。canonical peer `splitFunctionTypeName` が既存

両者とも本 fix と独立した別コードパス。

Closes #2264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed tuple type parsing to correctly handle nested generic types with multiple parameters (e.g., `Map<K, V>`). This resolves compilation errors when using complex generic types within tuples.

* **Tests**
  * Added comprehensive test coverage for tuple types with nested generics, including scenarios with List, Set, function returns, and type aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->