### PR TITLE
fix(regex): regexSearch returns char index instead of byte offset (#2265)

### DIFF
--- a/.claude/rules/regex-engine.md
+++ b/.claude/rules/regex-engine.md
@@ -43,3 +43,17 @@ graph and reads these states explicitly.
 **Tags**: regex, codegen, api-naming, ufcs, dispatch
 
 **Rule**: Each unprefixed UFCS regex function (`isMatch`, `search`, `replace`, `split`, `findAll`) must dispatch to a dedicated `__ry_regex_<verb>` runtime symbol whose semantics literally match the function's name. Never alias a UFCS form to the prefixed `regex*` form's runtime symbol — the two can have different semantics (e.g. `isMatch` is partial/unanchored search, but `regexMatch` is full-string match). When adding a new UFCS regex function, add a matching `__ry_regex_<verb>` C entry point in `src/runtime/core/regex.cpp` + `include/ry/runtime/core/regex.hpp` and cover it directly in `tests/test_regex_runtime.cpp` — do not rely on a shared symbol and a LLVM `Trunc` to paper over a semantic mismatch.
+
+### Regex APIs that return a numeric position MUST return a character index, not a raw NFA byte offset
+
+**Source**: #2265 (2026-06-20, bug fix)
+**Tags**: regex, utf8, char-index, byte-offset, runtime, api-policy
+
+**Rule**: Any regex runtime entry point that returns a numeric position into the subject (currently only `__ry_regex_search`; future `searchAll` / `findIndex` / capture-position APIs follow the same rule) must convert the Thompson NFA's internal byte offset to a character (codepoint) index before returning to Ry code. The canonical conversion is `__ry_utf8_char_index_n(text, textLen, byte_offset)` from `include/ry/runtime/core/utf8.hpp` — the same helper `find()` uses (`src/codegen_call_string.cpp`). This keeps the regex surface consistent with the rest of the string API (`len`, `charAt`, `substr`, `find`, `reverse` are all codepoint-based; only `byteLen` is byte-based).
+
+**Why**: The NFA simulator works in bytes internally; raw byte offsets are correct only for ASCII / NUL-only subjects. Multibyte subjects (Japanese, emoji) silently desync from `docs/reference/regex.md` and from the rest of the string API. The "ASCII tests pass, multibyte production bug" failure mode is invisible until users hit it.
+
+**How to apply**:
+- Guard the conversion with `if (byte_offset < 0) return byte_offset;` before calling `__ry_utf8_char_index_n` — the helper's precondition is `0 <= byte_offset <= byte_len` and not-found / sentinel-error returns are out of range.
+- Tests must include multibyte subjects (`"あx"`, `"🎉x"`, etc.) in both `tests/spec/regex_*.test.ry` and `tests/test_regex_runtime.cpp`. ASCII-only coverage cannot detect this class of bug.
+- `regexSplit` / `regexFindAll` return strings / `Match` structs (not numeric offsets) and are exempt — they expose the matched substrings directly, so no byte/char distinction surfaces. The rule applies only to numeric-offset returns.

--- a/changelog.d/2265-regex-search-char-index.md
+++ b/changelog.d/2265-regex-search-char-index.md
@@ -1,0 +1,5 @@
+### fix(regex): `regexSearch` / `search` return char index instead of byte offset (#2265)
+
+`regexSearch(text, pattern)` および UFCS `text.search(/pattern/)` は Thompson NFA から得た byte offset をそのまま返していたため、multibyte UTF-8 を含む subject では返値が character index と乖離していた (例: `regexSearch("あx", "x")` は `1` を期待するところ `3` を返していた)。`include/ry/runtime/core/regex.hpp` の `__ry_regex_search` 宣言コメントは元から "char-index" と謳っており、`find()` / `len` / `charAt` / `substr` 等 repo 全体の string API ポリシーとも整合しない契約違反だった。
+
+`__ry_regex_search` (`src/runtime/core/regex.cpp`) の戻り直前で `__ry_utf8_char_index_n` を呼び、`-1` (not found) と `kRegexSearchError` (catch sentinel) は変換せず短絡することで character index に揃えた。ASCII および NUL バイトを含む subject では byte == char で挙動不変、`__ry_regex_is_match` の `>= 0` 判定にも影響しない。docs/reference/regex.md トップテーブル 2 箇所の "start position" も "character index of the first match start" に厳密化した。

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -54,7 +54,7 @@ These functions take a regex literal pattern and use text-first argument order f
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `isMatch` | `(str, Regex) -> bool` | Returns whether the pattern matches anywhere in the text (use `^...$` to require a full-string match) |
-| `search` | `(str, Regex) -> int` | Returns the start position of the first match (-1 if not found) |
+| `search` | `(str, Regex) -> int` | Returns the character index of the first match start (-1 if not found) |
 | `replace` | `(str, Regex, str) -> str` | Replaces all matches with a replacement string |
 | `split` | `(str, Regex) -> List<str>` | Splits text by pattern matches |
 | `findAll` | `(str, Regex) -> List<Match>` | Returns all non-overlapping matches with capture groups |
@@ -81,7 +81,7 @@ The original `regex_*` functions remain available for backward compatibility. Th
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `regexMatch` | `(text: str, pattern: str) -> bool` | Returns whether the entire text matches the pattern |
-| `regexSearch` | `(text: str, pattern: str) -> int` | Returns the start position of the first match (-1 if not found) |
+| `regexSearch` | `(text: str, pattern: str) -> int` | Returns the character index of the first match start (-1 if not found) |
 | `regexReplace` | `(text: str, pattern: str, replacement: str) -> str` | Replaces all matches with a replacement string |
 | `regexSplit` | `(text: str, pattern: str) -> List<str>` | Splits text by pattern matches |
 | `regexFindAll` | `(text: str, pattern: str) -> List<Match>` | Returns all non-overlapping matches with capture groups |

--- a/include/ry/runtime/core/utf8.hpp
+++ b/include/ry/runtime/core/utf8.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ry {
+
+extern "C" {
+
+// Count UTF-8 codepoints in s[0..byte_offset), stopping exactly at byte_offset.
+// NUL-safe: NUL bytes are counted as single codepoints.
+// Precondition: 0 <= byte_offset <= byte_len.
+// Defined in src/runtime/core/utf8.cpp.
+int64_t __ry_utf8_char_index_n(const char *s, int64_t byte_len, int64_t byte_offset);
+
+}
+
+} // namespace ry

--- a/src/runtime/core/regex.cpp
+++ b/src/runtime/core/regex.cpp
@@ -4,6 +4,7 @@
 #include "ry/runtime/core/error.hpp"
 #include "ry/runtime/core/regex_internal.hpp"
 #include "ry/runtime/core/list.hpp"
+#include "ry/runtime/core/utf8.hpp"
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
@@ -869,6 +870,23 @@ static std::string expandReplacement(const char *repl, size_t repLen,
 
 } // anonymous namespace
 
+// Internal: returns the NFA byte offset of the first match start, -1 if not
+// found, or kRegexSearchError on compile failure. Shared by __ry_regex_search
+// (which converts to char index before returning to Ry) and __ry_regex_is_match
+// (which only checks the sign — char-index conversion would be wasted work).
+static int64_t regex_search_byte_offset(const char *pattern, int64_t patternLen,
+                                         const char *text,    int64_t textLen) {
+    if (!pattern || !text) return -1;
+    try {
+        auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
+        auto result = cr.search(text, static_cast<size_t>(textLen));
+        return result.first;
+    } catch (const std::runtime_error &e) {
+        setLastError("%s", e.what());
+        return kRegexSearchError;
+    }
+}
+
 // ============================================================
 // Public C API
 // ============================================================
@@ -889,22 +907,16 @@ int64_t __ry_regex_match(const char *pattern, int64_t patternLen,
 
 int64_t __ry_regex_search(const char *pattern, int64_t patternLen,
                            const char *text,    int64_t textLen) {
-    if (!pattern || !text) return -1;
-    try {
-        auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
-        auto result = cr.search(text, static_cast<size_t>(textLen));
-        return result.first;
-    } catch (const std::runtime_error &e) {
-        setLastError("%s", e.what());
-        return kRegexSearchError;
-    }
+    int64_t byteOff = regex_search_byte_offset(pattern, patternLen, text, textLen);
+    if (byteOff < 0) return byteOff;
+    return __ry_utf8_char_index_n(text, textLen, byteOff);
 }
 
 int64_t __ry_regex_is_match(const char *pattern, int64_t patternLen,
                              const char *text,    int64_t textLen) {
-    int64_t result = __ry_regex_search(pattern, patternLen, text, textLen);
-    if (result == kRegexSearchError) return kRegexMatchError;
-    return result >= 0 ? 1 : 0;
+    int64_t byteOff = regex_search_byte_offset(pattern, patternLen, text, textLen);
+    if (byteOff == kRegexSearchError) return kRegexMatchError;
+    return byteOff >= 0 ? 1 : 0;
 }
 
 const char *__ry_regex_replace(const char *pattern,     int64_t patternLen,

--- a/tests/spec/regex_literal.test.ry
+++ b/tests/spec/regex_literal.test.ry
@@ -198,3 +198,29 @@ fn nulByteHandlingInRegex1052Tests():
   fn regexsearchLocatesNulContainingSubPattern1052():
     # "\0b" is at index 1 in "a\0b"
     expect(regexSearch("a\0b", "\0b")).toEq(1)
+
+@describe("multibyte char index in search / regexSearch (#2265)")
+fn multibyteCharIndexInSearchRegexsearch2265Tests():
+  @it("char index after 3-byte UTF-8 codepoint (#2265)")
+  fn afterThreeByteCodepoint2265():
+    # "あx" — 'あ' is 3 bytes; 'x' is at char index 1
+    expect(search("あx", /x/)).toEq(1)
+    expect("あx".search(/x/)).toEq(1)
+  @it("char index after two 3-byte codepoints (#2265)")
+  fn afterTwoThreeByteCodepoints2265():
+    # "あいx" — 'x' is at char index 2
+    expect(search("あいx", /x/)).toEq(2)
+    expect(regexSearch("あいx", "x")).toEq(2)
+  @it("char index after 4-byte emoji codepoint (#2265)")
+  fn afterFourByteEmoji2265():
+    # "🎉x" — '🎉' is 4 bytes; 'x' is at char index 1
+    expect(search("🎉x", /x/)).toEq(1)
+    expect(regexSearch("🎉x", "x")).toEq(1)
+  @it("not-found returns -1 for multibyte subject (#2265)")
+  fn notFoundMultibyte2265():
+    expect(search("あいう", /x/)).toEq(-1)
+    expect(regexSearch("あいう", "x")).toEq(-1)
+  @it("NUL + multibyte combination (#2265)")
+  fn nulAndMultibyte2265():
+    # "あ\0x" — 'あ'(1 char) + NUL(1 char) + 'x'(1 char); x at char index 2
+    expect(regexSearch("あ\0x", "x")).toEq(2)

--- a/tests/test_regex_runtime.cpp
+++ b/tests/test_regex_runtime.cpp
@@ -824,6 +824,35 @@ TEST(RegexNul, PatternWithNul) {
 }
 
 // ============================================================
+// Multibyte char-index tests (#2265)
+// ============================================================
+
+TEST(RegexMultibyte, SearchAfterThreeByteCodepoint) {
+    // "あx": 'あ' = 3 bytes, 'x' at char index 1
+    EXPECT_EQ(rs("x", "あx"), 1);
+}
+
+TEST(RegexMultibyte, SearchAfterTwoThreeByteCodepoints) {
+    // "あいx": 'あ'(3) + 'い'(3), 'x' at char index 2
+    EXPECT_EQ(rs("x", "あいx"), 2);
+}
+
+TEST(RegexMultibyte, SearchAfterFourByteEmoji) {
+    // "🎉x": '🎉' = 4 bytes, 'x' at char index 1
+    EXPECT_EQ(rs("x", "🎉x"), 1);
+}
+
+TEST(RegexMultibyte, SearchNotFoundMultibyte) {
+    EXPECT_EQ(rs("x", "あいう"), -1);
+}
+
+TEST(RegexMultibyte, SearchWithNulAndMultibyte) {
+    // "あ\0x" raw bytes — char layout: ['あ'=0, NUL=1, 'x'=2]
+    const char text[] = {'\xe3', '\x81', '\x82', '\0', 'x'};
+    EXPECT_EQ(__ry_regex_search("x", 1, text, 5), 2);
+}
+
+// ============================================================
 // __ry_regex_is_match tests — partial (unanchored) match semantics (#1197)
 // ============================================================
 


### PR DESCRIPTION
## Summary
- `__ry_regex_search` was returning the Thompson NFA's raw byte offset, contradicting the header contract and silently desyncing from `len` / `charAt` / `substr` / `find` / `reverse` on multibyte subjects (e.g. `regexSearch("あx", "x")` returned `3` instead of the documented `1`).
- Convert via `__ry_utf8_char_index_n` with a `-1` short-circuit; extract an internal `regex_search_byte_offset` helper so `__ry_regex_is_match` keeps the byte-offset path (no wasted codepoint walk).
- Tighten the two ambiguous "start position" rows in `docs/reference/regex.md`, record the policy in `.claude/rules/regex-engine.md`, and lock in multibyte coverage in both spec and C++ tests.

Closes #2265

## Test plan
- [x] `./build-rust/ry_tests --gtest_filter='*Regex*'` — 139 PASS
- [x] `./build-rust/ry test tests/spec/regex_literal.test.ry` — 42 PASS
- [x] `./build-rust/ry test -p` — 210 files, 0 failures
- [x] ASan+UBSan via `./.claude/skills/pre-commit-checklist/run-asan.sh` — clean
- [x] TSan via `./.claude/skills/pre-commit-checklist/run-tsan.sh` — clean
- [x] Static analysis (clang-tidy / cppcheck / scan-build) — no new findings
- [x] Issue repro: `regexSearch` returns `1 / 2 / 1 / 1` for `"あx" / "あいx" / "🎉x" / "axb"` (was `3 / 6 / 4 / 1`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected regex search functions to return character indices for multibyte UTF-8 text instead of byte offsets, resolving mismatches in non-ASCII subjects.

* **Documentation**
  * Updated regex function reference to clarify return values represent character index of the first match start.

* **Tests**
  * Added test coverage for regex search behavior with multibyte UTF-8 characters and special cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->