### PR TITLE
docs: fix user-facing reference drift across 8 files (#2274)

### DIFF
--- a/docs/guide/visibility.md
+++ b/docs/guide/visibility.md
@@ -42,7 +42,7 @@ fn fmt(n: int) -> str:
 
 Any importer **outside** `mylib/` cannot see `add` or `fmt` until they are marked `@public`.
 
-Files that have no `package.toml` ancestor — for example, ad-hoc scripts run with `<build-dir>/ry script.ry`, or expressions passed via REPL `-c` — share a single **anonymous package**. They all behave as one package for visibility purposes, so a script can freely import any non-`@public` definition from another script in the same anonymous-package universe.
+Files that have no `package.toml` ancestor — for example, ad-hoc scripts run with `<build-dir>/ry run script.ry`, or code piped via `<build-dir>/ry -c` — share a single **anonymous package**. They all behave as one package for visibility purposes, so a script can freely import any non-`@public` definition from another script in the same anonymous-package universe.
 
 ## Making a definition public
 

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -8,6 +8,39 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 >
 > **Index access:** `str` does not support `[]` index syntax. Use `charAt(s, i)` to get the character at position `i`.
 
+## Block String Literal (`"""..."""`)
+
+In addition to the single-line form (`"..."`), `str` values can also be written as **block string literals** delimited by three double-quotes (`"""..."""`). The result is an ordinary `str` value — `"""hello"""` and `"hello"` compare equal.
+
+Key properties:
+
+- A block string may span multiple lines. Inside `"""..."""`, newlines are part of the body (unlike `"..."`, which forbids raw newlines).
+- An incidental newline immediately after the opening `"""` and immediately before the closing `"""` is dropped.
+- Indentation is normalized: the smallest leading whitespace common to the content lines is treated as the baseline and stripped from every line. Intentional blank lines are preserved.
+- Standard escape sequences (`\n`, `\t`, `\\`, `\"`, `\xNN`, etc.) are decoded the same way as in `"..."`.
+- A single `"` or two consecutive `""` inside the body are content; only `"""` terminates the literal.
+- The empty form `""""""` evaluates to `""`.
+
+```ry
+# Same-line form
+s = """hello"""
+print(s)              # hello
+
+# Multi-line with indentation normalization
+doc = """
+  a
+    b
+  c
+  """
+print(doc)            # a
+                      #   b
+                      # c
+
+# Embedded quotes are content
+q = """a"b""c"""
+print(q)              # a"b""c
+```
+
 ## Function List
 
 ### Search and Check

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -383,7 +383,7 @@ after any diverging control-flow statement is silently elided.
 Returns the command-line arguments passed to the script as a list of strings. Does not include the interpreter name or the script filename — only the arguments after the script path.
 
 ```ry
-# Run: ry script.ry hello world
+# Run: ry run script.ry hello world
 a = args()
 print(len(a))    # 2
 print(a[0])      # hello

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -692,7 +692,7 @@ print(b)          # [1, 2, 3]
 |------|------|
 | All elements must be the same type | Mixed types cause a compile error |
 | Empty list `[]` | Requires type annotation (e.g., `xs: List<int> = []`) |
-| Out-of-range access | Runtime error (exit(1)) |
+| Out-of-range access | Runtime error (process terminates with exit code 1) |
 
 ---
 
@@ -946,7 +946,7 @@ print(m3["c"])   # 3
 | All keys must be the same type | Mixed key types cause a compile error |
 | All values must be the same type | Mixed value types cause a compile error |
 | Empty map | Type annotation is required (e.g., `m: Map<str, int> = {"a": 1}`) |
-| Accessing a non-existent key | Runtime error (exit(1)) |
+| Accessing a non-existent key | Runtime error (process terminates with exit code 1) |
 | Key lookup | Hash table (O(1) average) |
 | Capacity overflow | Automatically doubles in size |
 

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -1,6 +1,6 @@
 # Design by Contract (DbC)
 
-Ry supports Eiffel-style Design by Contract with preconditions (`require`), postconditions (`ensure`), and record invariants (`invariant`). Contract violations terminate the process with `exit(1)`.
+Ry supports Eiffel-style Design by Contract with preconditions (`require`), postconditions (`ensure`), and record invariants (`invariant`). Contract violations terminate the process with exit code 1.
 
 ---
 
@@ -111,6 +111,6 @@ a.balance = -1                  # Contract violation: invariant failed for BankA
 - `ensure` requires a variable binding (e.g., `ensure v:`) to name the return value.
 - For tuple returns, multiple bindings can be specified (e.g., `ensure q, r:`).
 - `invariant` appears at the end of a `record` definition, after all field declarations.
-- All contract violations terminate with `exit(1)` and print a diagnostic message.
+- All contract violations terminate the process (exit code 1) and print a diagnostic message.
 
 > **See also**: For error-as-value patterns using `Result<T, E>`, `Ok`, `Err`, and the `?` operator, see [Types — Result](types.md#result-type) and [Operators — `?`](operators.md).

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -89,16 +89,16 @@ The table below shows the most common runtime errors; it is not exhaustive.
 | `range()` step zero | Called `range()` with a step argument of `0` (`runtime error: range() step must not be zero`) | `range(1, 10, 0)` |
 | `min()` / `max()` on empty list | Called `min()` or `max()` on an empty list (`runtime error: min() on empty list` / `runtime error: max() on empty list`) | `min([])`, `max([])` |
 
-All runtime errors terminate the process with `exit(1)`.
+All runtime errors terminate the process (exit code 1).
 
 ### Runtime Error Examples
 
 ```ry
 # List out-of-range access
 xs = [1, 2, 3]
-print(xs[10])   # Runtime error: exit(1)
+print(xs[10])   # Runtime error — process terminates
 
 # Map non-existent key access
 m = {"a": 1}
-print(m["z"])   # Runtime error: exit(1)
+print(m["z"])   # Runtime error — process terminates
 ```

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -145,7 +145,7 @@ print(stringify(m, 2))
 
 ### `stringifySafe` for recoverable encode failures
 
-`stringify` panics (`exit(1)`) when it encounters JSON-incompatible inputs
+`stringify` panics (process terminates with exit code 1) when it encounters JSON-incompatible inputs
 (non-finite floats, typed collections wrapped as `any`, `Set` / record /
 enum). `stringifySafe` returns those failures as `Err(Error)` so callers
 can recover.
@@ -278,7 +278,7 @@ case open("out.json", "w"):
   deterministic. Pass `sortKeys=true` when output must be reproducible
   across runs that build the same logical map via different insertion
   sequences (snapshot tests, config diffs, content-addressed hashing).
-- `stringify` panics (`exit(1)` with a diagnostic to stderr) when it
+- `stringify` panics (process terminates with exit code 1, with a diagnostic to stderr) when it
   encounters tags JSON cannot represent: non-finite floats (`NaN`,
   `±Infinity`), `Set<...>`, records, enums, or maps keyed by anything
   other than `str`. The return type `-> str` has no `Result` channel,
@@ -300,7 +300,7 @@ case open("out.json", "w"):
   stringify: any holds typed collection 'List<int>' — use List<any> / Map<str, any> / Set<any> instead
   ```
 
-  Followed by `exit(1)`. The recorded type name (`'List<int>'`,
+  Followed by process termination (exit code 1). The recorded type name (`'List<int>'`,
   `'Map<str, int>'`, etc.) reflects the source-level Ry type that was
   wrapped. Safe inputs are: `any` payloads parsed via
   `load[Map<str, any>]` / `load[List<any>]`, primitive `any` slots, and

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -7,7 +7,7 @@
 | `int` | i64 | `42`, `-7`, `0xFF`, `0b1010`, `100_000` | 64-bit signed integer |
 | `float` | f64 | `3.14`, `0.5`, `3.14_159`, `1e10`, `1.5e-3`, `2.5E+2` | 64-bit floating-point number (scientific notation supported) |
 | `bool` | i1 | `true`, `false` | Boolean value |
-| `str` | ptr | `"hello"`, `""`, `"a\nb"` | String (immutable byte sequence on the heap). Internally a pointer to the data portion of a `StringHeader` (`{strong_count, weak_count, byte_len, data[], '\0'}`). Supports embedded NUL bytes (#1022). |
+| `str` | ptr | `"hello"`, `""`, `"a\nb"`, `"""multi\nline"""` | String (immutable byte sequence on the heap). Internally a pointer to the data portion of a `StringHeader` (`{strong_count, weak_count, byte_len, data[], '\0'}`). Supports embedded NUL bytes (#1022). Block string literals (`"""..."""`) are documented in [builtins-string.md](builtins-string.md). |
 | `Unit` | void | (no return value) | Return type for functions with no return value. Must be specified explicitly with `-> Unit` |
 | `Option<T>` | `{ i1, T }` | `Some(42)`, `None` | A type that may or may not contain a value |
 | `(T1, T2, ...)` | LLVM StructType (literal) | `(1, 3.14)` | Tuple type |


### PR DESCRIPTION
## Summary

User-facing docs (`docs/reference/*.md` / `docs/guide/visibility.md`) で 3 系統の drift を一括修正。docs only / no behavior change。

**Drift 1 — triple-quoted block string literal の reference 反映**: `docs/grammar.ebnf` (867336c7) で追加された `"""..."""` literal が string 文法を学ぶページに届いていなかった。`types.md` の str 行に literal 例を追加し、`builtins-string.md` に専用セクションを新設 (prose は `tests/spec/block_strings.test.ry` の挙動を `./build-rust/ry -c` で実機検証してから記述)。

**Drift 2 — 廃止 CLI form の残存**: #1735 で削除された `ry <file>` bare 形式が `visibility.md:45` と `builtins.md:386` に残存していたため `ry run <file>` に置換。`visibility.md` の "REPL `-c`" 表記も `-c` は stdin パイプ専用なので "code piped via `ry -c`" に修正。

**Drift 3 — 他言語 idiom `exit(1)` の Ry 説明への混入**: 10 行で「Ry の `exit()` が呼べる/catch できる」誤読を招く `exit(1)` 表記を、Ry 中立な「exit code 1」/「process terminates with exit code 1」/「process terminates」に置換。`builtins.md:367` の `exit` builtin ドキュメントは Ry 実関数なので意図的に残置。

## Test plan

- [x] `tests/spec/block_strings.test.ry` 13/13 passed (Drift 1 prose の元データ確認)
- [x] `./build-rust/ry -c` で indentation 正規化 / embedded quote / escape sequence の各挙動を実機確認
- [x] verification sweep: `exit(1)` in 4 target files = 0 hits, `ry script.ry` across docs = 0 hits, `printf/malloc/fprintf` = 0 hits
- [x] 8 files / +46 -13 lines (plan 想定 ~30 LOC 範囲内)
- [x] pre-commit-checklist: docs-only カテゴリのため tests/sanitizers/fuzz は matrix 指定どおり skip。changelog.d は直近 4 件の docs-drift PR (6f0c5ec4 / 141616c6 / ecf1ee70 / c748458a) の慣例に従い追加せず

Closes #2274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive documentation for block string literals with examples and behavior specifications
* Clarified command-line usage examples across documentation
* Standardized terminology for process termination descriptions throughout reference documentation
* Enhanced type reference with block string literal examples and cross-references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->