### PR TITLE
test(grammar): hand-curated feature corpus with AST expectations (Phase 2)

### DIFF
--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -117,11 +117,10 @@ test name
 (<expected s-expression>)
 ```
 
-Coverage scope: exercises grammar surface area that the in-tree spec
-files in `tests/spec/` already parse cleanly (i.e. **not** the gaps
-listed in `expected-fail.txt`). Treat the corpus as a regression seed:
-when the grammar is improved to close an `expected-fail.txt` entry, add
-a corpus entry that locks in the new shape in the same PR.
+Treat the corpus as a regression seed: when the grammar improves to
+close an `expected-fail.txt` entry, add a corpus entry that locks in
+the new shape in the same PR. The matrix below details the per-rule
+scope.
 
 To regenerate an expected S-expression after an intentional shape
 change:
@@ -130,21 +129,74 @@ change:
 tree-sitter parse <snippet>.ry | sed -E 's/ \[[0-9]+, [0-9]+\] - \[[0-9]+, [0-9]+\]//g'
 ```
 
+### Coverage matrix
+
+Every top-level rule in `grammar.js` is exercised by at least one corpus
+entry, or is explicitly marked as covered by the smoke fixture only.
+
+| Top-level rule | Corpus file |
+|---|---|
+| `function_declaration` | `functions.txt`, `decorators.txt` |
+| `record_declaration`, `record_invariant` | `records.txt` |
+| `enum_declaration`, `variant_payload` (named / unnamed) | `enums.txt` |
+| `type_alias_declaration` | `type_aliases.txt` |
+| `import_statement`, `qualified_import_statement` | `imports.txt` |
+| `if_statement`, `while_statement`, `for_statement` | `control_flow.txt` |
+| `case_match_statement`, `case_cond_statement`, `case_arm` (or-pattern / guard / tuple / binding-only) | `case_match.txt` |
+| `using_statement` | `statements.txt` |
+| `typed_binding_statement` (top-level + in-function) | `statements.txt` |
+| `compound_assignment` (`+=`, `-=`, `*=`) | `statements.txt` |
+| `expect_statement` | `statements.txt` |
+| `assignment_statement`, `return_statement`, `break_statement`, `continue_statement`, `expression_statement` | `control_flow.txt`, `literals.txt`, `expressions.txt` |
+| `f_string` | `f_strings.txt` |
+| `regex_literal` | `regex.txt` |
+| `_indent` / `_dedent` / `_newline` edge cases | `indent.txt` |
+| `lambda_expression` | `lambdas.txt` |
+| literals (`integer_literal`, `float_literal`, `string_literal`, `block_string_literal`, `boolean_literal`, `none_literal`, `list_literal`, `map_literal`, `set_literal`, `tuple_literal`) | `literals.txt` |
+| `binary_expression`, `unary_expression`, `call_expression`, `index_expression`, `field_access` | `expressions.txt` |
+| **smoke-only** (corpus 化不能 / 既知 grammar gap) | `directive_def_declaration` (※1), `tuple_destructure_statement`, top-level `@<decorator> NAME: T = ...` (`expected-fail.txt` 該当) |
+
+Scope of the matrix is the rules that can appear as a direct child of
+`source_file` (declarations, top-level statements, imports). The
+following rules surface only inside another corpus entry's expression
+or type and are validated indirectly when that parent entry is parsed:
+
+- `cast_expression`, `unwrap_expression`, `update_expression`,
+  `if_expression` — expression-interior; appear inside `_expression`
+  but never at top level.
+- `weak_type` — type-interior; only meaningful inside `_primary_type`.
+- `contract_clause` — appears only inside `function_body` after the
+  introducing `:`. Indirectly exercised via `functions.txt` if a
+  contract is ever added there.
+- `operator_name` — surfaces only inside `function_declaration` to
+  declare an operator overload; the existing `expected-fail.txt`
+  "operator-overload" bucket covers this in the smoke layer.
+
+Adding dedicated corpus entries for the interior rules above is a
+worthwhile follow-up, but they are not within the Acceptance #2 scope
+("each *top-level* rule").
+
+※1 `directive_def_declaration` は grammar.js 側で body 必須に書かれているのに対し、`share/std/core/directive.ry` の実例は body-less で内部 `(ERROR ...)` を残すため AST shape が安定せず corpus ロック不可。grammar 側 rule 整合は別 issue 候補。
+
 ## Smoke-check (corpus regression test)
 
 ```bash
-./check.sh                # auto-builds ry.so if missing, then checks 176 spec files
+./check.sh                # auto-builds ry.so if missing, then checks spec files
 ./check.sh --no-build     # use the existing ry.so as-is
+./check.sh --no-corpus    # skip the `tree-sitter test` phase (smoke only)
 ./check.sh --verbose      # also list expected-fail entries that still fail (SKIP)
 ```
 
-`check.sh` runs `tree-sitter parse` against every `tests/spec/**/*.test.ry`
-and reports any file that surfaces an `ERROR` or `MISSING` node. Files
-listed in `expected-fail.txt` are tolerated — they document grammar gaps
-that have not yet been closed and are organised into named buckets
-(tuple member access, generic bounds, lambda-block bodies, numeric
-literal forms, …). Anything outside that list is treated as a grammar
-regression: the script prints `FAIL: <path>` and exits non-zero.
+`check.sh` is a two-phase pipeline: it first runs `tree-sitter parse`
+against every `tests/spec/**/*.test.ry` (the smoke phase) and, if that
+passes, runs `tree-sitter test` against `test/corpus/*.txt` (the corpus
+phase). The smoke phase reports any file that surfaces an `ERROR` or
+`MISSING` node. Files listed in `expected-fail.txt` are tolerated —
+they document grammar gaps that have not yet been closed and are
+organised into named buckets (tuple member access, generic bounds,
+lambda-block bodies, numeric literal forms, …). Anything outside that
+list is treated as a grammar regression: the script prints `FAIL:
+<path>` and exits non-zero, short-circuiting the corpus phase.
 
 If a previously failing file now parses cleanly (e.g. after a grammar
 improvement), `check.sh` prints `WARN: <path> now passes; remove from
@@ -248,10 +300,13 @@ eyeball the syntax highlighting and confirm no regressions.
 > Running `tree-sitter parse <file>.ry` against existing
 > `tests/spec/*.test.ry` will surface ERROR nodes today: the in-tree
 > grammar does not yet cover the full Ry surface. The known-gap files
-> are listed in `expected-fail.txt` and the Phase 1 corpus smoke-check
+> are listed in `expected-fail.txt` and the Phase 1 smoke-check
 > (`./check.sh`, see above) treats them as silent SKIPs. The Phase 2
 > hand-curated `tree-sitter test` corpus with S-expression assertions
-> lives at `test/corpus/*.txt` (see [Corpus tests](#corpus-tests-tree-sitter-test) above; #1633).
+> lives at `test/corpus/*.txt` (see
+> [Corpus tests](#corpus-tests-tree-sitter-test) above; seeded by
+> #1633 and completed in #1618 with the coverage matrix and
+> `./check.sh` integration).
 
 The pre-commit version of this loop lives in
 [`/pre-commit-checklist`](../../.claude/skills/pre-commit-checklist/SKILL.md).

--- a/editor/tree-sitter/check.sh
+++ b/editor/tree-sitter/check.sh
@@ -6,10 +6,14 @@
 #   - 非 expected-fail で ERROR/MISSING ノードが出る → FAIL: <path> 表示 + exit 1
 #   - expected-fail なのに parse 通る → WARN: <path> 表示 (exit は 0、エントリ削除を促す)
 #
+# smoke check が成功した後、`tree-sitter test` を実行して
+# test/corpus/*.txt 配下のハンドキュレート corpus の AST 形状一致を検証する。
+#
 # Usage:
-#   ./check.sh             # ry.so が無ければ自動で build.sh を呼ぶ
-#   ./check.sh --no-build  # ビルドをスキップして既存の ry.so で実行
-#   ./check.sh --verbose   # 期待通り fail している (SKIP) ファイルも表示する
+#   ./check.sh              # ry.so が無ければ自動で build.sh を呼ぶ
+#   ./check.sh --no-build   # ビルドをスキップして既存の ry.so で実行
+#   ./check.sh --no-corpus  # corpus テストフェーズをスキップ (smoke のみ)
+#   ./check.sh --verbose    # 期待通り fail している (SKIP) ファイルも表示する
 
 set -euo pipefail
 
@@ -21,13 +25,15 @@ SPEC_DIR="$REPO_ROOT/tests/spec"
 EXPECTED_FAIL="$SCRIPT_DIR/expected-fail.txt"
 
 DO_BUILD=1
+DO_CORPUS=1
 VERBOSE=0
 for arg in "$@"; do
   case "$arg" in
     --no-build)   DO_BUILD=0 ;;
+    --no-corpus)  DO_CORPUS=0 ;;
     -v|--verbose) VERBOSE=1 ;;
     -h|--help)
-      sed -n '3,12p' "$0"
+      awk '/^[^#]/{exit} NR>2' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)
@@ -144,6 +150,15 @@ if (( ${#fail_paths[@]} > 0 )); then
   echo "  $EXPECTED_FAIL" >&2
   echo "Otherwise fix grammar.js / src/scanner.c and rebuild via ./build.sh." >&2
   exit 1
+fi
+
+if (( DO_CORPUS )); then
+  echo "==> running corpus tests (test/corpus/*.txt)"
+  if ! tree-sitter test; then
+    echo "FAIL: tree-sitter corpus test detected an AST shape regression." >&2
+    echo "Inspect the diff above; fix grammar.js or update the corpus entry." >&2
+    exit 1
+  fi
 fi
 
 echo "==> done"

--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -3,8 +3,7 @@
 # ERROR/MISSING ノードを許容し、リスト外は regression として失敗させる。
 #
 # Phase 1 (#1617) は既存 corpus を smoke fixture として使う最小実装。
-# Phase 2 — `tree-sitter test` の hand-curated corpus + S-expression assertion ベースは
-# editor/tree-sitter/test/corpus/ で管理 (#1633)。
+# Phase 2 corpus は editor/tree-sitter/test/corpus/ で管理 (#1633 seed / #1618 補完)。
 #
 # === Format ===
 #   - 1 行 1 path (repo root 相対)。空行および `#` 始まりの行は無視される。
@@ -16,6 +15,7 @@
 #     存在しないため file path 登録は無し。spec が追加されたら追記する。
 
 # === Tuple member access (`.0`, `.1`, ..., `.N`) ===
+tests/spec/arc_set_map_tuple_2226.test.ry  # pre-existing, registered in #1618
 tests/spec/collections.test.ry
 tests/spec/combinatorial/collection_element_tuple_access.test.ry
 tests/spec/combinatorial/collection_element_tuple_iterate.test.ry
@@ -26,6 +26,7 @@ tests/spec/combinatorial/nested_types.test.ry
 tests/spec/combinatorial/syntax_combinations.test.ry
 tests/spec/generic_infer_container.test.ry
 tests/spec/tuple_destructure_assign_parens.test.ry
+tests/spec/tuple_nested_generic_2264.test.ry  # pre-existing, registered in #1618
 tests/spec/tuple_single_element.test.ry
 tests/spec/types.test.ry
 
@@ -53,6 +54,7 @@ tests/spec/functions.test.ry
 tests/spec/http.test.ry
 tests/spec/implicit_widening.test.ry
 tests/spec/list_destructure_assign.test.ry
+tests/spec/nested_fn_loop_capture.test.ry  # pre-existing (@const top-level), registered in #1618
 tests/spec/net.test.ry
 tests/spec/top_level_bindings.test.ry
 

--- a/editor/tree-sitter/test/corpus/case_match.txt
+++ b/editor/tree-sitter/test/corpus/case_match.txt
@@ -272,3 +272,134 @@ fn handle(r: Result<int, str>) -> int:
             (return_statement
               value: (unary_expression
                 operand: (integer_literal)))))))))
+
+==================
+case arm with or-pattern over integer literals
+==================
+
+res = case x:
+  1 | 2 | 3 : "small"
+  _ : "other"
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (case_expression
+      (case_match_expression
+        scrutinee: (qualified_identifier
+          (identifier))
+        (case_arm
+          pattern: (or_pattern
+            (literal_pattern
+              (integer_literal))
+            (literal_pattern
+              (integer_literal))
+            (literal_pattern
+              (integer_literal)))
+          body: (expression_statement
+            (string_literal)))
+        (case_arm
+          pattern: (wildcard_pattern)
+          body: (expression_statement
+            (string_literal)))))))
+
+==================
+case arm with binding pattern and guard clause
+==================
+
+res = case x:
+  n if n > 0 : "pos"
+  _ : "zp"
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (case_expression
+      (case_match_expression
+        scrutinee: (qualified_identifier
+          (identifier))
+        (case_arm
+          pattern: (binding_pattern
+            (identifier))
+          guard: (binary_expression
+            left: (qualified_identifier
+              (identifier))
+            right: (integer_literal))
+          body: (expression_statement
+            (string_literal)))
+        (case_arm
+          pattern: (wildcard_pattern)
+          body: (expression_statement
+            (string_literal)))))))
+
+==================
+case match with tuple destructuring pattern
+==================
+
+case t:
+  (a, b):
+    sum = a + b
+  _:
+    sum = 0
+
+---
+
+(source_file
+  (case_statement
+    (case_match_statement
+      scrutinee: (qualified_identifier
+        (identifier))
+      (case_arm
+        pattern: (tuple_pattern
+          (binding_pattern
+            (identifier))
+          (binding_pattern
+            (identifier)))
+        (assignment_statement
+          left: (identifier)
+          right: (binary_expression
+            left: (qualified_identifier
+              (identifier))
+            right: (qualified_identifier
+              (identifier)))))
+      (case_arm
+        pattern: (wildcard_pattern)
+        (assignment_statement
+          left: (identifier)
+          right: (integer_literal))))))
+
+==================
+case match on Option with binding-only None arm
+==================
+
+case x:
+  Some(v):
+    return v
+  None:
+    return 0
+
+---
+
+(source_file
+  (case_statement
+    (case_match_statement
+      scrutinee: (qualified_identifier
+        (identifier))
+      (case_arm
+        pattern: (constructor_pattern
+          (qualified_identifier
+            (identifier))
+          (binding_pattern
+            (identifier)))
+        (return_statement
+          value: (qualified_identifier
+            (identifier))))
+      (case_arm
+        pattern: (binding_pattern
+          (identifier))
+        (return_statement
+          value: (integer_literal))))))

--- a/editor/tree-sitter/test/corpus/decorators.txt
+++ b/editor/tree-sitter/test/corpus/decorators.txt
@@ -151,3 +151,69 @@ fn outer():
           (identifier))
         body: (function_body
           (return_statement))))))
+
+==================
+three-stack decorator on @native fn declaration
+==================
+
+@public
+@native
+@inline
+fn helper(x: int) -> int
+
+---
+
+(source_file
+  (decorator
+    name: (identifier))
+  (decorator
+    name: (identifier))
+  (decorator
+    name: (identifier))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))))
+
+==================
+multi-arg decorator combined with plain decorator on fn
+==================
+
+@todo
+@each([(1, 2)])
+fn cs(a: int, b: int):
+  return
+
+---
+
+(source_file
+  (decorator
+    name: (identifier))
+  (decorator
+    name: (identifier)
+    (decorator_arguments
+      (decorator_argument
+        value: (list_literal
+          (tuple_literal
+            (integer_literal)
+            (integer_literal))))))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type)))
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    body: (function_body
+      (return_statement))))

--- a/editor/tree-sitter/test/corpus/enums.txt
+++ b/editor/tree-sitter/test/corpus/enums.txt
@@ -1,0 +1,111 @@
+==================
+simple enum with no payload variants
+==================
+
+enum Color:
+  Red
+  Green
+  Blue
+
+---
+
+(source_file
+  (enum_declaration
+    name: (identifier)
+    (enum_variant
+      name: (identifier))
+    (enum_variant
+      name: (identifier))
+    (enum_variant
+      name: (identifier))))
+
+==================
+enum with unnamed payload variants
+==================
+
+enum Shape:
+  Circle(int)
+  Rect(int, int)
+
+---
+
+(source_file
+  (enum_declaration
+    name: (identifier)
+    (enum_variant
+      name: (identifier)
+      (variant_payload
+        (variant_field
+          type: (union_type
+            (primitive_type)))))
+    (enum_variant
+      name: (identifier)
+      (variant_payload
+        (variant_field
+          type: (union_type
+            (primitive_type)))
+        (variant_field
+          type: (union_type
+            (primitive_type)))))))
+
+==================
+enum with named payload variants
+==================
+
+enum Sh:
+  Circle(r: int)
+  Sq(side: int)
+
+---
+
+(source_file
+  (enum_declaration
+    name: (identifier)
+    (enum_variant
+      name: (identifier)
+      (variant_payload
+        (variant_field
+          name: (identifier)
+          type: (union_type
+            (primitive_type)))))
+    (enum_variant
+      name: (identifier)
+      (variant_payload
+        (variant_field
+          name: (identifier)
+          type: (union_type
+            (primitive_type)))))))
+
+==================
+enum with mixed payload and payload-less variants
+==================
+
+enum Msg:
+  Ping
+  Echo(str)
+  Move(x: int, y: int)
+
+---
+
+(source_file
+  (enum_declaration
+    name: (identifier)
+    (enum_variant
+      name: (identifier))
+    (enum_variant
+      name: (identifier)
+      (variant_payload
+        (variant_field
+          type: (union_type
+            (primitive_type)))))
+    (enum_variant
+      name: (identifier)
+      (variant_payload
+        (variant_field
+          name: (identifier)
+          type: (union_type
+            (primitive_type)))
+        (variant_field
+          name: (identifier)
+          type: (union_type
+            (primitive_type)))))))

--- a/editor/tree-sitter/test/corpus/f_strings.txt
+++ b/editor/tree-sitter/test/corpus/f_strings.txt
@@ -1,0 +1,81 @@
+==================
+empty f-string literal
+==================
+
+x = f""
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (f_string)))
+
+==================
+f-string with single interpolation
+==================
+
+x = f"{a}"
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (f_string
+      (qualified_identifier
+        (identifier)))))
+
+==================
+f-string with multiple interpolations and inline text
+==================
+
+x = f"a={a} b={b}"
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (f_string
+      (qualified_identifier
+        (identifier))
+      (qualified_identifier
+        (identifier)))))
+
+==================
+f-string interpolating a binary expression
+==================
+
+x = f"sum={a + b}"
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (f_string
+      (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (qualified_identifier
+          (identifier))))))
+
+==================
+f-string passed as call argument
+==================
+
+print(f"v={x}")
+
+---
+
+(source_file
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      arguments: (argument_list
+        (argument
+          value: (f_string
+            (qualified_identifier
+              (identifier))))))))

--- a/editor/tree-sitter/test/corpus/indent.txt
+++ b/editor/tree-sitter/test/corpus/indent.txt
@@ -1,0 +1,111 @@
+==================
+three-level nested indentation (fn / for / if)
+==================
+
+fn outer():
+  for i in range(3):
+    if i > 1:
+      print(i)
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (for_statement
+        target: (identifier)
+        iter: (call_expression
+          function: (qualified_identifier
+            (identifier))
+          arguments: (argument_list
+            (argument
+              value: (integer_literal))))
+        body: (block
+          (if_statement
+            condition: (binary_expression
+              left: (qualified_identifier
+                (identifier))
+              right: (integer_literal))
+            consequence: (block
+              (expression_statement
+                (call_expression
+                  function: (qualified_identifier
+                    (identifier))
+                  arguments: (argument_list
+                    (argument
+                      value: (qualified_identifier
+                        (identifier)))))))))))))
+
+==================
+comment-only line preserved inside indented block
+==================
+
+fn outer():
+  # a comment-only line
+  x = 1
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (assignment_statement
+        left: (identifier)
+        right: (integer_literal)))))
+
+==================
+blank line preserved between statements in indented block
+==================
+
+fn outer():
+  x = 1
+
+  y = 2
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (assignment_statement
+        left: (identifier)
+        right: (integer_literal))
+      (assignment_statement
+        left: (identifier)
+        right: (integer_literal)))))
+
+==================
+nested blocks closed by EOF (two-level dedent)
+==================
+
+fn outer():
+  if x > 0:
+    print(x)
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (if_statement
+        condition: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (integer_literal))
+        consequence: (block
+          (expression_statement
+            (call_expression
+              function: (qualified_identifier
+                (identifier))
+              arguments: (argument_list
+                (argument
+                  value: (qualified_identifier
+                    (identifier)))))))))))

--- a/editor/tree-sitter/test/corpus/records.txt
+++ b/editor/tree-sitter/test/corpus/records.txt
@@ -1,0 +1,107 @@
+==================
+basic record with two integer fields
+==================
+
+record Point:
+  x: int
+  y: int
+
+---
+
+(source_file
+  (record_declaration
+    name: (identifier)
+    (record_field
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))
+    (record_field
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))))
+
+==================
+record with multiple typed fields
+==================
+
+record User:
+  name: str
+  age: int
+  active: bool
+
+---
+
+(source_file
+  (record_declaration
+    name: (identifier)
+    (record_field
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))
+    (record_field
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))
+    (record_field
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))))
+
+==================
+record with @public field decorator
+==================
+
+record Account:
+  @public
+  balance: int
+  owner: str
+
+---
+
+(source_file
+  (record_declaration
+    name: (identifier)
+    (record_field
+      (decorator
+        name: (identifier))
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))
+    (record_field
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))))
+
+==================
+record with invariant clause
+==================
+
+record Pos:
+  x: int
+  y: int
+  invariant:
+    x > 0
+    y > 0
+
+---
+
+(source_file
+  (record_declaration
+    name: (identifier)
+    (record_field
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))
+    (record_field
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))
+    (record_invariant
+      (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (integer_literal))
+      (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (integer_literal)))))

--- a/editor/tree-sitter/test/corpus/regex.txt
+++ b/editor/tree-sitter/test/corpus/regex.txt
@@ -1,0 +1,64 @@
+==================
+regex literal in assignment
+==================
+
+x = /[a-z]+/
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (regex_literal)))
+
+==================
+regex literal containing escaped slash
+==================
+
+pat = /a\/b/
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (regex_literal)))
+
+==================
+regex literal coexisting with integer division on the previous line
+==================
+
+a = 10 / 2
+b = /x+/
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (binary_expression
+      left: (integer_literal)
+      right: (integer_literal)))
+  (assignment_statement
+    left: (identifier)
+    right: (regex_literal)))
+
+==================
+regex literal passed as call argument
+==================
+
+q = isMatch("x", /[a-z]+/)
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (qualified_identifier
+        (identifier))
+      arguments: (argument_list
+        (argument
+          value: (string_literal))
+        (argument
+          value: (regex_literal))))))

--- a/editor/tree-sitter/test/corpus/statements.txt
+++ b/editor/tree-sitter/test/corpus/statements.txt
@@ -1,0 +1,105 @@
+==================
+top-level typed binding declaration
+==================
+
+PI: float = 3.14
+
+---
+
+(source_file
+  (typed_binding_statement
+    name: (identifier)
+    type: (union_type
+      (primitive_type))
+    value: (float_literal)))
+
+==================
+typed binding inside function body
+==================
+
+fn f():
+  pi: float = 3.14
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (typed_binding_statement
+        name: (identifier)
+        type: (union_type
+          (primitive_type))
+        value: (float_literal)))))
+
+==================
+using statement with scoped resource binding
+==================
+
+using x = open("f.txt"):
+  x.read()
+
+---
+
+(source_file
+  (using_statement
+    name: (identifier)
+    value: (call_expression
+      function: (qualified_identifier
+        (identifier))
+      arguments: (argument_list
+        (argument
+          value: (string_literal))))
+    body: (block
+      (expression_statement
+        (call_expression
+          function: (field_access
+            object: (qualified_identifier
+              (identifier))
+            field: (identifier)))))))
+
+==================
+compound assignment operators (+=, -=, *=)
+==================
+
+x = 1
+x += 2
+x -= 1
+x *= 3
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (integer_literal))
+  (compound_assignment
+    left: (identifier)
+    right: (integer_literal))
+  (compound_assignment
+    left: (identifier)
+    right: (integer_literal))
+  (compound_assignment
+    left: (identifier)
+    right: (integer_literal)))
+
+==================
+expect statement inside function body
+==================
+
+fn t():
+  expect(x).toEq(42)
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (expect_statement
+        actual: (qualified_identifier
+          (identifier))
+        matcher: (identifier)
+        (integer_literal)))))

--- a/editor/tree-sitter/test/corpus/type_aliases.txt
+++ b/editor/tree-sitter/test/corpus/type_aliases.txt
@@ -1,0 +1,113 @@
+==================
+type alias to primitive type
+==================
+
+type Distance = int
+
+---
+
+(source_file
+  (type_alias_declaration
+    name: (identifier)
+    type: (union_type
+      (primitive_type))))
+
+==================
+type alias to union type
+==================
+
+type Val = int | str
+
+---
+
+(source_file
+  (type_alias_declaration
+    name: (identifier)
+    type: (union_type
+      (primitive_type)
+      (primitive_type))))
+
+==================
+type alias to tuple type
+==================
+
+type Pair = (int, str)
+
+---
+
+(source_file
+  (type_alias_declaration
+    name: (identifier)
+    type: (union_type
+      (tuple_type
+        (union_type
+          (primitive_type))
+        (union_type
+          (primitive_type))))))
+
+==================
+type alias to option type
+==================
+
+type Opt = int?
+
+---
+
+(source_file
+  (type_alias_declaration
+    name: (identifier)
+    type: (union_type
+      (option_type
+        (primitive_type)))))
+
+==================
+type alias to array type with fixed size
+==================
+
+type Buf = int[8]
+
+---
+
+(source_file
+  (type_alias_declaration
+    name: (identifier)
+    type: (union_type
+      (array_type
+        (primitive_type)
+        (integer_literal)))))
+
+==================
+type alias to function type
+==================
+
+type Cb = fn(int) -> int
+
+---
+
+(source_file
+  (type_alias_declaration
+    name: (identifier)
+    type: (union_type
+      (function_type
+        (union_type
+          (primitive_type))
+        (union_type
+          (primitive_type))))))
+
+==================
+type alias to generic named type
+==================
+
+type IntList = List<int>
+
+---
+
+(source_file
+  (type_alias_declaration
+    name: (identifier)
+    type: (union_type
+      (named_type
+        (identifier)
+        (type_arguments
+          (union_type
+            (primitive_type)))))))


### PR DESCRIPTION
## Summary

- New 7 corpus files + extensions to `case_match` / `decorators` (75 → 114 cases) covering type_aliases / records / enums / f_strings / regex / indent / statements / or-pattern / guard / decorator-stack.
- `editor/tree-sitter/check.sh` now runs `tree-sitter test` after smoke (with `--no-corpus` opt-out, fail-fast on smoke failure).
- README gains a Coverage matrix mapping every top-level `grammar.js` rule to its corpus file or to smoke-only, with interior rules (cast / unwrap / update / if_expression / weak_type / contract_clause / operator_name) declared as defensible exclusions.

## Notes

- Registered 3 pre-existing smoke failures (`arc_set_map_tuple_2226` / `tuple_nested_generic_2264` / `nested_fn_loop_capture`) in `expected-fail.txt` with `# pre-existing, registered in #1618` markers so the integrated `check.sh` exits 0. These are not introduced by this PR.
- `directive_def_declaration` is smoke-only because `grammar.js` requires a body while `share/std/core/directive.ry` declares body-less directives, producing internal `(ERROR ...)` nodes that can't be locked into a corpus shape. Grammar-side rule alignment is a separate triage candidate.
- `run-tree-sitter.sh`: verified via `CC=cc ./editor/tree-sitter/build.sh` + `CC=cc ./.claude/skills/pre-commit-checklist/run-tree-sitter.sh` (fresh `ry.so`, smoke pass=161 / skip=51 / fail=0 + corpus 114/114 green).
- Changelog skip: editor/dev tooling only — no user-visible runtime or compiler behavior.

## Test plan

- [x] `cd editor/tree-sitter && tree-sitter test` → 114/114 green against freshly built `ry.so`.
- [x] `./check.sh --no-build` → smoke pass=161 / skip=51 / fail=0 + corpus phase green.
- [x] `./check.sh --no-build --no-corpus` → smoke only (skip path).
- [x] `./check.sh --help` → emits header only (no in-function comment leakage; verifies the awk-based extraction replacing the prior magic line range).
- [x] Acceptance #3 (grammar-side regression catch demo): renamed `none_literal` → `none_literal_renamed` in `grammar.js`, rebuilt → `tree-sitter test` reported `✗ none literal`, reverted → 114/114 green.

Closes #1618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test corpus cases covering case matching, decorators, enums, f-strings, indentation, records, regex patterns, statements, and type aliases.
  * Enhanced testing workflow with improved corpus test control and command-line options.

* **Documentation**
  * Updated testing and contributor workflow documentation with expanded coverage guidance and clearer scope boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->