### PR TITLE
feat(lang): introduce `@doc` directive for Markdown documentation metadata

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -378,6 +378,20 @@ The error wording is `"tuple-destructure name '<n>' must be camelCase"`, matchin
 
 **Parser-side asymmetry — resolved by #1427**: Until #1427, `src/parser/parser.cpp:460-462` and `:718-720` rejected every user-defined directive on `for` statements (only `@parallel` allowed) and on function-call statements (only the special `@each` / `@property` on `it(...)` form allowed) at parse time, making the silent-no-op behavior unobservable at those sites. #1427 replaced both gates with a `builtinDirectiveRegistry()` membership check: only registry-tracked directives (today: `@native` only) are rejected, and user-defined directives pass through to codegen `validateDirectives()` where the silent-no-op rule applies. The `ForLoop` and `Statement` codegen wiring added defensively in #1425 is now reachable from user source. Tests `ForLoopAcceptsUserDirectiveAsSilentNoOp` / `CallStmtAcceptsUserDirectiveAsSilentNoOp` (formerly `…RejectsUserDirectiveAtParseTime`, flipped per the "Relaxing a rejection branch …" rule in `.claude/skills/test-checklist/SKILL.md`) lock in the new permissive behavior; `ForLoopRejectsBuiltinNativeDirective` / `CallStmtRejectsBuiltinNativeDirective` / `ForLoopRejectsMultipleParallel` lock in the restrictions that remain.
 
+### Built-in directive `allowed_targets` is informational; target rejection is delivered by other gates
+
+**Source**: #1844 (2026-06-22, implementation — advisor call-out)
+**Tags**: codegen, directive, builtin, allowed_targets, target-rejection, validateDirectives
+
+**Rule**: For a directive registered in `builtinDirectiveRegistry()` (`src/directive_meta.cpp`), the `allowed_targets` field is informational — `validateDirectiveSignature` reads `min_positional` / `max_positional` / `positional_param_names` / `defaulted_params` / `custom_validator`, but **does NOT consult `allowed_targets`** when the directive comes from the builtin path. `validateDirectiveArgs` (the builtin entry) is not even passed the current target. So adding `T::Enum` to a builtin's `allowed_targets` mask does not by itself reject the directive on non-Enum sites. The user-defined `@directive(target=[...])` path is different — that one IS gated by `allowed_targets` inside `validateDirectives()` (see the prior entry).
+
+**How target rejection actually fires for builtin directives**:
+- **`for` loop / call statement** — parser-time gates (`src/parser/parser.cpp` around the `For` and `LParen` dispatches) iterate `builtinDirectiveRegistry()` and reject any registry-member directive at parse time. Adding the directive to the registry auto-enables this rejection on these sites as a side effect.
+- **Enum variant** — no AST attachment point (`EnumVariant` has no `directives` field), so the directive is dropped by the parser before codegen sees it.
+- **Whatever the codegen `validateDirectives()` call sites cover** — Function / Record / Field / Statement / ForLoop / Enum / TypeAlias call sites accept the directive once it is in the registry; sites that don't call `validateDirectives()` at all (most expression positions) never see it.
+
+**How to apply**: When adding a new builtin directive, don't infer target enforcement from `allowed_targets`. Walk the call sites of `validateDirectives()` to see where it's accepted, walk the parser-time builtin-registry gates to see where it's rejected, and rely on AST attachment-point absence (e.g. enum variants) for the remaining holes. Adding new `DirectiveTarget` enum values (e.g. `Enum`, `TypeAlias` in #1844) is cosmetic for the builtin itself — it only matters for `directiveTargetMask()` round-trip and for any future user-defined directive that wants to declare `target=["enum"]` / `target=["typealias"]`. Tests should exercise both the accepted-here and rejected-there sites explicitly rather than trusting the bitmask.
+
 ### Formatter→parser roundtrip: `TupleDestructStmt` must not emit `: ` between pattern and `=`
 
 **Source**: #1189 (2026-04-19, implementation)

--- a/changelog.d/1844-doc-directive.md
+++ b/changelog.d/1844-doc-directive.md
@@ -1,0 +1,11 @@
+### Added
+
+- `@doc("...")` built-in directive for attaching Markdown documentation strings to declarations. Accepts a single string argument — single-line (`"..."`) or triple-quoted block string (`"""..."""`) — and applies to `fn` / `async fn`, `record`, record fields, `enum`, `type` aliases, and `@directive fn` declarations. The compiler does not parse Markdown; `@doc` preserves the body as metadata for future tooling. Empty strings (`@doc("")`) are accepted; `@doc` is rejected on `for` loops, function-call statements, and enum variants. Tree-sitter highlights `@doc` payloads with the `@string.documentation` capture (falling back to `@string` when the editor lacks the predicate). (#1844)
+
+### Changed
+
+- Stacking the same directive twice on one declaration is now rejected — e.g. `@public @public fn ...` or `@deprecated @deprecated fn ...` raise `duplicate directive '@<name>' on the same declaration`. The rule applies uniformly to every builtin and user-defined directive. (#1844)
+
+### Fixed
+
+- `ry fmt` no longer mistakes `#`-prefixed lines inside triple-quoted block strings (e.g. Markdown headings in a `@doc` body) for source comments. The comment extractor now tracks `"""..."""` state across line boundaries so block-string content survives round-trip formatting unchanged. (#1844)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -17,8 +17,8 @@ Directives can be applied to the following declarations:
 
 - `fn` - Function definitions (including named test functions with the `@it` / `@describe` directive)
 - `record` - Record definitions
-- `enum` - Enum definitions (currently `@public` targets enums)
-- `type` - Type alias declarations (currently `@public` targets type aliases)
+- `enum` - Enum definitions (currently `@public` and `@doc` target enums)
+- `type` - Type alias declarations (currently `@public` and `@doc` target type aliases)
 - Variable declarations (with or without `@const`)
 - Fields within a `record` definition
 - `for` - Counted loops; among built-ins, only `@parallel` targets `for`. User-defined directives declaring `target=["for"]` may also be applied to `for` statements; directives with a different target are silently ignored per the target-mismatch rule.
@@ -165,6 +165,51 @@ from mylib                   # wildcard: add is callable; helper is co-located i
 From inside the same package as `mylib/calc.ry`, both `add` and `helper` are importable regardless of `@public`.
 
 The leading `_` underscore on an identifier carries **no** visibility meaning; visibility is controlled exclusively by `@public`. See [Modules — Visibility](modules.md#visibility) for the full rules and [Glossary — Visibility scopes](glossary.md#visibility-scopes) for the underlying scope vocabulary.
+
+### `@doc`
+
+Attaches a Markdown documentation string to a declaration. The argument is preserved as metadata; the compiler does not parse Markdown itself. A documentation generator is out of scope for the current release — `@doc` exists today so the documentation lives next to the declaration and is available to future tooling.
+
+**Defined as:** Compiler built-in. Registered in `src/directive_meta.cpp`'s built-in registry; there is no `.ry` declaration for `@doc`.
+
+**Applicable to:** function (`fn` and `async fn`), record, record fields, enum, `type` alias, and `@directive` declarations. `@doc` cannot be applied to `for` loops, function-call statements, or enum variants.
+
+The directive takes exactly one positional string argument. Empty strings (`@doc("")`) are accepted. The argument may be a single-line string (`"..."`) or a triple-quoted [block string](builtins-string.md#block-string-literal-) (`"""..."""`) — block strings are the canonical form for multi-line Markdown bodies because they read naturally and preserve indentation through `ry fmt`.
+
+```ry
+@doc("Returns the absolute value of x.")
+@public
+fn abs(x: int) -> int:
+  if x < 0:
+    return -x
+  return x
+
+@doc("""
+A point in 2D space.
+
+Components use floating-point coordinates so the same record can be reused
+for both pixel and world-space geometry.
+""")
+record Point:
+  @doc("Horizontal coordinate.")
+  x: float
+  @doc("Vertical coordinate.")
+  y: float
+
+@doc("""
+Returns a stream on success, or `None` on failure.
+
+## Parameters
+
+- `host`: host name or IP address
+- `port`: TCP port
+""")
+fn tcpConnect(host: str, port: int) -> TcpStream?
+```
+
+**Convention:** Prefer Markdown sections (`## Parameters`, `## Returns`, `## Examples`) over Javadoc-style `@param` / `@return` tags. Ry signatures already carry names and types, so a separate parameter syntax would duplicate that information.
+
+**Duplicate rejection:** A declaration may carry at most one `@doc`. Stacking two `@doc` directives on the same declaration is rejected with `duplicate directive '@doc' on the same declaration`. This rule generalises to every directive — `@public @public`, `@deprecated @deprecated`, and any future duplicate is rejected the same way.
 
 ### `@native`
 

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -22,7 +22,7 @@ Directives can be applied to the following declarations:
 - Variable declarations (with or without `@const`)
 - Fields within a `record` definition
 - `for` - Counted loops; among built-ins, only `@parallel` targets `for`. User-defined directives declaring `target=["for"]` may also be applied to `for` statements; directives with a different target are silently ignored per the target-mismatch rule.
-- `@directive` declarations themselves (so a directive declaration can be marked `@public` for cross-package import)
+- `@directive` declarations themselves (so a directive declaration can be marked `@public` for cross-package import or carry a `@doc` documentation string)
 
 ## Built-in Directives
 

--- a/editor/tree-sitter/queries/highlights.scm
+++ b/editor/tree-sitter/queries/highlights.scm
@@ -123,6 +123,18 @@
   (identifier) @attribute
   (#set! "priority" 105))  ; outrank the generic `(identifier) @variable` fallback (default priority 100)
 
+; #1844: highlight the @doc payload as a documentation string so editors can
+; style it distinctly from ordinary string literals. Falls back to the generic
+; (block_string_literal) @string / (string_literal) @string rules above when
+; the directive is not @doc.
+((decorator
+  name: (identifier) @_doc_name
+  (decorator_arguments
+    (decorator_argument
+      value: [(block_string_literal) (string_literal)] @string.documentation)))
+ (#eq? @_doc_name "doc")
+ (#set! "priority" 110))
+
 ; ---------- Records / Enums ----------
 (record_declaration
   name: (identifier) @type)

--- a/editor/tree-sitter/test/corpus/decorators.txt
+++ b/editor/tree-sitter/test/corpus/decorators.txt
@@ -217,3 +217,74 @@ fn cs(a: int, b: int):
           (primitive_type))))
     body: (function_body
       (return_statement))))
+
+==================
+@doc decorator with single-line string argument
+==================
+
+@doc("Returns the square of x.")
+fn square(x: int) -> int:
+    return x * x
+
+---
+
+(source_file
+  (decorator
+    name: (identifier)
+    (decorator_arguments
+      (decorator_argument
+        value: (string_literal))))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (return_statement
+        value: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (qualified_identifier
+            (identifier)))))))
+
+==================
+@doc decorator with triple-quoted block string argument
+==================
+
+@doc("""
+Returns the absolute value of x.
+
+## Examples
+
+    abs(-3)  # 3
+""")
+fn abs(x: int) -> int:
+    return x
+
+---
+
+(source_file
+  (decorator
+    name: (identifier)
+    (decorator_arguments
+      (decorator_argument
+        value: (block_string_literal))))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (return_statement
+        value: (qualified_identifier
+          (identifier))))))

--- a/include/ry/directive_meta.hpp
+++ b/include/ry/directive_meta.hpp
@@ -15,6 +15,8 @@ enum class DirectiveTarget : uint8_t {
     Field     = 1 << 2,
     Statement = 1 << 3,  // AssignStmt, CallStmt
     ForLoop   = 1 << 4,
+    Enum      = 1 << 5,
+    TypeAlias = 1 << 6,
 };
 
 inline uint8_t asTarget(DirectiveTarget t) { return static_cast<uint8_t>(t); }

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -213,6 +213,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<InterpolatedStringEx
 void CodeGen::emitStmt(TypeAliasStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitTraceSymbolDefine("type_alias", s.name, s.loc);
+    validateDirectives(s.directives, DirectiveTarget::TypeAlias);
     if (current_namespace_target_) {
         codegenError("type alias declarations in qualified-imported user-defined modules are not yet supported; use 'from <mod> import <type>' instead");
     }

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -540,8 +540,20 @@ void CodeGen::forwardDeclareNestedFunctions(std::vector<StmtNode> &body) {
 
 void CodeGen::validateDirectives(const std::vector<Directive> &directives, DirectiveTarget current) {
     SourceLocation saved_loc = current_loc_;
-    for (const auto &d : directives) {
+    // #1844: reject duplicate directives on the same declaration. The check
+    // is name-only and applies to every directive (builtin and user-defined)
+    // — none of the directives Ry ships make sense applied twice to the same
+    // target. A linear prefix scan beats a hash set here because declarations
+    // carry 0–3 directives in practice; the set's per-call allocation would
+    // dominate the comparison cost.
+    for (size_t i = 0; i < directives.size(); ++i) {
+        const auto &d = directives[i];
         if (d.loc.isValid()) current_loc_ = d.loc;
+
+        for (size_t j = 0; j < i; ++j) {
+            if (directives[j].name == d.name)
+                codegenError("duplicate directive '@" + d.name + "' on the same declaration");
+        }
 
         try {
             auto userIt = user_directive_registry_.find(d.name);

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -520,6 +520,8 @@ void CodeGen::emitStmt(EnumStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitTraceSymbolDefine("enum", s.name, s.loc);
 
+    validateDirectives(s.directives, DirectiveTarget::Enum);
+
     if (current_namespace_target_) {
         codegenError("enum declarations in qualified-imported user-defined modules are not yet supported; use 'from <mod> import <enum>' instead");
     }
@@ -1485,6 +1487,11 @@ DirectiveSignature fromDirectiveDef(const DirectiveDefStmt &s) {
 
 void CodeGen::emitStmt(DirectiveDefStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
+
+    // Validate auxiliary directives attached to the @directive declaration
+    // itself (e.g. @doc, @public — #1844 / #708). @directive is stripped from
+    // s.directives at parse time so it does not need a registry entry.
+    validateDirectives(s.directives, DirectiveTarget::Function);
 
     const auto &builtin = builtinDirectiveRegistry();
     if (builtin.find(s.name) != builtin.end())

--- a/src/directive_meta.cpp
+++ b/src/directive_meta.cpp
@@ -75,6 +75,24 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
             /*positional_param_names=*/{},
             /*defaulted_params=*/{},
             /*custom_validator=*/nullptr}},
+        // @doc attaches a Markdown documentation string to a declaration
+        // (#1844). The argument is preserved on the AST as metadata; the
+        // compiler does not parse Markdown. allowed_targets is informational
+        // for builtin directives (validateDirectiveSignature ignores it);
+        // out-of-target attachment is gated elsewhere — parser registry
+        // checks reject @doc on for-loops / call statements, and enum
+        // variants have no AST attachment point.
+        {"doc", {"doc",
+            T::Function | T::Record | T::Field | T::Statement | T::Enum | T::TypeAlias,
+            /*min_pos=*/1, /*max_pos=*/1,
+            /*positional_param_names=*/{},
+            /*defaulted_params=*/{},
+            [](const std::string &, const std::vector<DirectiveArg> &args) {
+                if (const ExprNode *p = firstPositionalExpr(args)) {
+                    if (!std::get_if<StringExpr>(&p->data))
+                        throw std::runtime_error("@doc expects a string literal argument");
+                }
+            }}},
     };
     return registry;
 }
@@ -87,6 +105,8 @@ uint8_t directiveTargetMask(std::string_view name) {
     if (name == "field")     return asTarget(DirectiveTarget::Field);
     if (name == "statement") return asTarget(DirectiveTarget::Statement);
     if (name == "for")       return asTarget(DirectiveTarget::ForLoop);
+    if (name == "enum")      return asTarget(DirectiveTarget::Enum);
+    if (name == "typealias") return asTarget(DirectiveTarget::TypeAlias);
     return 0;
 }
 

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -30,6 +30,10 @@ std::vector<Comment> Formatter::extractComments(const std::string &source) {
     std::vector<Comment> result;
     int line = 1;
     size_t i = 0;
+    // Triple-quoted block strings (#1843) can span multiple lines and may
+    // contain '#'. Track block-string state across the outer loop so '#'
+    // inside `"""..."""` is not mistakenly recorded as a comment (#1844).
+    bool in_block_string = false;
     while (i < source.size()) {
         size_t line_start = i;
 
@@ -42,9 +46,19 @@ std::vector<Comment> Formatter::extractComments(const std::string &source) {
         // Scan for '#' outside string literals
         bool in_string = false;
         char quote_char = 0;
-        bool has_code = false;
+        bool has_code = in_block_string;
         for (size_t j = 0; j < line_str.size(); ++j) {
             char c = line_str[j];
+            if (in_block_string) {
+                if (c == '\\' && j + 1 < line_str.size()) {
+                    ++j; // skip escaped char
+                } else if (c == '"' && j + 2 < line_str.size()
+                    && line_str[j + 1] == '"' && line_str[j + 2] == '"') {
+                    in_block_string = false;
+                    j += 2;
+                }
+                continue;
+            }
             if (in_string) {
                 if (c == '\\' && j + 1 < line_str.size()) {
                     ++j; // skip escaped char
@@ -53,9 +67,17 @@ std::vector<Comment> Formatter::extractComments(const std::string &source) {
                 }
             } else {
                 if (c == '"') {
-                    in_string = true;
-                    quote_char = c;
-                    has_code = true;
+                    // Triple-quoted block string opens; same-line close
+                    // re-flips the state within this same character scan.
+                    if (j + 2 < line_str.size() && line_str[j + 1] == '"' && line_str[j + 2] == '"') {
+                        in_block_string = true;
+                        has_code = true;
+                        j += 2;
+                    } else {
+                        in_string = true;
+                        quote_char = c;
+                        has_code = true;
+                    }
                 } else if (c == '#') {
                     int col = static_cast<int>(j) + 1;
                     std::string text(line_str.substr(j));

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -649,15 +649,16 @@ StmtNode Parser::parseStatement() {
         parseError(first.line, "'import' is only allowed at top level");
 
     // @directive(...) declares a new directive (#708). Must be followed by `fn`.
-    // Only @public is permitted alongside @directive so stdlib directive
-    // definitions can be marked public for the v0.0.19 visibility model. Other
-    // directives (e.g. @inline, @deprecated, @native) remain rejected so misuse
-    // surfaces with a clear message.
+    // Only @public and @doc are permitted alongside @directive: @public marks
+    // the directive as exported (v0.0.19 visibility model), @doc attaches
+    // Markdown documentation (#1844). Other directives (e.g. @inline,
+    // @deprecated, @native) remain rejected so misuse surfaces with a clear
+    // message.
     if (const Directive *dirAnnot = findDirective(directives, "directive")) {
         for (const auto &d : directives) {
-            if (d.name != "directive" && d.name != "public")
+            if (d.name != "directive" && d.name != "public" && d.name != "doc")
                 parseError(d.loc.line,
-                    "@directive can only be combined with @public");
+                    "@directive can only be combined with @public or @doc");
         }
         if (first.kind != TokenKind::Fn)
             parseError(first.line, "@directive must be followed by 'fn'");

--- a/tests/spec/doc_directive.test.ry
+++ b/tests/spec/doc_directive.test.ry
@@ -1,0 +1,64 @@
+from testing import it, describe, expect, fail
+
+# #1844: @doc directive — Markdown documentation metadata.
+# Verifies that @doc parses and compiles on every declaration kind in scope,
+# accepts both single-line and triple-quoted block string arguments, and is
+# inert at runtime (the documented declarations behave normally).
+
+@doc("A 2D point in space.")
+record Point:
+  @doc("Horizontal coordinate.")
+  x: int
+  @doc("Vertical coordinate.")
+  y: int
+
+@doc("""
+A traffic light state.
+
+Used to express the three legal phases of a road signal.
+""")
+enum Light:
+  Red
+  Yellow
+  Green
+
+@doc("An opaque user identifier.")
+type UserId = int
+
+@doc("""
+Returns the absolute value of `x`.
+
+## Examples
+
+    abs(-3)  # 3
+""")
+fn abs(x: int) -> int:
+  if x < 0:
+    return -x
+  return x
+
+@describe("@doc directive metadata")
+fn docDirectiveTests():
+  @it("compiles and runs documented functions normally")
+  fn shouldExecuteDocumentedFn():
+    expect(abs(-7)).toEq(7)
+    expect(abs(5)).toEq(5)
+    expect(abs(0)).toEq(0)
+  @it("compiles and constructs documented records normally")
+  fn shouldConstructDocumentedRecord():
+    p = Point(3, 4)
+    expect(p.x).toEq(3)
+    expect(p.y).toEq(4)
+  @it("compiles documented enums and lets variants be referenced")
+  fn shouldReferenceDocumentedEnumVariant():
+    l = Light::Green
+    matched = false
+    case l:
+      Light::Red: fail("unexpected Red")
+      Light::Yellow: fail("unexpected Yellow")
+      Light::Green: matched = true
+    expect(matched).toEq(true)
+  @it("compiles documented type aliases as transparent integer types")
+  fn shouldUseDocumentedTypeAlias():
+    uid: UserId = 42
+    expect(uid).toEq(42)

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -394,11 +394,12 @@ TEST_F(DirectiveTest, DeprecatedFunctionStillWorks) {
     ASSERT_EQ(warnings.size(), 1);
 }
 
-// 8. Multiple directives stacked (parse check)
+// 8. Multiple directives stacked (parse check). Uses two distinct
+// directives — same-directive stacking is rejected as duplicate (#1844).
 TEST_F(DirectiveTest, MultipleDirectives) {
     auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "@deprecated\n"
-        "@deprecated\n"
+        "@public\n"
         "fn multi() -> int:\n"
         "    return 1\n"
         "print(multi())\n"
@@ -2993,5 +2994,207 @@ TEST_F(DirectiveTest, DescribeBeforeEachRunsBeforeItBody) {
     EXPECT_NE(output.find("1 passed, 0 failed"), std::string::npos)
         << "describe-level @beforeEach must observably run before the @it body: "
         << output;
+}
+
+// ===== @doc directive tests (#1844) =====
+
+// @doc on a function — accepts a single string positional argument and the
+// declaration compiles without effect on emitted IR (metadata-only).
+TEST_F(DirectiveTest, DocDirectiveOnFn) {
+    EXPECT_NO_THROW({
+        runSource(
+            "@doc(\"Returns the absolute value of x.\")\n"
+            "fn abs(x: int) -> int:\n"
+            "    if x < 0:\n"
+            "        return -x\n"
+            "    return x\n"
+            "print(abs(-3))\n"
+        );
+    });
+}
+
+// @doc on a record declaration and on individual record fields.
+TEST_F(DirectiveTest, DocDirectiveOnRecord) {
+    EXPECT_NO_THROW({
+        runSource(
+            "@doc(\"A 2D point.\")\n"
+            "record Point:\n"
+            "    @doc(\"X coordinate.\")\n"
+            "    x: int\n"
+            "    @doc(\"Y coordinate.\")\n"
+            "    y: int\n"
+            "p = Point(1, 2)\n"
+            "print(p.x)\n"
+        );
+    });
+}
+
+// @doc on an enum declaration.
+TEST_F(DirectiveTest, DocDirectiveOnEnum) {
+    EXPECT_NO_THROW({
+        runSource(
+            "@doc(\"A traffic light state.\")\n"
+            "enum Light:\n"
+            "    Red\n"
+            "    Yellow\n"
+            "    Green\n"
+            "l = Light::Red\n"
+        );
+    });
+}
+
+// Wrong-target builtin directive on enum — validateDirectives is wired and
+// the @native registry signature must produce a known-directive error path,
+// not the silent "validateDirectives never ran" miss.
+TEST_F(DirectiveTest, UnknownDirectiveOnEnumRejected) {
+    EXPECT_THROW({
+        runSource("@unknown\nenum E:\n    A\n");
+    }, std::runtime_error);
+}
+
+// @doc on a type alias declaration.
+TEST_F(DirectiveTest, DocDirectiveOnTypeAlias) {
+    EXPECT_NO_THROW({
+        runSource(
+            "@doc(\"A user identifier.\")\n"
+            "type UserId = int\n"
+            "uid: UserId = 42\n"
+            "print(uid)\n"
+        );
+    });
+}
+
+// Unknown directive on a type alias is rejected (sanity check that the
+// validateDirectives wiring fires on the TypeAlias path).
+TEST_F(DirectiveTest, UnknownDirectiveOnTypeAliasRejected) {
+    EXPECT_THROW({
+        runSource("@unknown\ntype T = int\n");
+    }, std::runtime_error);
+}
+
+// @doc combined with @directive fn declaration (#1844 initial scope: docs on
+// user-defined directive declarations). Currently rejected with
+// "@directive can only be combined with @public" before this cycle's fix.
+TEST_F(DirectiveTest, DocDirectiveOnDirectiveDef) {
+    EXPECT_NO_THROW({
+        runSource(
+            "@doc(\"Marks a function as parallelizable.\")\n"
+            "@directive(target=[\"function\"])\n"
+            "fn myAnnotation(name: str)\n"
+        );
+    });
+}
+
+// Argument validation on @doc fires through emitStmt(DirectiveDefStmt) too:
+// passing an integer where a string is required must error.
+TEST_F(DirectiveTest, DocDirectiveOnDirectiveDefRejectsNonStringArg) {
+    EXPECT_THROW({
+        runSource(
+            "@doc(42)\n"
+            "@directive(target=[\"function\"])\n"
+            "fn myAnnotation(name: str)\n"
+        );
+    }, std::runtime_error);
+}
+
+// @doc without an argument is rejected (1 string required).
+TEST_F(DirectiveTest, DocDirectiveMissingArgRejected) {
+    EXPECT_THROW({
+        runSource("@doc()\nfn foo() -> int:\n    return 1\n");
+    }, std::runtime_error);
+}
+
+// @doc with two string arguments is rejected (max 1 positional).
+TEST_F(DirectiveTest, DocDirectiveTooManyArgsRejected) {
+    EXPECT_THROW({
+        runSource("@doc(\"a\", \"b\")\nfn foo() -> int:\n    return 1\n");
+    }, std::runtime_error);
+}
+
+// @doc with a non-string positional arg (integer) is rejected.
+TEST_F(DirectiveTest, DocDirectiveNonStringArgRejected) {
+    EXPECT_THROW({
+        runSource("@doc(42)\nfn foo() -> int:\n    return 1\n");
+    }, std::runtime_error);
+}
+
+// Empty string is accepted (Markdown content "" is valid; the rendering
+// layer handles emptiness).
+TEST_F(DirectiveTest, DocDirectiveEmptyStringAccepted) {
+    EXPECT_NO_THROW({
+        runSource("@doc(\"\")\nfn foo() -> int:\n    return 1\n");
+    });
+}
+
+// Duplicate @doc on the same declaration is rejected (#1844 explicit
+// requirement). The rejection is implemented as a general "duplicate
+// directive" check in validateDirectives, so any builtin directive
+// duplicated on a declaration produces the same error.
+TEST_F(DirectiveTest, DuplicateDocDirectiveRejected) {
+    EXPECT_THROW({
+        runSource(
+            "@doc(\"first\")\n"
+            "@doc(\"second\")\n"
+            "fn foo() -> int:\n"
+            "    return 1\n"
+        );
+    }, std::runtime_error);
+}
+
+TEST_F(DirectiveTest, DuplicatePublicDirectiveRejected) {
+    EXPECT_THROW({
+        runSource(
+            "@public\n"
+            "@public\n"
+            "fn foo() -> int:\n"
+            "    return 1\n"
+        );
+    }, std::runtime_error);
+}
+
+// @doc on a for-loop is rejected at parse time by the builtin-registry gate.
+TEST_F(DirectiveTest, DocDirectiveOnForLoopRejected) {
+    EXPECT_THROW({
+        runSource("@doc(\"x\")\nfor i in range(3):\n    print(i)\n");
+    }, std::runtime_error);
+}
+
+// @doc on a call statement is rejected at parse time by the builtin-registry
+// gate (same path as @native on a call).
+TEST_F(DirectiveTest, DocDirectiveOnCallStmtRejected) {
+    EXPECT_THROW({
+        runSource("@doc(\"x\")\nprint(1)\n");
+    }, std::runtime_error);
+}
+
+// @doc on an enum variant is rejected: variants have no AST attachment
+// point for directives.
+TEST_F(DirectiveTest, DocDirectiveOnEnumVariantRejected) {
+    EXPECT_THROW({
+        runSource(
+            "enum E:\n"
+            "    @doc(\"first\")\n"
+            "    A\n"
+            "    B\n"
+        );
+    }, std::runtime_error);
+}
+
+// @doc accepting a triple-quoted block string (the issue's motivating form).
+TEST_F(DirectiveTest, DocDirectiveAcceptsBlockString) {
+    EXPECT_NO_THROW({
+        runSource(
+            "@doc(\"\"\"\n"
+            "Returns the square of x.\n"
+            "\n"
+            "## Examples\n"
+            "\n"
+            "    square(3)  # 9\n"
+            "\"\"\")\n"
+            "fn square(x: int) -> int:\n"
+            "    return x * x\n"
+            "print(square(3))\n"
+        );
+    });
 }
 

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -728,6 +728,50 @@ TEST(FormatterTest, DirectiveDefRoundTripMultipleTargets) {
     EXPECT_EQ(Formatter::formatSource(first), first);
 }
 
+// #1844: @doc("...") with a single-line string round-trips and is idempotent.
+TEST(FormatterTest, DocDirectiveSingleLineRoundTrip) {
+    auto src = "@doc(\"Returns the absolute value of x.\")\n"
+               "fn abs(x: int) -> int:\n"
+               "  return x\n";
+    auto first = Formatter::formatSource(src);
+    EXPECT_EQ(first, src);
+    EXPECT_EQ(Formatter::formatSource(first), first);
+    std::string reason;
+    EXPECT_TRUE(Formatter::verifyFormatting(first, reason)) << reason;
+}
+
+// #1844: @doc("""...""") with a triple-quoted block string round-trips and
+// is idempotent. The formatter routes block strings through formatBlockString
+// so the multi-line form is preserved.
+TEST(FormatterTest, DocDirectiveBlockStringRoundTrip) {
+    auto src = "@doc(\"\"\"\n"
+               "Returns the absolute value of x.\n"
+               "\n"
+               "## Examples\n"
+               "\"\"\")\n"
+               "fn abs(x: int) -> int:\n"
+               "  return x\n";
+    auto first = Formatter::formatSource(src);
+    EXPECT_EQ(Formatter::formatSource(first), first);
+    std::string reason;
+    EXPECT_TRUE(Formatter::verifyFormatting(first, reason)) << reason;
+}
+
+// @doc on a record and on record fields preserves placement through fmt.
+TEST(FormatterTest, DocDirectiveOnRecordRoundTrip) {
+    auto src = "@doc(\"A 2D point.\")\n"
+               "record Point:\n"
+               "  @doc(\"X coordinate.\")\n"
+               "  x: int\n"
+               "  @doc(\"Y coordinate.\")\n"
+               "  y: int\n";
+    auto first = Formatter::formatSource(src);
+    EXPECT_EQ(first, src);
+    EXPECT_EQ(Formatter::formatSource(first), first);
+    std::string reason;
+    EXPECT_TRUE(Formatter::verifyFormatting(first, reason)) << reason;
+}
+
 // Bare-string sugar `target="function"` canonicalises to List form
 // `target=["function"]` after one format pass, then round-trips idempotently.
 TEST(FormatterTest, DirectiveDefBareStringSugarCanonicalises) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -5119,3 +5119,39 @@ TEST(ParserTest, WeakReturnTypeWrappedInListAccepted) {
     Program prog = parseStr("fn make() -> List<weak str>:\n    return []\n");
     ASSERT_EQ(prog.size(), 1u);
 }
+
+// #1844: @doc("""...""") preserves is_block on the StringExpr held in the
+// directive argument so the formatter can later re-emit triple-quoted form.
+TEST(ParserTest, DocDirectiveBlockStringArgPreservesIsBlock) {
+    Program prog = parseStr(
+        "@doc(\"\"\"\n  short description\n  \"\"\")\n"
+        "fn foo() -> int:\n"
+        "    return 1\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &fnPtr = std::get<std::unique_ptr<FnStmt>>(prog[0]);
+    ASSERT_EQ(fnPtr->directives.size(), 1u);
+    const auto &d = fnPtr->directives[0];
+    EXPECT_EQ(d.name, "doc");
+    ASSERT_EQ(d.args.size(), 1u);
+    EXPECT_FALSE(d.args[0].name.has_value());
+    ASSERT_TRUE(std::holds_alternative<StringExpr>(d.args[0].value->data));
+    const auto &se = std::get<StringExpr>(d.args[0].value->data);
+    EXPECT_EQ(se.value, "short description");
+    EXPECT_TRUE(se.is_block);
+}
+
+TEST(ParserTest, DocDirectiveSingleLineStringArg) {
+    Program prog = parseStr(
+        "@doc(\"single line\")\n"
+        "fn foo() -> int:\n"
+        "    return 1\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &fnPtr = std::get<std::unique_ptr<FnStmt>>(prog[0]);
+    ASSERT_EQ(fnPtr->directives.size(), 1u);
+    const auto &d = fnPtr->directives[0];
+    ASSERT_EQ(d.args.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<StringExpr>(d.args[0].value->data));
+    const auto &se = std::get<StringExpr>(d.args[0].value->data);
+    EXPECT_EQ(se.value, "single line");
+    EXPECT_FALSE(se.is_block);
+}


### PR DESCRIPTION
## Summary

- Add a built-in `@doc("...")` directive that attaches a Markdown documentation string to `fn` / `async fn`, `record`, record fields, `enum`, `type` aliases, and `@directive fn` declarations. Argument is preserved as AST metadata; the compiler does not parse Markdown. Single-line and triple-quoted (`"""..."""`) block strings are both accepted; empty strings are allowed.
- Stacking the same directive twice on one declaration is now rejected with `duplicate directive '@<name>' on the same declaration` (a general rule, not limited to `@doc`).
- Fix a latent `ry fmt` bug where `#`-prefixed lines inside triple-quoted block strings (e.g. Markdown headings in a `@doc` body) were mistaken for source comments. `extractComments` now tracks block-string state across line boundaries.

Closes #1844

## Test plan

- [x] `./build-rust/ry_tests` — 2895 PASS
- [x] `./build-rust/ry test -p` — 216 files / 0 failure (includes new `tests/spec/doc_directive.test.ry`)
- [x] tree-sitter `tree-sitter test` + `./check.sh` — 116/116 PASS, decorators corpus updated with `@doc` cases
- [x] ASan + UBSan (Docker) — 0 failure
- [x] TSan (Docker) — 0 failure
- [x] libFuzzer (parser/json/utf8/io_open, 60s each) — 0 crash
- [x] static analysis (clang-tidy / cppcheck / scan-build) — No bugs found
- [x] prompt-refs-lint — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `@doc` directive to attach documentation to functions, records (including fields), enums, and type aliases, with both single-line and triple-quoted block strings.
  * Allowed `@directive` declarations to be annotated with `@doc`.

* **Bug Fixes**
  * Fixed the formatter to preserve multi-line `@doc` block strings and avoid misreading `#`-prefixed text as comments inside them.

* **Improvements**
  * Updated documentation-string syntax highlighting.
  * Documentation tooling now rejects duplicate directives stacked on the same declaration.

* **Documentation / Tests**
  * Expanded the directives reference and added parser/codegen/formatter coverage for `@doc`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->