### PR TITLE
test: apply contract/internal/regression taxonomy to parser tests (#1831)

### DIFF
--- a/.claude/skills/test-checklist/SKILL.md
+++ b/.claude/skills/test-checklist/SKILL.md
@@ -53,3 +53,7 @@ Use before implementation and during test review.
 2. Confirm failures indicate the intended condition.
 3. Remove redundant cases.
 4. Run the narrow test, then the required suite from `/pre-commit-checklist`.
+
+## Related
+
+- `docs/reference/test-taxonomy.md` — contract / internal / regression 分類と section header tag 規約。テスト追加時は適切な tag 配置を確認する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ Issue creation:
 - tree-sitter edits: `editor/tree-sitter/README.md` and `.claude/rules/tree-sitter-grammar-editing.md`; rebuild `ry.so`.
 - CI image changes: `/ci-image-workflow`.
 - Fuzzer harness changes: `/libfuzzer-harness`.
+- Test classification (contract / internal / regression): `docs/reference/test-taxonomy.md`.
 
 ## Completion
 

--- a/docs/reference/test-taxonomy.md
+++ b/docs/reference/test-taxonomy.md
@@ -1,0 +1,91 @@
+# Test Taxonomy
+
+C++ / Ry の test を「何を守っているか」で 3 カテゴリに分類し、可視化する。テストはコスト資産であり、削減ではなく **navigability の向上** が目的。
+
+## カテゴリ
+
+### contract / black-box
+
+公開 API や層間契約に対する観察的検証。実装詳細に依存しない。
+
+- 入力 → 戻り値・AST 形状・例外型・診断メッセージのみを assert する
+- リファクタで内部実装が変わっても、契約が同じなら fail しない
+- 例: `parseStr("x = 1")` を呼び `Program.size() == 1` を assert する parser test、`from math import pow` の振る舞いを assert する spec test、CLI の exit code / stdout を assert する subprocess test
+
+### internal / white-box
+
+内部ヘルパー・不変量・lookahead・ownership・lowering metadata など、実装詳細に踏み込む検証。
+
+- 内部関数を直接呼ぶ、内部状態を覗く、特定の IR 形状を assert する
+- 実装に依存することが前提なので、対象実装の変更で fail することは想定内
+- C++ test として書くときは、何の内部を測っているか header コメントで明記する
+- 例: ARC live-count 計測、IR pattern 検証、`__ry_*` runtime symbol を直接呼ぶ stress test
+
+### regression
+
+特定の過去バグ・review 指摘の再発を防ぐ guard。contract level でも internal level でも成立する。
+
+- 関連 issue / PR 番号を必ず明示する (`#NNNN` を tag またはコメントに残す)
+- 規約上の安定性を「将来 refactor で消されないため」のメタ情報として持つ
+- 例: `tests/test_regression_2246_str_metadata_gate.cpp`、`tests/test_regression_2248_positive_str_predicate.cpp`
+
+## 配置・命名規約
+
+### 1 ファイルにまとめる場合: section header に tag を置く
+
+```cpp
+// ===== [contract] type パーサーテスト =====
+// ===== [contract] using statement (#1817) =====   // feat-add — issue 番号は spec の出典
+// ===== [regression #1748] wildcard import rejection =====
+// ===== [internal] parser lookahead state probe =====
+```
+
+- ファイル冒頭に taxonomy index コメント (本文書への link と、当該ファイルで使うタグの凡例) を置く。
+- 既存 section header の format (`// ===== Title =====` / `// ---- Title ----` / `// ====...====` 等) は **`// ===== [tag] Title =====` に統一**する。
+
+### 単一 issue 専任の regression は独立ファイル
+
+`tests/test_regression_<issue>_<desc>.cpp` を作る既存運用を継続する。
+
+### Section 内で混在するときは inline tag
+
+Section の dominant category を採り、別カテゴリの個別テストの直上にコメントを 1 行追加する:
+
+```cpp
+// [regression: #1450] enforce camelCase on tuple-destructure LHS
+TEST(ParserTest, ParenTupleDestructRejectsSnakeCase) { ... }
+```
+
+### Issue 番号の意味分け
+
+`(#NNNN)` を section title に残すときの意味は以下:
+
+- `[contract] X (#NNNN)` — `#NNNN` は **spec / feature を追加した出典 issue**。テスト群はそのスペックの正常系・異常系を網羅する。
+- `[regression #NNNN] X` — `#NNNN` は **発見されたバグ / review 指摘の発生元**。テスト群は同じ症状の再発を gate する。
+
+「fix:」「bug:」プレフィックスを持つ issue は基本 `[regression]` 候補。「feat:」「chore:」プレフィックスは基本 `[contract]` (新規スペックの本来テスト) と扱う。
+
+## 重複統合の安全ルール
+
+2 つのテストを 1 つに統合してよいのは、以下 4 条件 **すべて** を満たすときのみ:
+
+1. 同じ parser / API entrypoint を呼ぶ
+2. 入力が意味的に等価 (lexical 差はあっても spec 上同じ branch を踏む)
+3. assert する性質と粒度が同じ (例: 一方が AST を見ていて他方が例外を見ているなら統合不可)
+4. 守っている edge case が同じ (lookahead / indentation / precedence 等の interaction を区別している場合は別物とみなす)
+
+判断に迷ったら **残す**。テスト本数の削減自体は目的ではない。
+
+## カテゴリ分布は層によって偏る
+
+3 カテゴリを抽象的に並べているが、テスト対象の層によって分布は自然に偏る。公開境界が単一の層 (例: parser の `parseProgram()`) では `[contract]` が支配的になり `[internal]` はほぼ立たない。ARC / IR / runtime layer のテストでは `[internal]` の比率が上がる。
+
+## "Contract" の語義衝突
+
+本 taxonomy の `[contract]` (= black-box) と、Ry の言語機能 **Design by Contract (`require:` / `ensure:`)** は別物。衝突する section header は両方の context が読める形に書く (例: `// ===== [contract] Design by Contract 言語機能 (require / ensure) =====`)。
+
+## 関連
+
+- `.claude/skills/test-checklist/SKILL.md` — テスト作成時の perspective チェック
+- `.claude/rules/tests-cpp-conventions.md` — C++ テストの実装規約
+- 適用 pilot: `tests/test_parser.cpp` (#1831)

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1,3 +1,7 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include <gtest/gtest.h>
 #include "ry/parser/parser.hpp"
 #include "ry/diagnostic/diagnostic.hpp"
@@ -276,7 +280,7 @@ TEST(ParserTest, TypeAnnotationAcceptsUserDefinedType) {
     EXPECT_EQ(s.type_annotation->toString(),"Point");
 }
 
-// ===== type パーサーテスト =====
+// ===== [contract] type パーサーテスト =====
 
 TEST(ParserTest, TypeDefinition) {
     Program prog = parseStr("record Point:\n    x: int\n    y: int");
@@ -421,7 +425,7 @@ TEST(ParserTest, TypeAnnotationWithoutValue) {
     EXPECT_EQ(s.type_annotation->toString(),"int");
 }
 
-// ===== if / when パーサーテスト =====
+// ===== [contract] if / when パーサーテスト =====
 
 TEST(ParserTest, IfSimple) {
     Program prog = parseStr("if true:\n    print(1)");
@@ -645,7 +649,7 @@ TEST(ParserTest, IfEmptyBlockThrows) {
     EXPECT_THROW(parseStr("if true:\nprint(1)"), std::runtime_error);
 }
 
-// ===== while パーサーテスト =====
+// ===== [contract] while パーサーテスト =====
 
 TEST(ParserTest, WhileSimple) {
     Program prog = parseStr("while true:\n    print(1)");
@@ -669,7 +673,7 @@ TEST(ParserTest, WhileMissingColonThrows) {
     EXPECT_THROW(parseStr("while true\n    print(1)"), std::runtime_error);
 }
 
-// ===== using statement (#1817) =====
+// ===== [contract] using statement (#1817) =====
 
 TEST(ParserTest, UsingSimple) {
     Program prog = parseStr("using f = open(p, \"r\"):\n    readAll(f)");
@@ -698,7 +702,7 @@ TEST(ParserTest, UsingMissingColonThrows) {
                  std::runtime_error);
 }
 
-// ===== function / return / CallExpr パーサーテスト =====
+// ===== [contract] function / return / CallExpr パーサーテスト =====
 
 TEST(ParserTest, FnSimple) {
     Program prog = parseStr("fn add(a: int, b: int) -> int:\n    return a + b");
@@ -827,7 +831,7 @@ TEST(ParserTest, FnReturnOptionType) {
     EXPECT_EQ(function.return_type->toString(), "Option<int>");
 }
 
-// ===== import パーサーテスト =====
+// ===== [contract] import パーサーテスト =====
 
 TEST(ParserTest, ImportAll) {
     Program prog = parseStr("from math");
@@ -875,7 +879,7 @@ TEST(ParserTest, ImportInBlockThrows) {
     EXPECT_THROW(parseStr("if true:\n    from math import add"), std::runtime_error);
 }
 
-// ===== relative import tests =====
+// ===== [contract] relative import tests =====
 
 TEST(ParserTest, RelativeImportDot) {
     Program prog = parseStr("from . import add");
@@ -1000,7 +1004,7 @@ TEST(ParserTest, ImportFnKeywordRejectedAfterComma) {
     }
 }
 
-// ===== wildcard import rejection (#1748) =====
+// ===== [regression #1748] wildcard import rejection =====
 //
 // `*` is not accepted at any import-name position. All four sites
 // (non-braced head, braced head, non-braced post-comma, braced post-comma)
@@ -1051,7 +1055,7 @@ TEST(ParserTest, ImportWildcardBracedAfterCommaRejected) {
     }
 }
 
-// ===== alias tests (#1721) =====
+// ===== [contract] alias tests (#1721) =====
 
 TEST(ParserTest, ImportSingleAlias) {
     Program prog = parseStr("from math import add as plus");
@@ -1115,7 +1119,7 @@ TEST(ParserTest, ImportAsRequiresAliasNotKeyword) {
     EXPECT_THROW(parseStr("from math import add as fn"), std::runtime_error);
 }
 
-// ===== braced selective import tests (#1722) =====
+// ===== [contract] braced selective import tests (#1722) =====
 
 TEST(ParserTest, ImportBracedSingleItem) {
     Program prog = parseStr("from math import { add }");
@@ -1202,7 +1206,7 @@ TEST(ParserTest, ImportBracedRejectsBadAlias) {
     EXPECT_THROW(parseStr("from math import { add as 123 }"), std::runtime_error);
 }
 
-// ===== qualified import tests (#1723) =====
+// ===== [contract] qualified import tests (#1723) =====
 
 TEST(ParserTest, QualifiedImportSingleModule) {
     Program prog = parseStr("import math");
@@ -1720,7 +1724,7 @@ TEST(ParserTest, DuplicateFieldNameThrows) {
     EXPECT_THROW(parseStr("record Point:\n    x: int\n    x: int"), std::runtime_error);
 }
 
-// ===== タプル パーサーテスト =====
+// ===== [contract] タプル パーサーテスト =====
 
 TEST(ParserTest, TupleLiteral) {
     Program prog = parseStr("t = (1, 2)");
@@ -1816,7 +1820,7 @@ TEST(ParserTest, TupleSingleElementString) {
     ASSERT_TRUE(std::holds_alternative<StringExpr>(tuple.elements[0]->data));
 }
 
-// ===== Parenthesized tuple destructuring assignment (#1189) =====
+// ===== [contract] Parenthesized tuple destructuring assignment (#1189) =====
 
 TEST(ParserTest, ParenTupleDestructBasic) {
     Program prog = parseStr("(a, b) = (10, 20)");
@@ -1953,7 +1957,7 @@ TEST(ParserTest, BareTupleDestructAcceptsUnderscore) {
     EXPECT_EQ(s2.names[1], "_");
 }
 
-// ===== UFCS パーサーテスト =====
+// ===== [contract] UFCS パーサーテスト =====
 
 TEST(ParserTest, UFCSBasic) {
     // a.f(b) → CallExpr{f, [a, b]}
@@ -2535,7 +2539,7 @@ TEST(ParserTest, CallStmtLeaderErrorPropagateNowAccepted) {
     EXPECT_EQ(std::get<std::unique_ptr<CallExpr>>(ep.operand->data)->callee, "foo");
 }
 
-// ===== Map パーステスト =====
+// ===== [contract] Map パーステスト =====
 
 TEST(ParserTest, MapLiteral) {
     Program prog = parseStr("m = {\"a\": 1, \"b\": 2}");
@@ -2573,7 +2577,7 @@ TEST(ParserTest, MapTypeAnnotation) {
     EXPECT_EQ(s.type_annotation->toString(),"Map<str, int>");
 }
 
-// ===== Operator overloading =====
+// ===== [contract] Operator overloading =====
 
 TEST(ParserTest, OperatorFnBinaryPlus) {
     std::string src =
@@ -2631,7 +2635,7 @@ TEST(ParserTest, OperatorFnInvalidParamCount) {
     EXPECT_THROW(parseStr(src), std::runtime_error);
 }
 
-// ===== Operator return type constraint =====
+// ===== [contract] Operator return type constraint =====
 
 TEST(ParserTest, OperatorEqMustReturnBool) {
     EXPECT_THROW(parseStr(
@@ -2760,7 +2764,7 @@ TEST(ParserTest, OperatorAsKeywordAcceptsSpaceForm) {
     EXPECT_EQ(prog.size(), 1u);
 }
 
-// ===== Compound assignment operator tests =====
+// ===== [contract] Compound assignment operator tests =====
 
 TEST(ParserTest, CompoundAssignPreservesOp) {
     Program prog = parseStr("x += 1\n");
@@ -2838,7 +2842,7 @@ TEST(ParserTest, PlainAssignHasNoCompoundOp) {
     EXPECT_FALSE(s.compound_op.has_value());
 }
 
-// ===== Set パーサーテスト =====
+// ===== [contract] Set パーサーテスト =====
 
 TEST(ParserTest, SetLiteral) {
     Program prog = parseStr("s = {1, 2, 3}");
@@ -2881,7 +2885,7 @@ TEST(ParserTest, InOperator) {
     EXPECT_EQ(std::get<VariableExpr>(bin.rhs->data).name, "s");
 }
 
-// ===== Enum パーサーテスト =====
+// ===== [contract] Enum パーサーテスト =====
 
 TEST(ParserTest, EnumDefinition) {
     Program prog = parseStr("enum Color:\n    Red\n    Green\n    Blue");
@@ -2919,7 +2923,7 @@ TEST(ParserTest, EnumComparison) {
     EXPECT_EQ(ea.variant_name, "Green");
 }
 
-// ===== Union 型パーサーテスト =====
+// ===== [contract] Union 型パーサーテスト =====
 
 TEST(ParserTest, LetUnionTypeAnnotation) {
     Program prog = parseStr("x: int | str = 42");
@@ -2943,7 +2947,7 @@ TEST(ParserTest, FnUnionReturn) {
     EXPECT_EQ(function.return_type->toString(), "int | str");
 }
 
-// ===== >>> パーサーテスト =====
+// ===== [contract] >>> パーサーテスト =====
 
 TEST(ParserTest, LogicalRightShift) {
     Program prog = parseStr("x = a >>> b");
@@ -2956,7 +2960,7 @@ TEST(ParserTest, LogicalRightShift) {
     EXPECT_EQ(std::get<VariableExpr>(bin.rhs->data).name, "b");
 }
 
-// ===== not in パーサーテスト =====
+// ===== [contract] not in パーサーテスト =====
 
 TEST(ParserTest, NotInOperator) {
     Program prog = parseStr("r = x not in s");
@@ -2986,7 +2990,7 @@ TEST(ParserTest, UnionThreeTypes) {
     EXPECT_EQ(s.type_annotation->toString(),"int | float | str");
 }
 
-// ===== Contract (Design by Contract) tests =====
+// ===== [contract] Design by Contract 言語機能 (require / ensure) =====
 
 TEST(ParserTest, FnWithRequire) {
     std::string src =
@@ -3107,7 +3111,7 @@ TEST(ParserTest, EnsureTupleBinding) {
     EXPECT_EQ(function->ensure_bindings[1], "r");
 }
 
-// ===== record キーワード =====
+// ===== [contract] record キーワード =====
 
 TEST(ParserTest, RecordKeyword) {
     Program prog = parseStr("record Point:\n    x: int\n    y: int");
@@ -3118,7 +3122,7 @@ TEST(ParserTest, RecordKeyword) {
     EXPECT_EQ(ts.fields.size(), 2u);
 }
 
-// ===== type エイリアス =====
+// ===== [contract] type エイリアス =====
 
 TEST(ParserTest, TypeAlias) {
     Program prog = parseStr("type MyInt = int");
@@ -3153,7 +3157,7 @@ TEST(ParserTest, EnumAcceptsPublicDirective) {
     EXPECT_EQ(es.directives[0].name, "public");
 }
 
-// ===== for k, v in map =====
+// ===== [contract] for k, v in map =====
 
 TEST(ParserTest, ForKVParsing) {
     Program prog = parseStr("for k, v in m:\n    print(k)");
@@ -3296,7 +3300,7 @@ TEST(ParserTest, AsyncWithoutFnRejected) {
     EXPECT_THROW(parseStr("async let x = 1"), std::runtime_error);
 }
 
-// ===== .. 演算子 =====
+// ===== [contract] .. 演算子 =====
 
 TEST(ParserTest, RangeExpr) {
     Program prog = parseStr("xs = 1 .. 5");
@@ -3306,7 +3310,7 @@ TEST(ParserTest, RangeExpr) {
     ASSERT_TRUE(range != nullptr);
 }
 
-// ===== ?? 演算子 =====
+// ===== [contract] ?? 演算子 =====
 
 TEST(ParserTest, NullCoalesceExpr) {
     Program prog = parseStr("x = a ?? 0");
@@ -3317,7 +3321,7 @@ TEST(ParserTest, NullCoalesceExpr) {
     EXPECT_EQ((*bin)->op, "??");
 }
 
-// ===== none キーワード =====
+// ===== [contract] none キーワード =====
 
 TEST(ParserTest, NoneExpr) {
     Program prog = parseStr("x = none");
@@ -3326,7 +3330,7 @@ TEST(ParserTest, NoneExpr) {
     ASSERT_TRUE(std::holds_alternative<NoneExpr>(let.value->data));
 }
 
-// ===== 命名規約チェック =====
+// ===== [contract] 命名規約チェック =====
 
 TEST(ParserTest, VariableAssignmentAcceptsCamelCase) {
     // Variable names are not checked at parser level
@@ -3515,7 +3519,7 @@ TEST(ParserTest, PascalCaseEnumVariantRequired) {
     EXPECT_THROW(parseStr("enum Color:\n    red\n    Green"), std::runtime_error);
 }
 
-// ===== Explicit enum value parser tests =====
+// ===== [contract] Explicit enum value parser tests =====
 
 TEST(ParserTest, EnumExplicitValues) {
     Program prog = parseStr("enum HttpStatus:\n    Ok = 200\n    NotFound = 404\n    InternalError = 500");
@@ -3552,7 +3556,7 @@ TEST(ParserTest, EnumExplicitValueOnADTError) {
     EXPECT_THROW(parseStr("enum Bad:\n    A(int) = 1\n    B = 2"), std::runtime_error);
 }
 
-// ===== Named fields in ADT enum variants =====
+// ===== [contract] Named fields in ADT enum variants =====
 
 TEST(ParserTest, EnumNamedFields) {
     Program prog = parseStr("enum Shape:\n    Circle(radius: float)\n    Rect(width: float, height: float)\n    Point");
@@ -3679,7 +3683,7 @@ TEST(ParserTest, SnakeCaseRecordFieldRejected) {
     EXPECT_THROW(parseStr("record Point:\n    my_x: int"), std::runtime_error);
 }
 
-// ===== trailing block syntax =====
+// ===== [contract] trailing block syntax =====
 
 TEST(ParserTest, TrailingBlockNoArgs) {
     Program prog = parseStr("foo():\n    bar()");
@@ -3715,7 +3719,7 @@ TEST(ParserTest, TrailingBlockUFCS) {
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(s.args[1]->data));
 }
 
-// ===== @native fn tests =====
+// ===== [contract] @native fn tests =====
 
 TEST(ParserTest, NativeFnDeclaration) {
     Program prog = parseStr("@native\nfn contains(s: str, sub: str) -> bool\n");
@@ -3768,7 +3772,7 @@ TEST(ParserTest, NativeFnWithColonError) {
     }, std::runtime_error);
 }
 
-// ===== @public directive tests (#1545) =====
+// ===== [contract] @public directive tests (#1545) =====
 // Parser-level acceptance only — visibility semantics are deferred to #1544.
 
 TEST(ParserTest, PublicOnFn) {
@@ -3800,7 +3804,7 @@ TEST(ParserTest, PublicOnRecord) {
     EXPECT_EQ(ts.directives[0].name, "public");
 }
 
-// ===== @directive (DirectiveDefStmt) rejection tests (#708) =====
+// ===== [contract] @directive (DirectiveDefStmt) rejection tests (#708) =====
 
 TEST(DirectiveDefParserTest, RejectsSnakeCaseDirectiveName) {
     EXPECT_THROW(parseStr("@directive(target=[\"function\"])\nfn my_directive()\n"),
@@ -3909,7 +3913,7 @@ TEST(DirectiveDefParserTest, RejectsCombiningDirectiveWithDeprecatedAfter) {
                  DiagnosticError);
 }
 
-// ===== @directive acceptance tests (#708) =====
+// ===== [contract] @directive acceptance tests (#708) =====
 
 TEST(DirectiveDefParserTest, AcceptsBasicDirectiveDef) {
     Program prog = parseStr("@directive(target=[\"function\"])\nfn it(description: str)\n");
@@ -3976,7 +3980,7 @@ TEST(DirectiveDefParserTest, AcceptsForTarget) {
     EXPECT_EQ(d.targets[0], "for");
 }
 
-// ===== @directive + @public combination tests (#1546) =====
+// ===== [contract] @directive + @public combination tests (#1546) =====
 
 TEST(DirectiveDefParserTest, AcceptsPublicBeforeDirective) {
     Program prog = parseStr("@public\n@directive(target=[\"function\"])\nfn it(description: str)\n");
@@ -4014,7 +4018,7 @@ TEST(DirectiveDefParserTest, RejectsCombiningDirectiveWithInlineAfter) {
                  DiagnosticError);
 }
 
-// ===== OR pattern binding check =====
+// ===== [contract] OR pattern binding check =====
 
 TEST(ParserTest, OrPatternRejectsVariableBinding) {
     EXPECT_THROW({
@@ -4090,7 +4094,7 @@ TEST(ParserTest, ModerateNestingSucceeds) {
     EXPECT_NO_THROW(parseStr(moderate));
 }
 
-// ===== Default arguments =====
+// ===== [contract] Default arguments =====
 
 TEST(ParserTest, DefaultArgBasic) {
     Program prog = parseStr("fn f(x: int, y: int = 10) -> int:\n    return x + y");
@@ -4200,7 +4204,7 @@ TEST(ParserTest, NestedLambdaAcceptsCamelCase) {
     EXPECT_EQ(inner.params[0].name, "myY");
 }
 
-// ===== Bare-paren-omitted single-param lambda (#1572) =====
+// ===== [contract] Bare-paren-omitted single-param lambda (#1572) =====
 
 TEST(ParserTest, BareLambdaSingleParamAccepts) {
     Program prog = parseStr("f = s => s + 1");
@@ -4290,7 +4294,7 @@ TEST(ParserTest, BareLambdaBodyDoesNotInheritAsyncContext) {
         std::runtime_error);
 }
 
-// ===== Cast expression with generic types (#490) =====
+// ===== [contract] Cast expression with generic types (#490) =====
 
 TEST(ParserTest, CastSimpleType) {
     Program prog = parseStr("x = 42 as float");
@@ -4343,7 +4347,7 @@ TEST(ParserTest, CastChained) {
     EXPECT_EQ(inner.target_type->toString(), "float");
 }
 
-// ===== case <subject> 式パーサーテスト =====
+// ===== [contract] case <subject> 式パーサーテスト =====
 
 TEST(ParserTest, CaseExprBasic) {
     Program prog = parseStr("x = case y:\n    1 : 10\n    _ : 0");
@@ -4513,7 +4517,7 @@ TEST(ParserTest, IdentifierStartingWithENotStolen) {
     EXPECT_THROW(parseStr("x = 1exp"), std::runtime_error);
 }
 
-// ===== Chained LHS assignment (#812) =====
+// ===== [regression #812] Chained LHS assignment =====
 
 TEST(ParserTest, ChainedLhsListFieldAssign) {
     // `list[i].field = v` parses as FieldAssignStmt with IndexExpr object.
@@ -4612,7 +4616,7 @@ TEST(ParserTest, ChainedLhsFieldMissingEqualsThrows) {
     EXPECT_THROW(parseStr("rec.field\n"), std::runtime_error);
 }
 
-// ===== Trailing comma tests (#832) =====
+// ===== [contract] Trailing comma tests (#832) =====
 
 TEST(ParserTest, ListTrailingComma) {
     Program prog = parseStr("x = [1, 2, 3,]");
@@ -4806,9 +4810,7 @@ TEST(ParserTest, GenericTypeArgDoubleCommaError) {
     EXPECT_THROW(parseStr("fn foo(x: List<int,,>) -> int:\n    return 0\n"), std::runtime_error);
 }
 
-// ============================================================
-// Named arguments in function calls (#747)
-// ============================================================
+// ===== [contract] Named arguments in function calls (#747) =====
 
 TEST(ParserTest, NamedArgInCallStmt) {
     Program prog = parseStr("print(\"hello\", end=\"\")\n");
@@ -4848,9 +4850,7 @@ TEST(ParserTest, DuplicateNamedArgError) {
     EXPECT_THROW(parseStr("print(end=\"\\n\", end=\"!\")\n"), std::runtime_error);
 }
 
-// ============================================================
-// Tuple patterns in case (#834)
-// ============================================================
+// ===== [contract] Tuple patterns in case (#834) =====
 
 TEST(ParserTest, TuplePatternZeroTupleRejected) {
     // '()' as a pattern is not supported
@@ -4906,7 +4906,7 @@ TEST(ParserTest, TuplePatternGroupingUnclosedError) {
     EXPECT_THROW(parseStr("case x:\n    (42:\n        print(0)\n"), std::runtime_error);
 }
 
-// ===== Record Pattern parsing =====
+// ===== [contract] Record Pattern parsing =====
 
 TEST(ParserTest, RecordPatternBasic) {
     // Point(a, b) parses to RecordPattern with two VariablePattern elements
@@ -4984,7 +4984,7 @@ TEST(ParserTest, RecordPatternTrailingComma) {
     EXPECT_TRUE(std::holds_alternative<VariablePattern>(rp.elements[1]));
 }
 
-// ---- Array type T[N] parser tests (regression for #1259) ----
+// ===== [regression #1259] Array type T[N] parser tests =====
 
 TEST(ParserArrayType, HappyPath_SmallSize) {
     Program prog = parseStr("x: int[10] = 0");
@@ -5010,7 +5010,7 @@ TEST(ParserArrayType, RejectsUnderscoreInSize) {
     EXPECT_THROW(parseStr("x: int[1_000] = 0"), DiagnosticError);
 }
 
-// ---- Angle-bracket generic call rejection (regression for #1885) ----
+// ===== [regression #1885] Angle-bracket generic call rejection =====
 //
 // `f<T>(args)` at expression position used to be silently parsed as a
 // comparison-chain (`f < T > (args)`), causing the misleading


### PR DESCRIPTION
## Summary

#1831 (parser tests pilot) と、#1830 で close 時に「定義は #1831 の PR に含める」と判断された taxonomy 定義を 1 つの PR にまとめた。

- 新規: `docs/reference/test-taxonomy.md` — contract / internal / regression 3 カテゴリの定義、section header tag 規約、`tests/test_regression_<n>_<desc>.cpp` 既存運用との接続、重複統合の安全ルール、Design by Contract との命名衝突の注記
- `tests/test_parser.cpp`: 51 セクションヘッダーを `// ===== [tag] Title =====` に統一 (47 contract / 4 regression: #1748 / #812 / #1259 / #1885)。冒頭に taxonomy doc への 3 行ポインタコメント。test 名・本体は完全無変更
- `.claude/skills/test-checklist/SKILL.md` と `AGENTS.md` (Path-Specific Entry Points) に新文書へのリンク追加

### 非対象

テスト振る舞いの変更・テスト削除・テストリネーム・ファイル分割は本 pilot では行わない (issue の lowest-risk 方針)。codegen/runtime tests への taxonomy 適用は別 issue。

### Internal カテゴリについて

Parser の公開境界は `parseProgram()` ほぼ単一で、C++ テストはすべて API 境界で観測する形を取るため、本ファイルに `[internal]` セクションは立たない。3 カテゴリの並びはそのままに、層分布の偏りとして taxonomy doc に明記。

## Test plan

- [x] `grep -cE '^TEST\(' tests/test_parser.cpp` = 526 (不変)
- [x] テスト名 diff vs HEAD = 空 (`diff <(grep ... | sort) <(git show HEAD:... | grep ... | sort)`)
- [x] `cmake --build build-rust --target ry_tests` 成功
- [x] `./build-rust/ry_tests --gtest_filter='ParserTest.*:DirectiveDefParserTest.*:ParserArrayType.*'` → 526/526 PASS
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` clean
- [x] `.claude/skills/pre-commit-checklist/run-tests.sh` → 218 test files, 0 failures
- [x] `.claude/skills/pre-commit-checklist/run-static-analysis-all.sh` → scan-build: No bugs found
- ASan / TSan / fuzz: 本 PR の `tests/test_parser.cpp` 変更はコメント編集のみ (テスト名・本体不変) で binary 振る舞いが同一のため省略

Closes #1831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive test classification guide defining contract, internal, and regression test categories with formatting conventions, organization best practices, and safety rules for test merging.

* **Chores**
  * Updated test section headers to standardized taxonomy format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->