### PR TITLE
chore(stdlib): sync share/std/manifest.json with json5 module, bump to 0.0.7

### DIFF
--- a/share/std/manifest.json
+++ b/share/std/manifest.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "files": [
     "builtins.ry", "convert.ry", "higher_order.ry",
     "list.ry", "map.ry", "set.ry", "str.ry", "regex.ry",
     "base64/base64.ry", "core/directive.ry",
     "filesystem/filesystem.ry", "gc/gc.ry",
-    "http/http.ry", "io/io.ry", "json/json.ry", "math/math.ry", "net/net.ry",
+    "http/http.ry", "io/io.ry", "json/json.ry", "json5/json5.ry", "math/math.ry", "net/net.ry",
     "path/path.ry", "testing/testing.ry", "thread/thread.ry",
     "runtime_internal/runtime_internal.ry"
   ]


### PR DESCRIPTION
## Summary

- PR #2289 (issue #1855) added `share/std/json5/json5.ry` as a new top-level stdlib module but did not update `share/std/manifest.json`. The manifest listed 21 files while the directory contained 22.
- This PR inserts `"json5/json5.ry"` into the `files` array (alphabetical position, next to `"json/json.ry"`) and bumps `version` from `0.0.6` to `0.0.7`, mirroring the shape #1390 established when it added `core/directive.ry`.
- Runtime impact is nil: `scripts/bundle-dist.sh` uses `cp -r share/std`, and `self_update` rewrites the installed manifest from a directory scan. The fix restores the bundled manifest's role as the release inventory ledger so future drift in either direction cannot slip through silently.

## Test plan

- [x] Drift check: `diff <(jq -r '.files[] | "share/std/" + .' share/std/manifest.json | sort) <(find share/std -name '*.ry' | sort)` → empty
- [x] `jq -r '.version' share/std/manifest.json` → `0.0.7`
- [x] `jq -r '.files | length' share/std/manifest.json` → `22`
- [x] `./.claude/skills/pre-commit-checklist/run-tests.sh` — 219 files, 0 failures
- [x] `./.claude/skills/pre-commit-checklist/run-asan.sh` — 219 files, 0 failures
- [x] `./.claude/skills/pre-commit-checklist/run-tsan.sh` — 219 files, 0 failures
- [x] `./.claude/skills/pre-commit-checklist/run-static-analysis-all.sh` — scan-build "No bugs found"

## Skipped checks (with reasons)

- Docs: no user-visible behavior change.
- `changelog.d/` fragment: chore-level, no user-visible behavior change (per `.claude/rules/changelog-fragments.md`).
- Rust lint: no `crates/` changes.
- Prompt-reference lint: no `.claude/`, `AGENTS.md`, or `CLAUDE.md` changes.
- tree-sitter check: no grammar / scanner / query / EBNF changes.
- Fuzz: not required for the "Other code" category in the pre-commit table.

## Follow-up

The release-prep manifest verification step (issue body, "Follow-up" section) is intentionally out of scope and will be filed as a separate issue.

Closes #2295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.0.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->