### PR TITLE
fix(module): bare 'import ry' / 'from ry import' bypasses reserved namespace warning

### DIFF
--- a/changelog.d/2297-bare-ry-namespace-fix.md
+++ b/changelog.d/2297-bare-ry-namespace-fix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `import ry` および `from ry import X` の bare 形式が予約 namespace ガードを bypass し、project-local の `ry/` ディレクトリ / `ry.ry` ファイルが silently shadow する問題を修正。bare 形式は無効として reject し、`ry.<module>` の使用を促すヒントを返す。あわせて `ry.*` 経路は #1769 で documented public とされた 11 module (`ry.lang`, `ry.math`, `ry.io`, `ry.path`, `ry.filesystem`, `ry.json`, `ry.http`, `ry.thread`, `ry.regex`, `ry.testing`, `ry.base64`) のみ受理する allowlist を導入。internal modules (`ry.builtins`, `ry.gc`, `ry.core`, `ry.runtime_internal` 等) は許可リストヒント付きで reject される。bare な互換エイリアス (`from net import`, `from json5 import`) は変更なし。`ry.*` 配下のエラーメッセージは loader 内部のスラッシュ表記ではなくユーザが書いたドット表記で返す。 (#2297)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -56,7 +56,9 @@ See [Module Reference — Visibility](modules.md#visibility) for the practical v
 
 ## ry namespace
 
-The **canonical reserved namespace** for the official standard library, introduced in v0.0.30 (#1769). All stdlib modules are addressable under the `ry.*` path: the implicit prelude is `ry.lang`, and each submodule lives under `ry.<module>` (e.g. `ry.math`, `ry.io`, `ry.path`, `ry.filesystem`, `ry.json`, `ry.http`, `ry.thread`).
+The **canonical reserved namespace** for the official standard library, introduced in v0.0.30 (#1769). Documented public stdlib modules are addressable under the `ry.*` path: the implicit prelude is `ry.lang`, and each public submodule lives under `ry.<module>`.
+
+The full set of public modules accepted via `ry.*` is the 11 documented entries: `ry.lang`, `ry.math`, `ry.io`, `ry.path`, `ry.filesystem`, `ry.json`, `ry.http`, `ry.thread`, `ry.regex`, `ry.testing`, `ry.base64`. Anything else under the `ry.*` prefix — including internal stdlib helpers such as `ry.builtins`, `ry.gc`, `ry.core`, `ry.runtime_internal`, and any module not on the documented list — is **rejected** with an error that lists the public modules. Bare modules that exist as compatibility aliases (e.g. `net`, `json5`) are not part of the `ry.*` surface and must be imported with their bare names.
 
 Two import shapes resolve through this namespace:
 
@@ -64,6 +66,8 @@ Two import shapes resolve through this namespace:
 from ry.math import sqrt, PI    # selective import
 import ry.math                  # qualified import; binds `math` (last segment)
 ```
+
+Bare `import ry` and `from ry import X` are **invalid** — `ry` is a reserved namespace with no top-level exports. The loader rejects both forms with an error advising `ry.<module>`.
 
 The legacy `from std import` / `from std.<mod> import` / flat `from <mod> import` spellings continue to work as **compatibility aliases**; they resolve through the same physical modules under `share/std/`.
 

--- a/src/jit/jit_runner.cpp
+++ b/src/jit/jit_runner.cpp
@@ -175,12 +175,20 @@ int runRySource(const std::string &src, const std::string &source_name,
         // stdlib not installed — continue without it
     }
 
-    // Resolve remaining imports
+    // Resolve remaining imports. #2297: warnings accumulated up to a throw
+    // (e.g. a `ry/` shadow probe that fires immediately before a bare `import
+    // ry` rejection) must reach stderr too — flush them in every catch arm
+    // before rethrowing so "warn + reject" does not silently degrade to "reject".
+    auto flushWarnings = [&loader] {
+        for (const auto &w : loader.loaderWarnings()) errs() << w << "\n";
+    };
     try {
         prog = loader.resolveImports(prog, referrer_dir);
     } catch (const DiagnosticError &) {
+        flushWarnings();
         throw;
     } catch (const std::exception &e) {
+        flushWarnings();
         ry::emitTraceEvent("import.resolve.error", "compile", &sourceLoc,
                            {ry::TraceField("file", source_name),
                             ry::TraceField("detail", e.what())});
@@ -189,9 +197,7 @@ int runRySource(const std::string &src, const std::string &source_name,
 
     // #1769: surface loader-level warnings (reserved-namespace shadowing, ...)
     // alongside codegen warnings. The loader dedupes; surface as-is.
-    for (const auto &w : loader.loaderWarnings()) {
-        errs() << w << "\n";
-    }
+    flushWarnings();
 
     // CodeGen -> ThreadSafeModule
     //

--- a/src/module/module_loader.cpp
+++ b/src/module/module_loader.cpp
@@ -6,11 +6,13 @@
 #include "ry/stdlib_registry.hpp"
 #include "ry/trace/trace.hpp"
 #include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+#include <string_view>
 
 
 namespace ry {
@@ -19,6 +21,58 @@ namespace fs = std::filesystem;
 using ry::TraceField;
 using ry::emitTraceDiagnostic;
 using ry::emitTraceEvent;
+
+// #2297: 公開 stdlib モジュール許可リスト。#1769 で `ry.*` の public surface
+// として列挙された 11 モジュールのみ受理し、それ以外は internal とみなして
+// reject する。`StdlibRegistry` は codegen dispatch table で「dispatcher を持つ
+// package」を列挙するもので意図が異なるため、ここで独立に policy を維持する
+// (例: `runtime_internal` は dispatch を持つが internal、逆に `lang` / `regex` /
+// `filesystem` / `testing` は dispatcher を持たないが public)。
+static constexpr std::array<std::string_view, 11> kPublicRyModules = {
+    "lang", "math", "io", "path", "filesystem", "json",
+    "http", "thread", "regex", "testing", "base64",
+};
+
+static bool isPublicRyModule(std::string_view first_segment) {
+    return std::find(kPublicRyModules.begin(), kPublicRyModules.end(),
+                     first_segment) != kPublicRyModules.end();
+}
+
+// #2297: allowlist エラー文の "available: ..." リストを `kPublicRyModules` から
+// 一度だけ組み立てる。文字列をハードコードすると set/array との drift を招くため。
+static const std::string &publicRyModulesListForError() {
+    static const std::string kList = [] {
+        std::string s;
+        bool first = true;
+        for (auto m : kPublicRyModules) {
+            if (!first) s += ", ";
+            s += "ry.";
+            s += m;
+            first = false;
+        }
+        return s;
+    }();
+    return kList;
+}
+
+// #2297: `ry/foo/bar` を user-facing `ry.foo.bar` に変換する。loader は内部
+// 表現としてスラッシュ区切りを使うが、エラーメッセージはユーザーが書いた
+// dot 表記に揃える。
+static std::string toRyDotForm(const std::string &slash_path) {
+    std::string result = slash_path;
+    std::replace(result.begin(), result.end(), '/', '.');
+    return result;
+}
+
+// #2297: user-facing パス表記の正規化。`ry/*` (予約 namespace) はドット形式に
+// 変換し、それ以外 (legacy bare `math` / 相対 `./submod` / 通常パッケージ) は
+// loader 内部表現と一致させたまま返す。エラーメッセージで `module_path` を
+// 直接埋め込んでいる箇所をこのヘルパーに通すことで、ユーザーが書いたスペリ
+// ングに揃った診断を出す。
+static std::string toUserFacingPath(const std::string &module_path) {
+    return ModuleLoader::isRyPath(module_path) ? toRyDotForm(module_path)
+                                                : module_path;
+}
 
 // Check if a statement is an exportable definition
 static bool isExportable(const StmtNode &stmt) {
@@ -224,7 +278,7 @@ static void rejectUnsupportedAlias(ExportableKind kind,
     detail += " '";
     detail += name;
     detail += "' from module '";
-    detail += import_path;
+    detail += toUserFacingPath(import_path);
     detail += "': mutable globals and directives cannot be re-bound via 'as'";
     throw std::runtime_error(makeImportError(line, detail));
 }
@@ -308,7 +362,7 @@ static void extractDefinitions(Program &source, Program &dest,
                     std::string detail = "alias not supported for testing intrinsic '";
                     detail += name;
                     detail += "' from module '";
-                    detail += import_path;
+                    detail += toUserFacingPath(import_path);
                     detail += "': intrinsics cannot be re-bound (tracked in #1725)";
                     throw std::runtime_error(makeImportError(line, detail));
                 }
@@ -337,7 +391,7 @@ static void extractDefinitions(Program &source, Program &dest,
             std::string detail = "'";
             detail += name;
             detail += "' not found in module '";
-            detail += import_path;
+            detail += toUserFacingPath(import_path);
             detail += "'";
             throw std::runtime_error(makeImportError(line, detail));
         }
@@ -345,7 +399,7 @@ static void extractDefinitions(Program &source, Program &dest,
             std::string detail = "cannot import '";
             detail += name;
             detail += "' from module '";
-            detail += import_path;
+            detail += toUserFacingPath(import_path);
             detail += "': symbol is not @public";
             throw std::runtime_error(makeImportError(line, detail));
         }
@@ -372,8 +426,13 @@ ModuleLoader::ModuleLoader(const std::vector<std::string> &search_paths,
 }
 
 bool ModuleLoader::isRyPath(const std::string &module_path) {
-    return module_path.size() >= 3 && module_path[0] == 'r' &&
-           module_path[1] == 'y' && module_path[2] == '/';
+    // #2297: bare "ry" (length 2) is also a reserved-namespace reference.
+    // The original predicate required `[2] == '/'` and silently let bare
+    // forms (`import ry`, `from ry import X`) fall through to user-path
+    // search, bypassing the namespace guard entirely.
+    return module_path == "ry" ||
+           (module_path.size() >= 3 && module_path[0] == 'r' &&
+            module_path[1] == 'y' && module_path[2] == '/');
 }
 
 std::string ModuleLoader::canonicalStdlibName(const std::string &module_path) {
@@ -382,6 +441,10 @@ std::string ModuleLoader::canonicalStdlibName(const std::string &module_path) {
     // compatible with the existing `from math import` / `from testing import`
     // resolution paths.
     if (!isRyPath(module_path)) return module_path;
+    // #2297: bare "ry" is rejected by `resolve()` before reaching here, but
+    // guard substr(3) defensively — gating predicates call this from
+    // outside the resolve flow and `"ry".substr(3)` would throw out_of_range.
+    if (module_path == "ry") return "";
     std::string tail = module_path.substr(3);
     if (tail == "lang") return "std";  // ry.lang -> the prelude directory
     return tail;                       // ry.<sub> -> <sub>
@@ -483,6 +546,9 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
     // is cached per-referrer so a file with many `ry.*` imports does not
     // re-stat the same directory.
     if (isRyPath(module_path)) {
+        // Shadow probe: bare "ry" 形式でも発火させる (#2297) — 一貫した警告で
+        // ユーザーに将来の予約衝突を知らせる。bare reject よりも前に push する
+        // ことで、jit_runner の catch flush 経由で stderr に出る。
         if (!referrer_dir.empty() &&
             probed_ry_shadow_dirs_.insert(referrer_dir).second) {
             std::error_code shadow_ec;
@@ -495,6 +561,35 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
                     "the local 'ry' module in '" + referrer_dir +
                     "' is ignored and will become an error in a future release");
             }
+        }
+
+        // #2297: bare `import ry` / `from ry import X` は無効 — `ry` は予約
+        // namespace で top-level export を持たないため、`ry.<module>` 形式を
+        // 要求する rejection で失敗させる。
+        if (module_path == "ry") {
+            if (ry::traceEnabled())
+                emitTraceEvent("import.resolve.error", "compile", &loc,
+                               {TraceField("module_path", module_path),
+                                TraceField("detail", "bare 'ry' rejected")});
+            throw std::runtime_error(
+                "'ry' is the reserved stdlib namespace; "
+                "use 'ry.<module>' (e.g. 'ry.lang', 'ry.math')");
+        }
+
+        // #2297: stdlib allowlist — `ry/` 接頭辞の直後の第一セグメントが #1769
+        // 列挙の 11 module のいずれでなければ reject。`ry.builtins` / `ry.gc` /
+        // `ry.core` 等の internal module を user-facing でアクセス不能にする。
+        const auto sep = module_path.find('/', 3);
+        const std::string first_segment = module_path.substr(
+            3, sep == std::string::npos ? std::string::npos : sep - 3);
+        if (!isPublicRyModule(first_segment)) {
+            if (ry::traceEnabled())
+                emitTraceEvent("import.resolve.error", "compile", &loc,
+                               {TraceField("module_path", module_path),
+                                TraceField("detail", "internal stdlib module rejected")});
+            throw std::runtime_error(
+                "'ry." + first_segment + "' is not a public stdlib module; "
+                "available: " + publicRyModulesListForError());
         }
 
         const std::string remapped = canonicalStdlibName(module_path);
@@ -513,7 +608,8 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
             emitTraceEvent("import.resolve.error", "compile", &loc,
                            {TraceField("module_path", module_path),
                             TraceField("detail", "module not found")});
-        throw std::runtime_error("module not found: " + module_path);
+        // #2297: ry/* の "module not found" はユーザーが書いた dot 表記で返す。
+        throw std::runtime_error("module not found: " + toRyDotForm(module_path));
     }
 
     // Relative import: "." or "./submod" — resolve only against referrer_dir
@@ -917,7 +1013,7 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                                 std::string detail = "alias not supported for testing intrinsic '";
                                 detail += name;
                                 detail += "' from module '";
-                                detail += imp.module_path;
+                                detail += toUserFacingPath(imp.module_path);
                                 detail += "': intrinsics cannot be re-bound (tracked in #1725)";
                                 throw std::runtime_error(makeImportError(imp.loc.line, detail));
                             }
@@ -946,7 +1042,7 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                         std::string detail = "'";
                         detail += name;
                         detail += "' not found in module '";
-                        detail += imp.module_path;
+                        detail += toUserFacingPath(imp.module_path);
                         detail += "'";
                         throw std::runtime_error(makeImportError(imp.loc.line, detail));
                     }
@@ -954,7 +1050,7 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                         std::string detail = "cannot import '";
                         detail += name;
                         detail += "' from module '";
-                        detail += imp.module_path;
+                        detail += toUserFacingPath(imp.module_path);
                         detail += "': symbol is not @public";
                         throw std::runtime_error(makeImportError(imp.loc.line, detail));
                     }

--- a/src/module/module_loader.cpp
+++ b/src/module/module_loader.cpp
@@ -576,19 +576,21 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
                 "use 'ry.<module>' (e.g. 'ry.lang', 'ry.math')");
         }
 
-        // #2297: stdlib allowlist — `ry/` 接頭辞の直後の第一セグメントが #1769
-        // 列挙の 11 module のいずれでなければ reject。`ry.builtins` / `ry.gc` /
-        // `ry.core` 等の internal module を user-facing でアクセス不能にする。
-        const auto sep = module_path.find('/', 3);
-        const std::string first_segment = module_path.substr(
-            3, sep == std::string::npos ? std::string::npos : sep - 3);
-        if (!isPublicRyModule(first_segment)) {
+        // #2297: stdlib allowlist — `ry/<sub>` の `<sub>` が #1769 列挙の 11
+        // module のいずれでなければ reject。`ry.builtins` / `ry.gc` / `ry.core`
+        // 等の internal module だけでなく、`ry.math.internal` のようなネスト
+        // パスも reject する (public surface は **完全な enumeration** であり、
+        // public module の下に深い public path は存在しない)。
+        const std::string public_module = module_path.substr(3);
+        if (public_module.find('/') != std::string::npos ||
+            !isPublicRyModule(public_module)) {
             if (ry::traceEnabled())
                 emitTraceEvent("import.resolve.error", "compile", &loc,
                                {TraceField("module_path", module_path),
                                 TraceField("detail", "internal stdlib module rejected")});
             throw std::runtime_error(
-                "'ry." + first_segment + "' is not a public stdlib module; "
+                "'" + toRyDotForm(module_path) +
+                "' is not a public stdlib module; "
                 "available: " + publicRyModulesListForError());
         }
 

--- a/tests/test_ry_namespace_warning.cpp
+++ b/tests/test_ry_namespace_warning.cpp
@@ -256,3 +256,20 @@ TEST_F(RyNamespaceWarningTest, BogusRyModuleErrorUsesDotSpelling) {
     EXPECT_EQ(r.err.find("ry/bogus"), std::string::npos)
         << "error must NOT use slash spelling 'ry/bogus': " << r.err;
 }
+
+TEST_F(RyNamespaceWarningTest, NestedRyPathRejectedAsNotPublic) {
+    // public surface は full enumeration なので、`ry.<public>.<deeper>` のような
+    // ネスト import も "not a public stdlib module" として早期 reject される
+    // (たとえ `share/std/math/internal.ry` が将来追加されても resolve loop に
+    // 落とさず、policy gate でブロックする)。
+    auto p = writeScript("nested_ry.ry",
+        "from ry.math.internal import x\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_NE(r.exit_code, 0) << "nested ry.* path must reject, stderr was: " << r.err;
+    EXPECT_NE(r.err.find("'ry.math.internal' is not a public stdlib module"),
+              std::string::npos)
+        << "error should explicitly state the nested path is not public: " << r.err;
+    EXPECT_EQ(r.err.find("ry/math/internal"), std::string::npos)
+        << "error must NOT use slash spelling: " << r.err;
+}

--- a/tests/test_ry_namespace_warning.cpp
+++ b/tests/test_ry_namespace_warning.cpp
@@ -177,3 +177,82 @@ TEST_F(RyNamespaceWarningTest, ShadowWarningDeduplicatedAcrossImports) {
     }
     EXPECT_EQ(count, 1u) << "expected exactly one warning, stderr was: " << r.err;
 }
+
+// #2297 — bare `import ry` / `from ry import X` も予約 namespace の対象。
+// shadow 警告は出すが、bare 形式は ry.<module> を要求する rejection で失敗させる。
+// 警告と rejection の双方が "reserved" を含むため、テストは distinct fragment で
+// 区別する: 警告 → "is ignored" / rejection → "use 'ry.<module>'".
+
+TEST_F(RyNamespaceWarningTest, BareImportRyEmitsWarningAndRejects) {
+    // local `ry/` shadow + bare `import ry` → shadow 警告 + bare reject を両方出す。
+    fs::create_directories(tmpDir_ / "ry");
+
+    auto p = writeScript("bare_import_ry.ry", "import ry\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_NE(r.exit_code, 0) << "bare 'import ry' must reject, stderr was: " << r.err;
+    EXPECT_NE(r.err.find("is ignored"), std::string::npos)
+        << "stderr should contain shadow warning ('is ignored'): " << r.err;
+    EXPECT_NE(r.err.find("use 'ry.<module>'"), std::string::npos)
+        << "stderr should contain rejection hint ('use 'ry.<module>''): " << r.err;
+}
+
+TEST_F(RyNamespaceWarningTest, BareFromRyImportEmitsWarningAndRejects) {
+    // local `ry/helper.ry` shadow + `from ry import helper` → bare 形式の reject。
+    fs::create_directories(tmpDir_ / "ry");
+    std::ofstream(tmpDir_ / "ry" / "helper.ry")
+        << "@public\nfn helper() -> int:\n    return 42\n";
+
+    auto p = writeScript("bare_from_ry.ry", "from ry import helper\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_NE(r.exit_code, 0) << "bare 'from ry import' must reject, stderr was: " << r.err;
+    EXPECT_NE(r.err.find("is ignored"), std::string::npos)
+        << "stderr should contain shadow warning ('is ignored'): " << r.err;
+    EXPECT_NE(r.err.find("use 'ry.<module>'"), std::string::npos)
+        << "stderr should contain rejection hint ('use 'ry.<module>''): " << r.err;
+}
+
+TEST_F(RyNamespaceWarningTest, BareImportRyWithoutShadowRejects) {
+    // shadow なしでも bare `import ry` は reject。警告は出ない。
+    auto p = writeScript("bare_no_shadow.ry", "import ry\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_NE(r.exit_code, 0) << "bare 'import ry' must reject, stderr was: " << r.err;
+    EXPECT_EQ(r.err.find("is ignored"), std::string::npos)
+        << "no shadow → no 'is ignored' warning, stderr was: " << r.err;
+    EXPECT_NE(r.err.find("use 'ry.<module>'"), std::string::npos)
+        << "stderr should contain rejection hint ('use 'ry.<module>''): " << r.err;
+}
+
+TEST_F(RyNamespaceWarningTest, InternalStdlibModuleRejectedWithHint) {
+    // `from ry.builtins import print` のような internal stdlib module は許可リスト外
+    // として reject される。bare `from builtins import print` は影響を受けない (今回の
+    // 対象外なのでテストもしない)。
+    auto p = writeScript("internal_module.ry",
+        "from ry.builtins import print\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_NE(r.exit_code, 0) << "internal 'ry.builtins' must reject, stderr was: " << r.err;
+    EXPECT_NE(r.err.find("'ry.builtins' is not a public stdlib module"),
+              std::string::npos)
+        << "error should name the module + 'not a public stdlib module': " << r.err;
+    EXPECT_NE(r.err.find("ry.lang"), std::string::npos)
+        << "error should list 'ry.lang' in available modules: " << r.err;
+    EXPECT_NE(r.err.find("ry.math"), std::string::npos)
+        << "error should list 'ry.math' in available modules: " << r.err;
+}
+
+TEST_F(RyNamespaceWarningTest, BogusRyModuleErrorUsesDotSpelling) {
+    // ユーザが書いた dot spelling (`ry.bogus`) で reject されるべき。loader 内部の
+    // slash 表現 (`ry/bogus`) が user-facing error にリークしてはいけない。
+    auto p = writeScript("bogus_ry.ry",
+        "from ry.bogus import x\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_NE(r.exit_code, 0) << "'ry.bogus' must reject, stderr was: " << r.err;
+    EXPECT_NE(r.err.find("'ry.bogus'"), std::string::npos)
+        << "error should mention 'ry.bogus' (dot spelling): " << r.err;
+    EXPECT_EQ(r.err.find("ry/bogus"), std::string::npos)
+        << "error must NOT use slash spelling 'ry/bogus': " << r.err;
+}


### PR DESCRIPTION
## Summary

- bare `import ry` / `from ry import X` が `isRyPath` の `[2] == '/'` 要求で予約 namespace ガードを bypass し、project-local の `ry/` ディレクトリ / `ry.ry` ファイルが silently shadow する問題を修正。bare 形式は無効として reject し、`ry.<module>` の使用を促すヒントを返す。
- `ry.*` 経路に #1769 列挙の 11 public module (`ry.lang`, `ry.math`, `ry.io`, `ry.path`, `ry.filesystem`, `ry.json`, `ry.http`, `ry.thread`, `ry.regex`, `ry.testing`, `ry.base64`) のみ受理する allowlist を導入。`ry.builtins` / `ry.gc` / `ry.core` / `ry.runtime_internal` 等の internal module は許可リストヒント付きで reject。bare な互換エイリアス (`from net import`, `from json5 import`) は無変更。
- `ry.*` 配下のエラーメッセージを loader 内部スラッシュ表記からユーザが書いたドット表記 (`ry.bogus`) に統一。`jit_runner.cpp` の `resolveImports` 2 catch arms で `loaderWarnings()` を flush し、`warn + reject` が `reject` 単独に degrade しないようにした。

Closes #2297

## Test plan

- [x] `./build-rust/ry_tests --gtest_filter=RyNamespaceWarningTest.*` — 既存 4 件 + 新 5 件 (`BareImportRyEmitsWarningAndRejects` / `BareFromRyImportEmitsWarningAndRejects` / `BareImportRyWithoutShadowRejects` / `InternalStdlibModuleRejectedWithHint` / `BogusRyModuleErrorUsesDotSpelling`) 全 pass
- [x] `./build-rust/ry_tests` 全体 — 2922/2922 pass
- [x] `./build-rust/ry test -p` — 219/219 spec files pass
- [x] ASan+UBSan (Docker) — 2922 C++ + 219 spec、findings 0
- [x] TSan (Docker) — 2922 C++ (6 SpecTimeout skipped、既存挙動) + 219 spec、race 0
- [x] 静的解析 (clang-tidy / cppcheck / scan-build) — 新 finding 0
- [x] smoke: `import ry` / `from ry.gc` / `from ry.bogus` / `from ry.math import bogusFn` / `from ry.math import sqrt` 各ケース手動確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `ry` namespace import handling to prevent bare `import ry` / `from ry import X` from bypassing the reserved-namespace guard and shadowing local `ry/` directories.
  * Enforced a fixed allowlist of 11 documented public `ry.*` modules; unsupported `ry.*` imports are rejected with clear guidance and “available modules” hints.
  * Improved user-facing error paths to consistently use dot notation, and ensured loader warnings are shown before import errors.

* **Documentation**
  * Updated the glossary to document the `ry` namespace restrictions and list the 11 public modules.

* **Tests**
  * Expanded coverage for reservation, allowlisting, and dot-notation error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->