### PR TITLE
refactor(stdlib): drop unused version field from manifest.json

### DIFF
--- a/.claude/skills/preparing-for-release/SKILL.md
+++ b/.claude/skills/preparing-for-release/SKILL.md
@@ -79,18 +79,33 @@ Aggregate `changelog.d/` fragments into `CHANGELOG.md` and finalize the `[<X.Y.Z
 
 Collapses `changelog.d/*.md` fragments into `[Unreleased]` and deletes them.
 
-### 2. Rename `[Unreleased]` → `[<X.Y.Z>] - YYYY-MM-DD` (today's UTC date)
+### 2. Verify `share/std/manifest.json` matches the on-disk stdlib
+
+`share/std/manifest.json` is hand-maintained (#1390 precedent) and is the inventory ledger for the release. Drift between the manifest and the actual stdlib directory is not caught by CI, packaging, or runtime — verify here.
+
+```bash
+diff <(jq -r '.files[] | "share/std/" + .' share/std/manifest.json | sort) \
+     <(find share/std -name '*.ry' | sort)
+```
+
+- Empty diff → no action.
+- Files present on disk but missing from manifest → add to `files` array (match existing grouping: top-level flat entries, then per-module subdirectories).
+- Files in manifest but missing on disk → remove from `files` array.
+
+Include the manifest edit in the same Release prep PR.
+
+### 3. Rename `[Unreleased]` → `[<X.Y.Z>] - YYYY-MM-DD` (today's UTC date)
 
 ```diff
 -## [Unreleased]
 +## [<X.Y.Z>] - YYYY-MM-DD
 ```
 
-### 3. Insert a fresh empty `[Unreleased]` heading
+### 4. Insert a fresh empty `[Unreleased]` heading
 
 Above the new `[<X.Y.Z>]` heading, insert `## [Unreleased]` (body empty; future fragments repopulate).
 
-### 4. Update comparison links at the bottom of `CHANGELOG.md`
+### 5. Update comparison links at the bottom of `CHANGELOG.md`
 
 ```diff
 -[Unreleased]: https://github.com/t0k0sh1/ry/compare/v<PREV>...HEAD
@@ -100,7 +115,7 @@ Above the new `[<X.Y.Z>]` heading, insert `## [Unreleased]` (body empty; future 
 
 `<PREV>` = previous released version (top of the existing list).
 
-### 5. Verify `release.yml`'s container pin is fresh
+### 6. Verify `release.yml`'s container pin is fresh
 
 `release.yml` pins the Linux release container to an immutable
 `:llvm-<MAJOR>-rev<N>` tag (#1508) for byte-reproducibility across

--- a/changelog.d/2296-drop-stdlib-manifest-version.md
+++ b/changelog.d/2296-drop-stdlib-manifest-version.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `share/std/manifest.json` から `version` フィールドを削除。コード上一切消費されない装飾メタデータで、`src/cli/self_update.cpp` の `install_stdlib` は読み込み直後に捨て、書き戻し時は呼出元から渡された `new_version` を上書きするのみだった。`StdlibManifest` 構造体と `write_manifest()` シグネチャを単純化し、`install_stdlib()` の `new_version` パラメータも併せて削除。`files` 配列は引き続き hand-maintained で、`/preparing-for-release` skill に追加した新 verify task が release ごとに on-disk stdlib との突合をゲートする。(#2296)

--- a/include/ry/cli/self_update.hpp
+++ b/include/ry/cli/self_update.hpp
@@ -48,7 +48,7 @@ SignatureAction evaluate_signature_policy(
 
 std::string download_and_extract(const std::string &download_url, const std::string &tag);
 bool replace_binary(const std::string &tmp_dir, const std::string &binary_path);
-bool install_stdlib(const std::string &tmp_dir, const std::string &new_version);
+bool install_stdlib(const std::string &tmp_dir);
 bool install_native_libs(const std::string &tmp_dir);
 
 } // namespace detail

--- a/include/ry/project/paths.hpp
+++ b/include/ry/project/paths.hpp
@@ -31,13 +31,11 @@ std::filesystem::path find_native_library(const std::string &exe_path,
                                           const std::string &lib_name);
 
 struct StdlibManifest {
-    std::string version;
     std::vector<std::string> files;
 };
 
 StdlibManifest read_manifest(const std::filesystem::path &dir);
 void write_manifest(const std::filesystem::path &dir,
-                    const std::string &version,
                     const std::vector<std::string> &files);
 
 } // namespace ry

--- a/share/std/manifest.json
+++ b/share/std/manifest.json
@@ -1,5 +1,4 @@
 {
-  "version": "0.0.7",
   "files": [
     "builtins.ry", "convert.ry", "higher_order.ry",
     "list.ry", "map.ry", "set.ry", "str.ry", "regex.ry",

--- a/src/cli/self_update.cpp
+++ b/src/cli/self_update.cpp
@@ -587,7 +587,7 @@ bool replace_binary(const std::string &tmp_dir_str, const std::string &binary_pa
     return true;
 }
 
-bool install_stdlib(const std::string &tmp_dir_str, const std::string &new_version) {
+bool install_stdlib(const std::string &tmp_dir_str) {
     namespace fs = std::filesystem;
 
     // Detect archive layout: new archives use share/std, old ones use lib/std.
@@ -658,7 +658,7 @@ bool install_stdlib(const std::string &tmp_dir_str, const std::string &new_versi
     }
 
     // Write new manifest
-    ry::write_manifest(dest_std, new_version, new_files);
+    ry::write_manifest(dest_std, new_files);
 
     // Clean up old lib/std only when ALL files were copied successfully.
     // On partial failure, keep old lib/std so the user retains a working stdlib.
@@ -779,9 +779,7 @@ int cmd_self_update(int argc, char *argv[]) {
     }
 
     // Install/update stdlib
-    std::string version = target.tag;
-    if (!version.empty() && version[0] == 'v') version = version.substr(1);
-    if (detail::install_stdlib(tmp_dir, version)) {
+    if (detail::install_stdlib(tmp_dir)) {
         std::cerr << "Standard library updated.\n";
     }
 

--- a/src/project/paths.cpp
+++ b/src/project/paths.cpp
@@ -1,9 +1,7 @@
 #include "ry/project/paths.hpp"
 #include "ry/project/project_config.hpp"
-#include "ry/cli/self_update.hpp"
 #include <cstdlib>
 #include <fstream>
-#include <sstream>
 #include <stdexcept>
 
 namespace fs = std::filesystem;
@@ -131,8 +129,6 @@ StdlibManifest read_manifest(const fs::path &dir) {
     std::string json((std::istreambuf_iterator<char>(file)),
                      std::istreambuf_iterator<char>());
 
-    manifest.version = ry::self_update::detail::extract_json_string(json, "version");
-
     // Extract files array
     auto arr_start = json.find('[');
     auto arr_end = json.find(']');
@@ -153,11 +149,10 @@ StdlibManifest read_manifest(const fs::path &dir) {
 }
 
 void write_manifest(const fs::path &dir,
-                    const std::string &version,
                     const std::vector<std::string> &files) {
     fs::path manifest_path = dir / "manifest.json";
     std::ofstream out(manifest_path);
-    out << "{\n  \"version\": \"" << version << "\",\n  \"files\": [";
+    out << "{\n  \"files\": [";
     for (size_t i = 0; i < files.size(); i++) {
         if (i > 0) out << ", ";
         out << "\"" << files[i] << "\"";

--- a/tests/test_paths.cpp
+++ b/tests/test_paths.cpp
@@ -259,10 +259,9 @@ TEST(Paths, ManifestReadWrite) {
     std::string tmp(tmp_dir);
 
     std::vector<std::string> files = {"builtins.ry", "str.ry"};
-    ry::write_manifest(tmp, "0.0.3", files);
+    ry::write_manifest(tmp, files);
 
     auto manifest = ry::read_manifest(tmp);
-    EXPECT_EQ(manifest.version, "0.0.3");
     ASSERT_EQ(manifest.files.size(), 2u);
     EXPECT_EQ(manifest.files[0], "builtins.ry");
     EXPECT_EQ(manifest.files[1], "str.ry");
@@ -378,6 +377,5 @@ TEST(Paths, FindNativeLibraryPrefersExeParentOverRyHome) {
 
 TEST(Paths, ManifestReadMissing) {
     auto manifest = ry::read_manifest("/nonexistent/path");
-    EXPECT_TRUE(manifest.version.empty());
     EXPECT_TRUE(manifest.files.empty());
 }

--- a/tests/test_self_update.cpp
+++ b/tests/test_self_update.cpp
@@ -111,7 +111,7 @@ TEST_F(InstallStdlibTest, CopiesNestedModules) {
     write_file(src_std / "http" / "http.ry", "# http module");
     write_file(src_std / "net" / "net.ry", "# net module");
 
-    bool ok = install_stdlib(src_dir.string(), "0.1.0");
+    bool ok = install_stdlib(src_dir.string());
     ASSERT_TRUE(ok);
 
     auto dest_std = dest_home / "share" / "std";
@@ -125,10 +125,9 @@ TEST_F(InstallStdlibTest, ManifestContainsRelativePaths) {
     write_file(src_std / "builtins.ry", "# builtins");
     write_file(src_std / "http" / "http.ry", "# http");
 
-    install_stdlib(src_dir.string(), "0.1.0");
+    install_stdlib(src_dir.string());
 
     auto manifest = ry::read_manifest(dest_home / "share" / "std");
-    EXPECT_EQ(manifest.version, "0.1.0");
 
     // Check that both top-level and nested files are in the manifest
     auto &files = manifest.files;
@@ -141,13 +140,13 @@ TEST_F(InstallStdlibTest, CleansUpOldNestedFiles) {
 
     // Pre-populate dest with an old nested file and manifest
     write_file(dest_std / "old_mod" / "old.ry", "# old");
-    ry::write_manifest(dest_std, "0.0.1", {"old_mod/old.ry"});
+    ry::write_manifest(dest_std, {"old_mod/old.ry"});
 
     // New archive has only builtins.ry
     auto src_std = src_dir / "share" / "std";
     write_file(src_std / "builtins.ry", "# builtins");
 
-    install_stdlib(src_dir.string(), "0.1.0");
+    install_stdlib(src_dir.string());
 
     EXPECT_TRUE(fs::exists(dest_std / "builtins.ry"));
     EXPECT_FALSE(fs::exists(dest_std / "old_mod" / "old.ry"));
@@ -158,13 +157,13 @@ TEST_F(InstallStdlibTest, CleansUpEmptyDirectories) {
 
     // Pre-populate with a nested file
     write_file(dest_std / "removed_mod" / "removed.ry", "# removed");
-    ry::write_manifest(dest_std, "0.0.1", {"removed_mod/removed.ry"});
+    ry::write_manifest(dest_std, {"removed_mod/removed.ry"});
 
     // New archive has no removed_mod
     auto src_std = src_dir / "share" / "std";
     write_file(src_std / "builtins.ry", "# builtins");
 
-    install_stdlib(src_dir.string(), "0.1.0");
+    install_stdlib(src_dir.string());
 
     EXPECT_FALSE(fs::exists(dest_std / "removed_mod"));
 }
@@ -174,13 +173,13 @@ TEST_F(InstallStdlibTest, CleansUpDeeplyNestedEmptyDirectories) {
 
     // Pre-populate with a deeply nested file (a/b/c.ry)
     write_file(dest_std / "a" / "b" / "c.ry", "# deep");
-    ry::write_manifest(dest_std, "0.0.1", {"a/b/c.ry"});
+    ry::write_manifest(dest_std, {"a/b/c.ry"});
 
     // New archive has no a/b/c.ry
     auto src_std = src_dir / "share" / "std";
     write_file(src_std / "builtins.ry", "# builtins");
 
-    install_stdlib(src_dir.string(), "0.1.0");
+    install_stdlib(src_dir.string());
 
     // Both a/b/ and a/ should be removed
     EXPECT_FALSE(fs::exists(dest_std / "a" / "b"));
@@ -194,7 +193,7 @@ TEST_F(InstallStdlibTest, OldLayoutArchiveInstallsToLibStd) {
     fs::create_directories(src_dir / "lib" / "std");
     write_file(src_dir / "lib" / "std" / "builtins.ry", "# builtins from old layout");
 
-    bool ok = install_stdlib(src_dir.string(), "0.0.7");
+    bool ok = install_stdlib(src_dir.string());
     ASSERT_TRUE(ok);
 
     // Old layout archive → install to lib/std (matching old binary expectation)
@@ -207,13 +206,13 @@ TEST_F(InstallStdlibTest, ReturnsFalseWhenNoStdlibInArchive) {
     EXPECT_TRUE(fs::is_empty(dest_std));
     fs::remove_all(src_dir / "share" / "std");
 
-    bool ok = install_stdlib(src_dir.string(), "0.1.0");
+    bool ok = install_stdlib(src_dir.string());
     EXPECT_FALSE(ok);
     EXPECT_TRUE(fs::is_empty(dest_std));
 }
 
 TEST_F(InstallStdlibTest, HandlesEmptyStdlibDirectory) {
-    bool ok = install_stdlib(src_dir.string(), "0.1.0");
+    bool ok = install_stdlib(src_dir.string());
     EXPECT_TRUE(ok);
 }
 


### PR DESCRIPTION
## Summary

- `share/std/manifest.json` から `version` フィールドを削除。`install_stdlib` は読み込み後に捨て、書き戻し時は引数で上書きするだけで、コード上の挙動を gate するパスは無かった
- それに伴い `StdlibManifest` 構造体、`write_manifest()` シグネチャ、`install_stdlib()` の `new_version` パラメータ、`cmd_self_update` の `v`-strip ロジックを併せて削除
- `/preparing-for-release` skill に `share/std/manifest.json` の `files` 配列と on-disk `*.ry` を diff するタスクを追加。drift を release ごとに gate する
- `changelog.d/2296-drop-stdlib-manifest-version.md` を `### Changed` カテゴリで追加

## Scope note

Issue #2296 は当初「verify task 追加のみ」を提案していたが、plan 段階で `version` フィールドが完全に未使用な装飾メタデータと判明したため、削除を併せて行う方針に転換した。version 規約を文書化する必要が消え、verify task の本文が最小化できる。

forward/backward compat: parser は missing key を寛容に扱い、`self_update` は manifest を archive の directory walk から regenerate するため、新旧バイナリ間で破綻しない。

## Test plan

- [x] `cmake --build build-rust` 成功
- [x] `./build-rust/ry_tests` で 2923 件 pass（`Paths.ManifestReadWrite` / `Paths.ManifestReadMissing` / `InstallStdlibTest.*` 含む）
- [x] `./build-rust/ry test -p` で 219 ファイル pass
- [x] `run-asan.sh` / `run-tsan.sh` green
- [x] `run-static-analysis-all.sh` clean（既存 `main.cpp` deadcode warning は PR 外）
- [x] `run-prompt-refs-lint.sh` clean
- [x] `jq . share/std/manifest.json` で syntax 検証
- [x] `diff <(jq -r '.files[] | "share/std/" + .' share/std/manifest.json | sort) <(find share/std -name '*.ry' | sort)` empty（in-sync state 維持）

Closes #2296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Standard library manifest structure simplified—the version field is no longer included in the manifest file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->