### PR TITLE
test(scripts/export-run-logs): add JSONL schema contract test and single-source SCHEMA_VERSION

### DIFF
--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -24,6 +24,7 @@ Always evaluate:
 - Static analysis.
 - Rust lint when `crates/` changed.
 - Prompt-reference lint when `.claude/`, `AGENTS.md`, or `CLAUDE.md` changed.
+- Export-run-logs JSONL schema test when `scripts/export-run-logs.sh`, `tests/scripts/`, or the `__ry_test_summary` output format in `src/test_runtime.cpp` changed.
 - tree-sitter check when grammar, scanner, query, or EBNF changed.
 - Background-execution prohibition.
 - Label cleanup policy.
@@ -58,6 +59,7 @@ Use `/knowledge-md-management` when no destination exists.
 ./.claude/skills/pre-commit-checklist/run-static-analysis-all.sh
 ./.claude/skills/pre-commit-checklist/run-rust-lint.sh
 ./.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh
+./.claude/skills/pre-commit-checklist/run-export-run-logs-tests.sh
 ./.claude/skills/pre-commit-checklist/run-fuzz.sh
 ./.claude/skills/pre-commit-checklist/run-tree-sitter.sh
 ```

--- a/.claude/skills/pre-commit-checklist/run-export-run-logs-tests.sh
+++ b/.claude/skills/pre-commit-checklist/run-export-run-logs-tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# §3.5.8 export-run-logs JSONL schema contract test (#2300) — runs the harness
+# at tests/scripts/test-export-run-logs.sh against a tiny fixture, asserts the
+# run_meta + command record invariants documented in
+# docs/architecture/jsonl-run-logs.md. Run before pushing any change under
+# scripts/export-run-logs.sh, tests/scripts/, or src/test_runtime.cpp's
+# __ry_test_summary output format.
+#
+# Requires: a built ry binary in build-rust/ or build/ (or $RY_BUILD_DIR).
+# No --clean flag: shell + jq harness, no build dir to wipe.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+
+echo "==> tests/scripts/test-export-run-logs.sh" >&2
+bash tests/scripts/test-export-run-logs.sh
+
+echo "==> export-run-logs JSONL schema OK" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,14 +194,19 @@ jobs:
         run: ./build/ry test
       - name: Test (export-run-logs JSONL schema, #2300)
         # `jq` is not in `ry-ci:llvm-21` (gcc:14-trixie base); install a
-        # prebuilt binary inline using the same wget-from-github pattern as
-        # docker/ci.Dockerfile uses for cmake/ninja. Long-term: bake `jq` into
-        # the image and drop this step's install lines.
+        # prebuilt binary inline, verified against the project's published
+        # sha256sum.txt (https://github.com/jqlang/jq/tree/master/sig) so an
+        # upstream compromise or MITM cannot poison this step. Long-term: bake
+        # `jq` into the image and drop these install lines.
         run: |
           JQ_VERSION=1.7.1
-          wget -qO /usr/local/bin/jq \
-            "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
-          chmod +x /usr/local/bin/jq
+          (
+            cd /tmp
+            wget -q "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
+            wget -q "https://raw.githubusercontent.com/jqlang/jq/master/sig/v${JQ_VERSION}/sha256sum.txt"
+            grep 'jq-linux-amd64$' sha256sum.txt | sha256sum -c -
+            install -m 0755 jq-linux-amd64 /usr/local/bin/jq
+          )
           bash tests/scripts/test-export-run-logs.sh
       - name: Bundle distribution (Linux)
         # Exercise the #2005 packaging path on every PR/push: release.yml is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,17 @@ jobs:
         run: ./build/ry_tests
       - name: Test (Ry self-tests)
         run: ./build/ry test
+      - name: Test (export-run-logs JSONL schema, #2300)
+        # `jq` is not in `ry-ci:llvm-21` (gcc:14-trixie base); install a
+        # prebuilt binary inline using the same wget-from-github pattern as
+        # docker/ci.Dockerfile uses for cmake/ninja. Long-term: bake `jq` into
+        # the image and drop this step's install lines.
+        run: |
+          JQ_VERSION=1.7.1
+          wget -qO /usr/local/bin/jq \
+            "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
+          chmod +x /usr/local/bin/jq
+          bash tests/scripts/test-export-run-logs.sh
       - name: Bundle distribution (Linux)
         # Exercise the #2005 packaging path on every PR/push: release.yml is
         # tag-driven and cannot be dry-run, so the bundling + rpath rewrite is

--- a/changelog.d/2300-export-run-logs-tests.md
+++ b/changelog.d/2300-export-run-logs-tests.md
@@ -1,0 +1,3 @@
+### Added
+
+- `tests/scripts/test-export-run-logs.sh` — `scripts/export-run-logs.sh` の JSONL スキーマ契約 (`docs/architecture/jsonl-run-logs.md`) を 1 ケース fixture で検証する pure shell + `jq` ハーネス。`run_meta` / `command` の両レコードに `schema_version: "1"`、必須キー、`summary` ↔ `exit_code` 整合を assert する。あわせて `scripts/export-run-logs.sh` の `schema_version: "1"` リテラル重複を `SCHEMA_VERSION` 変数 1 箇所に抽出して 2 ブロック間の drift を機械的に排除。`/pre-commit-checklist` から `.claude/skills/pre-commit-checklist/run-export-run-logs-tests.sh` 経由で実行可能。(#2300)

--- a/scripts/export-run-logs.sh
+++ b/scripts/export-run-logs.sh
@@ -17,6 +17,12 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+# ---- Constants -------------------------------------------------------------
+
+# JSONL schema version (single source of truth for both record builders, #2300).
+# Schema contract: docs/architecture/jsonl-run-logs.md.
+SCHEMA_VERSION="1"
+
 # ---- Repo root -------------------------------------------------------------
 
 REPO_ROOT="$PWD"
@@ -187,6 +193,7 @@ STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 HOST_OS="$(uname -s)"
 
 jq -nc \
+  --arg schema_version "$SCHEMA_VERSION" \
   --arg run_id "$RUN_ID" \
   --arg started_at "$STARTED_AT" \
   --arg host_os "$HOST_OS" \
@@ -197,7 +204,7 @@ jq -nc \
   --arg ry_version "$RY_VERSION" \
   '{
     record_type: "run_meta",
-    schema_version: "1",
+    schema_version: $schema_version,
     run_id: $run_id,
     started_at: $started_at,
     host_os: $host_os,
@@ -299,6 +306,7 @@ run_one() {
   fi
 
   jq -nc \
+    --arg schema_version "$SCHEMA_VERSION" \
     --arg run_id "$RUN_ID" \
     --arg target "$target" \
     --argjson exit_code "$exit_code" \
@@ -314,7 +322,7 @@ run_one() {
     --args \
     '{
       record_type: "command",
-      schema_version: "1",
+      schema_version: $schema_version,
       run_id: $run_id,
       target: $target,
       command: $ARGS.positional,

--- a/tests/scripts/fixtures/sample.test.ry
+++ b/tests/scripts/fixtures/sample.test.ry
@@ -1,0 +1,7 @@
+from testing import it, describe, expect
+
+@describe("export-run-logs fixture")
+fn exportRunLogsFixtureTests():
+  @it("trivial pass for run-log schema validation")
+  fn trivialPass():
+    expect(1).toEq(1)

--- a/tests/scripts/test-export-run-logs.sh
+++ b/tests/scripts/test-export-run-logs.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Contract test for scripts/export-run-logs.sh JSONL schema (#2300).
+#
+# Runs the script against a 1-case fixture and asserts the run_meta + command
+# record invariants documented in docs/architecture/jsonl-run-logs.md. Drift
+# in any of these surfaces (schema_version literal, summary-line format in
+# src/test_runtime.cpp, summary parser regex in scripts/export-run-logs.sh)
+# fails this test with a focused diagnostic.
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: 'jq' is required by tests/scripts/test-export-run-logs.sh" >&2
+  exit 1
+fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+# Build-dir resolution (RY_BUILD_DIR → build-rust/ → build/) and the
+# "no ry binary" fast-fail are delegated to scripts/export-run-logs.sh
+# itself (lines 121-142). Inheriting RY_BUILD_DIR from our env is enough.
+
+# ---- Scratch output dir ----------------------------------------------------
+# RY_LOG_DIR must be repo-relative (script enforces this at :160). Use a
+# per-PID subdir under .ry-eval/ (which is git-ignored) so concurrent
+# invocations don't collide and so cleanup is local. rm in committed scripts
+# is permitted per AGENTS.md.
+
+SCRATCH=".ry-eval/test-export-run-logs-$$"
+rm -rf "$SCRATCH"
+mkdir -p "$SCRATCH"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+FIXTURE="tests/scripts/fixtures/sample.test.ry"
+if [[ ! -f "$FIXTURE" ]]; then
+  echo "error: fixture not found: $FIXTURE" >&2
+  exit 1
+fi
+
+# ---- Run the script under test ---------------------------------------------
+
+RY_LOG_DIR="$SCRATCH" bash scripts/export-run-logs.sh "$FIXTURE" >/dev/null
+
+# ---- Locate the produced run.jsonl -----------------------------------------
+
+shopt -s nullglob
+candidates=("$SCRATCH"/*/)
+shopt -u nullglob
+if (( ${#candidates[@]} != 1 )); then
+  echo "error: expected exactly one run dir under $SCRATCH, found ${#candidates[@]}" >&2
+  exit 1
+fi
+RUN_DIR="${candidates[0]%/}"
+RUN_JSONL="$RUN_DIR/run.jsonl"
+
+if [[ ! -f "$RUN_JSONL" ]]; then
+  echo "error: $RUN_JSONL was not produced" >&2
+  exit 1
+fi
+
+# `mapfile` is bash 4+; macOS ships bash 3.2 by default, so use a portable
+# read-into-array loop instead.
+records=()
+while IFS= read -r line; do records+=("$line"); done <"$RUN_JSONL"
+if (( ${#records[@]} < 2 )); then
+  echo "error: expected >= 2 JSONL records (run_meta + >= 1 command), got ${#records[@]}" >&2
+  cat "$RUN_JSONL" >&2
+  exit 1
+fi
+
+fail_with_record() {
+  echo "error: $1" >&2
+  echo "  record: $2" >&2
+  exit 1
+}
+
+# ---- Every line parses as JSON (1 jq fork over the whole stream) ----------
+
+if ! jq -e . "$RUN_JSONL" >/dev/null; then
+  echo "error: $RUN_JSONL contains an invalid JSON line (see jq diagnostic above)" >&2
+  exit 1
+fi
+
+# ---- First record: run_meta -----------------------------------------------
+
+first="${records[0]}"
+rt="$(jq -r '.record_type' <<<"$first")"
+if [[ "$rt" != "run_meta" ]]; then
+  fail_with_record "expected first record_type='run_meta', got '$rt'" "$first"
+fi
+
+schema="$(jq -r '.schema_version' <<<"$first")"
+if [[ "$schema" != "1" ]]; then
+  echo "error: run_meta.schema_version != \"1\" (got: '$schema')" >&2
+  echo "       if this is an intentional schema bump, update tests/scripts/test-export-run-logs.sh and docs/architecture/jsonl-run-logs.md." >&2
+  echo "  record: $first" >&2
+  exit 1
+fi
+
+for key in run_id started_at host_os git_sha git_branch git_dirty ry_build_dir; do
+  if ! jq -e --arg k "$key" 'has($k)' <<<"$first" >/dev/null; then
+    fail_with_record "run_meta missing key '$key'" "$first"
+  fi
+done
+
+# ---- Subsequent records: command ------------------------------------------
+
+cmd_count=0
+for line in "${records[@]:1}"; do
+  rt="$(jq -r '.record_type' <<<"$line")"
+  if [[ "$rt" != "command" ]]; then
+    fail_with_record "expected record_type='command' after run_meta, got '$rt'" "$line"
+  fi
+
+  cs="$(jq -r '.schema_version' <<<"$line")"
+  if [[ "$cs" != "1" ]]; then
+    echo "error: command.schema_version != \"1\" (got: '$cs')" >&2
+    echo "       drift between run_meta and command schema_version is the exact failure mode #2300 prevents." >&2
+    echo "  record: $line" >&2
+    exit 1
+  fi
+
+  for key in run_id target command exit_code duration_ms started_at finished_at \
+             stdout_path stderr_path stdout_byte_count summary; do
+    if ! jq -e --arg k "$key" 'has($k)' <<<"$line" >/dev/null; then
+      fail_with_record "command missing key '$key'" "$line"
+    fi
+  done
+
+  cmd_count=$((cmd_count + 1))
+done
+
+if (( cmd_count == 0 )); then
+  echo "error: no command records produced" >&2
+  exit 1
+fi
+
+# ---- Last command: summary parsed AND matches exit_code -------------------
+
+last_cmd="${records[${#records[@]}-1]}"
+summary_json="$(jq -c '.summary' <<<"$last_cmd")"
+exit_code="$(jq -r '.exit_code' <<<"$last_cmd")"
+
+if [[ "$summary_json" == "null" ]]; then
+  echo "error: last command's summary is null." >&2
+  echo "       this indicates drift between the summary parser (scripts/export-run-logs.sh:295-297)" >&2
+  echo "       and the format emitted by src/test_runtime.cpp (__ry_test_summary)." >&2
+  fail_with_record "summary parse failed" "$last_cmd"
+fi
+
+for key in passed failed skipped todo; do
+  if ! jq -e --arg k "$key" 'has($k)' <<<"$summary_json" >/dev/null; then
+    fail_with_record "summary missing key '$key' (got: $summary_json)" "$last_cmd"
+  fi
+done
+
+failed_count="$(jq -r '.failed' <<<"$summary_json")"
+if [[ "$failed_count" == "0" && "$exit_code" != "0" ]]; then
+  echo "error: summary.failed=0 but exit_code=$exit_code." >&2
+  echo "       drift between summary parser and ry exit code." >&2
+  fail_with_record "summary/exit_code mismatch" "$last_cmd"
+fi
+
+# Trivial-pass fixture: exit_code must be 0 and passed must be 1.
+if [[ "$exit_code" != "0" ]]; then
+  fail_with_record "expected exit_code=0 for trivial-pass fixture, got '$exit_code'" "$last_cmd"
+fi
+passed_count="$(jq -r '.passed' <<<"$summary_json")"
+if [[ "$passed_count" != "1" ]]; then
+  fail_with_record "expected summary.passed=1 for trivial-pass fixture, got '$passed_count'" "$last_cmd"
+fi
+
+echo "OK: tests/scripts/test-export-run-logs.sh — ${#records[@]} JSONL records validated ($cmd_count command)"


### PR DESCRIPTION
## Summary

- `scripts/export-run-logs.sh` の JSONL 出力 (外部消費者 `t0k0sh1/ry-code` LoRA 学習パイプラインとの契約) に対する自動テストを新設。`run_meta` / `command` レコードの `schema_version`、必須キー、`summary` ↔ `exit_code` 整合を 1 ケース fixture でアサート。`summary` が黙って `null` になる drift も検出。
- `schema_version: "1"` の 2 ブロックに渡るリテラル重複を `SCHEMA_VERSION` 1 箇所に抽出して drift を機械的に排除 (片方だけ昇格すれば必ずテストが落ちる)。
- `/pre-commit-checklist` ラッパー + SKILL.md 更新 + CI Linux ホストビルドジョブへの 1 ステップ統合。

## Notes

- CI ステップは `ry-ci:llvm-21` (`gcc:14-trixie` ベース) に `jq` がないため、`docker/ci.Dockerfile` の cmake/ninja inline-install パターンで prebuilt linux-amd64 バイナリを wget で取得している。長期的には `jq` を image に焼き込んで install 行を削除するクリーンアップが follow-up 候補。
- Issue で "Optional, lower priority — could be a follow-up" と明示された 2 項目 (`RUN_NONCE` に `$$` 混入 / シンボリックリンク `.test.ry` 探索) は別 follow-up として対象外。

## Test plan

- [x] `bash tests/scripts/test-export-run-logs.sh` → exit 0 (fresh tree)
- [x] `./.claude/skills/pre-commit-checklist/run-export-run-logs-tests.sh` → exit 0
- [x] Drift detection self-test: `SCHEMA_VERSION="2"` に変更してハーネスが `run_meta.schema_version != "1"` で fail する (revert で green) — 旧 `:200`/`:317` の片方だけ書換でも別診断で fail を確認
- [x] `./.claude/skills/pre-commit-checklist/run-tests.sh` → 220 test files pass (新 fixture 含む)
- [x] `./.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` → clean
- [ ] CI: Linux ホストビルドジョブの新ステップが green

Closes #2300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added CI validation for the JSONL schema produced by exported run logs, including required fields and per-record structure checks.
  * Introduced a dedicated contract-style test harness to verify schema version consistency and that `summary` aligns with `exit_code`.

* **Chores**
  * Centralized the exported-log schema version to prevent drift between different parts of the output.
  * Added a changelog entry covering the new test infrastructure and fixture coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->