### PR TITLE
test(map): tighten getPath/setPath compile-time and runtime coverage

### DIFF
--- a/share/std/map.ry
+++ b/share/std/map.ry
@@ -36,6 +36,20 @@ fn remove(map: Map<str, int>, key: str) -> Unit
 # or leaf returns None. Numeric segments resolve to List<any> int indexes
 # when the intermediate any holds a List, or to str keys when it holds a
 # Map (runtime tag dispatch).
+#
+# Path constraints (compile-time errors): the `path` argument must be
+# a string literal — variable-bound paths are rejected. Empty paths
+# (`""`), leading dots (`".a"`), trailing dots (`"a."`), and consecutive
+# dots (`"a..b"`) are rejected as malformed.
+#
+# Numeric segments use base-10 parsing only: `"items.012"` resolves to
+# index 12 (no octal handling). Segments containing a minus sign
+# (`"items.-1"`) are NOT reverse indexes — they fall back to str-key
+# lookup, which yields None on List intermediates.
+#
+# Keys containing '.' are unaddressable: there is no escape syntax,
+# so a Map<str, any> loaded from JSON whose key is `"server.host"`
+# cannot be reached via getPath (the path is always split on '.').
 @public
 @native
 fn getPath(map: Map<str, any>, path: str) -> Option<any>
@@ -46,6 +60,17 @@ fn getPath(map: Map<str, any>, path: str) -> Option<any>
 # The leaf segment is inserted (if new) or updated (if existing).
 # Top-level receiver is COW-checked; intermediate Maps mutate in place,
 # so callers sharing references to a nested Map see the change.
+#
+# Path constraints (compile-time errors) match getPath: the `path`
+# argument must be a string literal; empty / leading-dot / trailing-dot /
+# consecutive-dot paths are rejected.
+#
+# Unlike getPath, setPath cannot write through a List intermediate:
+# every intermediate segment must be a Map<str, any> at runtime, so a
+# List value at any non-leaf segment aborts with "intermediate segment
+# 'X' is not a Map" (e.g. `setPath(m, "items.0", v)` fails on "items",
+# not on the numeric leaf). Reach List elements via direct index
+# assignment instead (`m["items"][0] = v`).
 @public
 @native
 fn setPath(map: Map<str, any>, path: str, value: any) -> Unit

--- a/src/codegen_any.cpp
+++ b/src/codegen_any.cpp
@@ -2060,12 +2060,12 @@ llvm::Value *CodeGen::emitAnyPathStep(llvm::Value *anyVal,
             listHeaderTy_, listPtr, 0, "pathstep.list.len.field");
         llvm::Value *len = builder_.CreateLoad(
             i64Ty_, lenField, "pathstep.list.len");
+        // `*intSegment` is non-negative by `tryParseSegmentInt`'s
+        // invariant (src/codegen_call_collection.cpp), so a negative-
+        // wrap + `idx < 0` check would be dead — only the upper bound
+        // can fire (#2301).
         llvm::Value *idxVal = llvm::ConstantInt::getSigned(i64Ty_, *intSegment);
-        llvm::Value *wrapped = emitNegativeIndexWrap(idxVal, len, "pathstep.list");
-        llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
-        llvm::Value *neg = builder_.CreateICmpSLT(wrapped, zero, "pathstep.list.neg");
-        llvm::Value *over = builder_.CreateICmpSGE(wrapped, len, "pathstep.list.over");
-        llvm::Value *oob = builder_.CreateOr(neg, over, "pathstep.list.oob");
+        llvm::Value *oob = builder_.CreateICmpSGE(idxVal, len, "pathstep.list.oob");
         auto *listHitBB = createBBInFn("pathstep.list_hit", fn);
         emitBranchCond(oob, missBB, listHitBB);
 
@@ -2075,7 +2075,7 @@ llvm::Value *CodeGen::emitAnyPathStep(llvm::Value *anyVal,
         llvm::Value *dataPtr = builder_.CreateLoad(
             ptrTy_, dataField, "pathstep.list.data.ptr");
         llvm::Value *listElemPtr = builder_.CreateGEP(
-            anyTy_, dataPtr, wrapped, "pathstep.list.elem.ptr");
+            anyTy_, dataPtr, idxVal, "pathstep.list.elem.ptr");
         listFoundAny = builder_.CreateLoad(
             anyTy_, listElemPtr, "pathstep.list.elem");
         listFoundEndBB = builder_.GetInsertBlock();

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -13,6 +13,8 @@ namespace {
 // Empty path or any empty segment is a static error (matches the issue
 // #1701 grammar: every segment must be a non-empty identifier-like str).
 // `callee` flows into the diagnostic ("getPath" / "setPath").
+// The "no escape syntax for '.' in keys" limitation falls out of this
+// unconditional split — see share/std/map.ry for the user-facing contract.
 std::vector<std::string> splitDotPath(CodeGen &cg, const std::string &pathStr,
                                        const char *callee) {
     std::vector<std::string> segments;
@@ -37,6 +39,12 @@ std::vector<std::string> splitDotPath(CodeGen &cg, const std::string &pathStr,
 // Returns the segment's int form when it is a non-empty all-digits str;
 // nullopt otherwise. Shared between getPath now and setPath when its
 // List-index support lands.
+//
+// Invariant: the returned value is always >= 0. The all-digits filter
+// excludes '-', so negative inputs are rejected (downstream codegen
+// relies on this — see emitAnyPathStep in src/codegen_any.cpp). Base-10
+// only via std::stoll: "012" → 12, not 10 (no octal handling). User-
+// facing contract is documented at share/std/map.ry.
 std::optional<int64_t> tryParseSegmentInt(const std::string &s) {
     if (s.empty()) return std::nullopt;
     for (char c : s)

--- a/tests/spec/map_path.test.ry
+++ b/tests/spec/map_path.test.ry
@@ -320,3 +320,72 @@ fn questionOpTests():
     cfg: Map<str, any> = {}
     expect(lookupHostGetPath(cfg)).toBeNone()
 
+# Issue #2301: numeric-segment edge cases for `tryParseSegmentInt`
+# (src/codegen_call_collection.cpp:40). The helper uses `std::isdigit`
+# to filter then `std::stoll` for parsing — base-10 only, no negative
+# sign acceptance.
+@describe("getPath: numeric segment edge cases")
+fn getPathNumericEdgeCases():
+  @it("leading zero is parsed as base-10 integer (no octal handling)")
+  fn leadingZeroIsDecimal():
+    # Build a list long enough that index 12 is distinct from index 8.
+    items: List<any> = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130]
+    m: Map<str, any> = {"items": items}
+    case m.getPath("items.012"):
+      Some(v):
+        x: int = v
+        # std::stoll("012") returns 12, NOT 10 (octal).
+        expect(x).toEq(130)
+      None: fail("expected Some(130) at items.012")
+
+  @it("negative-looking segment is treated as a str key, not a reverse index")
+  fn negativeIsStrKey():
+    # tryParseSegmentInt rejects '-' (not a std::isdigit char), so "-1"
+    # falls through to str-key lookup. List<any> has no str-key path, so
+    # getPath returns None — there is no Python-style xs[-1] semantics here.
+    items: List<any> = [10, 20, 30]
+    m: Map<str, any> = {"items": items}
+    expect(m.getPath("items.-1")).toBeNone()
+
+  @it("integer segment exceeding int64 range falls back to str key (None for List)")
+  fn hugeIntegerIsStrKey():
+    # All-digit segment passes the isdigit gate but std::stoll throws
+    # std::out_of_range → tryParseSegmentInt catches and returns nullopt.
+    # The segment is then treated as a str key on the List, yielding None.
+    items: List<any> = [10, 20, 30]
+    m: Map<str, any> = {"items": items}
+    expect(m.getPath("items.99999999999999999999")).toBeNone()
+
+# Issue #2301: COW shared-receiver semantics. The top-level receiver
+# is COW-checked at src/codegen_call_collection.cpp:1547, but the
+# intermediate-walk loop (lines 1571-1616) mutates inner Maps in
+# place. When two aliases share the outer Map, setPath on one writes
+# through to the other's view of the inner Map.
+@describe("setPath: shared-receiver aliasing through intermediate Map")
+fn setPathSharedAliasing():
+  @it("intermediate Map is mutated in place even when the outer Map is aliased")
+  fn intermediateSharedAcrossAliases():
+    inner: Map<str, any> = {"b": 1}
+    m1: Map<str, any> = {"a": inner}
+    m2 = m1
+    m1.setPath("a.b", 99)
+    case m2.getPath("a.b"):
+      Some(v):
+        x: int = v
+        # Top-level COW forks m1's outer Map but the inner Map's Arc
+        # remains shared with m2, so m2 observes the in-place write.
+        expect(x).toEq(99)
+      None: fail("expected Some(99) at m2.a.b")
+
+# Issue #2301: keys containing '.' are unaddressable. `splitDotPath`
+# has no escape syntax, so a Map<str, any> loaded from JSON whose key
+# contains '.' (e.g. "server.host") is never reachable via getPath
+# or dot-sugar — it is always treated as a nested path.
+@describe("getPath: dotted keys in Map are unaddressable")
+fn getPathDottedKeyUnaddressable():
+  @it("Map key containing '.' is never matched by getPath")
+  fn dottedKeyIsSplit():
+    # The key "a.b" exists as a top-level entry, but getPath("a.b")
+    # splits into ["a", "b"] and walks — there is no top-level "a".
+    m: Map<str, any> = {"a.b": 1}
+    expect(m.getPath("a.b")).toBeNone()

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -1543,3 +1543,132 @@ TEST_F(CodeGenTest, ReservedBuiltinAllowsNativeGenericDeclaration) {
         "fn map<T, U>(xs: List<T>, f: fn(T) -> U) -> List<U>\n"
     ));
 }
+
+// ============================================================
+// #2301: getPath / setPath rejection coverage
+//
+// Issue #1701 / PR #2287 added `getPath(map, path)` and
+// `setPath(map, path, value)` for nested Map<str, any> access.
+// `splitDotPath` (src/codegen_call_collection.cpp:17-34) and the
+// per-function receiver/literal checks (lines 1421/1427 for getPath,
+// 1523/1525/1529 for setPath) reject malformed calls at compile time,
+// and the setPath intermediate-walk loop (lines 1571-1616) aborts at
+// runtime when an intermediate segment is missing or not a Map.
+// None of these branches were exercised before #2301.
+//
+// `Map<str, any>` annotation and `m.getPath(...)` / `m.setPath(...)`
+// dispatch flow through `emitCollOp_getPath` / `emitCollOp_setPath`
+// in src/codegen_call_collection.cpp — no `from map import` is needed,
+// so these tests work in the ModuleLoader-less compileSource harness.
+// ============================================================
+
+TEST_F(CodeGenTest, GetPathEmptyPathRejected) {
+    expectCompileError(
+        "m: Map<str, any> = {}\n"
+        "m.getPath(\"\")\n",
+        "getPath() path has empty trailing segment");
+}
+
+TEST_F(CodeGenTest, GetPathLeadingDotRejected) {
+    expectCompileError(
+        "m: Map<str, any> = {}\n"
+        "m.getPath(\".a\")\n",
+        "getPath() path has empty segment");
+}
+
+TEST_F(CodeGenTest, GetPathTrailingDotRejected) {
+    expectCompileError(
+        "m: Map<str, any> = {}\n"
+        "m.getPath(\"a.\")\n",
+        "getPath() path has empty trailing segment");
+}
+
+TEST_F(CodeGenTest, GetPathNonAnyValueTypeRejected) {
+    expectCompileError(
+        "m: Map<str, int> = {\"a\": 1}\n"
+        "m.getPath(\"a\")\n",
+        "getPath() receiver value type must be `any`");
+}
+
+TEST_F(CodeGenTest, GetPathNonLiteralPathRejected) {
+    expectCompileError(
+        "m: Map<str, any> = {}\n"
+        "p = \"a\"\n"
+        "m.getPath(p)\n",
+        "getPath() currently requires a string literal path");
+}
+
+TEST_F(CodeGenTest, SetPathEmptyPathRejected) {
+    expectCompileError(
+        "m: Map<str, any> = {}\n"
+        "m.setPath(\"\", 1)\n",
+        "setPath() path has empty trailing segment");
+}
+
+TEST_F(CodeGenTest, SetPathLeadingDotRejected) {
+    expectCompileError(
+        "m: Map<str, any> = {}\n"
+        "m.setPath(\".a\", 1)\n",
+        "setPath() path has empty segment");
+}
+
+TEST_F(CodeGenTest, SetPathTrailingDotRejected) {
+    expectCompileError(
+        "m: Map<str, any> = {}\n"
+        "m.setPath(\"a.\", 1)\n",
+        "setPath() path has empty trailing segment");
+}
+
+TEST_F(CodeGenTest, SetPathNonAnyValueTypeRejected) {
+    expectCompileError(
+        "m: Map<str, int> = {\"a\": 1}\n"
+        "m.setPath(\"a\", 1)\n",
+        "setPath() receiver value type must be `any`");
+}
+
+TEST_F(CodeGenTest, SetPathNonLiteralPathRejected) {
+    expectCompileError(
+        "m: Map<str, any> = {}\n"
+        "p = \"a\"\n"
+        "m.setPath(p, 1)\n",
+        "setPath() currently requires a string literal path");
+}
+
+// setPath runtime aborts: intermediate-walk loop in
+// src/codegen_call_collection.cpp:1571-1616 emits
+// `__ry_runtime_error` + `_Exit(1)` when an intermediate segment is
+// missing or is not a Map. Use `EXPECT_EXIT` to assert both message
+// and exit code.
+
+TEST_F(CodeGenTest, SetPathIntermediateMissAborts) {
+    EXPECT_EXIT(
+        runSource(
+            "m: Map<str, any> = {}\n"
+            "m.setPath(\"a.b\", 1)\n"),
+        ::testing::ExitedWithCode(1),
+        "setPath 'a\\.b': intermediate segment 'a' not found");
+}
+
+TEST_F(CodeGenTest, SetPathIntermediateNotMapAborts) {
+    EXPECT_EXIT(
+        runSource(
+            "m: Map<str, any> = {\"a\": 42}\n"
+            "m.setPath(\"a.b\", 1)\n"),
+        ::testing::ExitedWithCode(1),
+        "setPath 'a\\.b': intermediate segment 'a' is not a Map");
+}
+
+// setPath cannot write into List intermediates (asymmetric with
+// getPath, which dispatches numeric segments to list indices via
+// `emitAnyPathStep`). The setPath intermediate-walk loop only checks
+// `tag == RyAnyTag::Map`, so a List-tagged intermediate falls through
+// to the "is not a Map" error path. Documented in share/std/map.ry.
+TEST_F(CodeGenTest, SetPathListIntermediateAborts) {
+    EXPECT_EXIT(
+        runSource(
+            "items: List<any> = [1]\n"
+            "m: Map<str, any> = {\"items\": items}\n"
+            "m.setPath(\"items.0\", 9)\n"),
+        ::testing::ExitedWithCode(1),
+        "setPath 'items\\.0': intermediate segment 'items' is not a Map");
+}


### PR DESCRIPTION
## Summary

- Adds 18 tests pinning previously-uncovered `getPath` / `setPath` behavior: 13 in `tests/test_codegen_fail.cpp` (10 compile-time rejections + 3 runtime aborts) and 5 in `tests/spec/map_path.test.ry` (numeric edge cases, COW shared-receiver aliasing, dotted-key unaddressability).
- Documents four previously-implicit constraints in `share/std/map.ry` (string-literal path, empty/dot-segment rejection, base-10 numeric segments, setPath cannot write through a List intermediate, dotted keys unaddressable). Cross-references the user-facing contract from `splitDotPath` and `tryParseSegmentInt`.
- Drops the dead `emitNegativeIndexWrap` call in `emitAnyPathStep`'s List arm (`tryParseSegmentInt` rejects '-', so the negative-wrap was unreachable). Behavior-preserving IR cleanup.

## Test plan

- [x] `./build-rust/ry_tests --gtest_filter='*GetPath*:*SetPath*'` (13 new tests pass)
- [x] `./build-rust/ry test tests/spec/map_path.test.ry` (36 pass, 31 existing + 5 new)
- [x] Full `ry_tests` under ASan+UBSan (clean)
- [x] Full `ry_tests` under TSan (clean; only pre-existing `siglongjmp`-skipped tests)
- [x] Static analysis (clang-tidy / cppcheck / scan-build): clean

## Side finding (not addressed in this PR)

`CodeGenTest.HttpConnectionClose` is flaky under the full `ry_tests` suite (single-test reruns: 5/5 PASS; `Http*` filter: 6/6 PASS). bug-forensics-analyst traced this to fixed-port test design (port 18935 + 200 ms `sleep`) introduced in commit 49a616c4 (#79), unrelated to this PR's changes. Recommend filing as a separate issue.

Closes #2301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed numeric path segment parsing to use base-10 only; minus-sign segments now treated as string keys rather than reverse indices.
  * Updated list indexing to remove negative index wrapping behavior.
  * Clarified that Map keys containing dots are unaddressable via dotted paths.

* **Tests**
  * Added comprehensive regression test coverage for nested-path access edge cases and list/Map interaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->