### PR TITLE
fix(codegen): reject overflowing literal and range type bounds without aborting

### DIFF
--- a/changelog.d/2307-reject-overflowing-type-constraint-bounds.md
+++ b/changelog.d/2307-reject-overflowing-type-constraint-bounds.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `parseTypeConstraint` (`src/codegen_type.cpp`) が単一整数リテラル型 / 範囲型の上下境界 / 整数リテラル union のメンバーで `int64_t` を超える値を受け取った際、`std::stoll` の uncaught `std::out_of_range` でプロセス全体が abort (`libc++abi: ... stoll: out of range`, exit 134) する問題を修正。`src/parser/parser_decl.cpp:951-955` の固定長配列サイズで既に確立されている `std::strtoll` + `errno == ERANGE` + end-pointer + empty-string check のパターンを移植した file-local テンプレート helper `parseInt64Bound` を導入し、4 箇所 (`std::stoll`) の呼び出しを差し替えた。失敗時は `codegenError` 経由で通常のコンパイル診断 (`integer literal out of range in type constraint: <value>` / `range low bound out of range ...` / `range high bound out of range ...`) を返す。 (#2307)

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -3,6 +3,9 @@
 #include "ry/llvm_emit/cast_helpers.hpp"
 #include "ry/stdlib_registry.hpp"
 
+#include <cerrno>
+#include <cstdlib>
+
 
 namespace ry {
 
@@ -536,16 +539,31 @@ bool CodeGen::isLiteralUnionType(const std::string &typeName) {
     return ry::util::isLiteralUnionType(typeName);
 }
 
+// Safe std::strtoll wrapper for type constraint integer literals.
+// Rejects empty, trailing-garbage, and out-of-int64 inputs via the caller-
+// supplied error callback. Mirrors src/parser/parser_decl.cpp:951-955.
+template<typename ErrorFn>
+static int64_t parseInt64Bound(const std::string &what,
+                               const std::string &s, ErrorFn error) {
+    char *end = nullptr;
+    errno = 0;
+    int64_t val = std::strtoll(s.c_str(), &end, 10);
+    if (s.empty() || errno == ERANGE || end != s.c_str() + s.size())
+        error(what + " out of range in type constraint: " + s);
+    return val;
+}
+
 std::optional<CodeGen::TypeConstraint> CodeGen::parseTypeConstraint(const std::string &typeName) {
     // Callers are responsible for resolving type aliases before calling this function.
+    auto err = [this](const std::string &m) { codegenError(m); };
 
     // Range type: "1..12"
     if (isRangeType(typeName)) {
         auto pos = typeName.find("..");
         TypeConstraint tc;
         tc.kind = TypeConstraint::Kind::IntRange;
-        tc.range_low = std::stoll(typeName.substr(0, pos));
-        tc.range_high = std::stoll(typeName.substr(pos + 2));
+        tc.range_low = parseInt64Bound("range low bound", typeName.substr(0, pos), err);
+        tc.range_high = parseInt64Bound("range high bound", typeName.substr(pos + 2), err);
         if (tc.range_low > tc.range_high)
             codegenError("invalid range type: low bound " +
                 std::to_string(tc.range_low) + " > high bound " +
@@ -557,7 +575,7 @@ std::optional<CodeGen::TypeConstraint> CodeGen::parseTypeConstraint(const std::s
     if (isIntLiteralType(typeName)) {
         TypeConstraint tc;
         tc.kind = TypeConstraint::Kind::IntLiteral;
-        tc.int_values.push_back(std::stoll(typeName));
+        tc.int_values.push_back(parseInt64Bound("integer literal", typeName, err));
         return tc;
     }
 
@@ -584,7 +602,7 @@ std::optional<CodeGen::TypeConstraint> CodeGen::parseTypeConstraint(const std::s
             tc.kind = TypeConstraint::Kind::IntLiteral;
             tc.int_values.reserve(components.size());
             for (auto &c : components)
-                tc.int_values.push_back(std::stoll(c));
+                tc.int_values.push_back(parseInt64Bound("integer literal", c, err));
             return tc;
         }
 

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -2609,6 +2609,42 @@ TEST_F(CodeGenTest, TypeAliasRefinedTypes) {
         "print(d)"), "5\n");
 }
 
+// ===== Type constraint integer overflow (#2307) =====
+
+TEST_F(CodeGenTest, TypeConstraintIntOverflow) {
+    // Single int literal — large positive overflow
+    expectCompileError("x: 999999999999999999999999999999 = 1",
+                       "out of range in type constraint");
+    // Single int literal — large negative overflow
+    // (isIntLiteralType in src/util/type_name.cpp accepts a leading '-')
+    expectCompileError("x: -999999999999999999999999999999 = 1",
+                       "out of range in type constraint");
+    // Single int literal — INT64_MAX + 1
+    expectCompileError("x: 9223372036854775808 = 1",
+                       "out of range in type constraint");
+    // Single int literal — INT64_MIN - 1
+    expectCompileError("x: -9223372036854775809 = 1",
+                       "out of range in type constraint");
+
+    // Range type — low bound overflow
+    expectCompileError("x: 999999999999999999999999999999..1 = 1",
+                       "out of range in type constraint");
+    // Range type — high bound overflow
+    expectCompileError("x: 1..999999999999999999999999999999 = 1",
+                       "out of range in type constraint");
+    // Range type — negative low bound overflow
+    expectCompileError("x: -9223372036854775809..1 = 1",
+                       "out of range in type constraint");
+
+    // Int-literal union — one overflow member
+    expectCompileError("x: 1 | 999999999999999999999999999999 | 3 = 1",
+                       "out of range in type constraint");
+
+    // Sanity guard: INT64_MAX still compiles and runs.
+    EXPECT_EQ(runSource("x: 9223372036854775807 = 9223372036854775807\nprint(x)"),
+              "9223372036854775807\n");
+}
+
 // ===== Function type alias =====
 
 TEST_F(CodeGenTest, TypeAliasFnType) {


### PR DESCRIPTION
## Summary

- `CodeGen::parseTypeConstraint` (`src/codegen_type.cpp`) で `std::stoll` を 4 箇所無防備に呼んでおり、`x: 999999999999999999999999999999999999999999 = 1` や `x: N..M = 1` 形式のユーザ入力で uncaught `std::out_of_range` が投げられ `libc++abi` が exit 134 でプロセスを abort していた問題を修正。
- File-local テンプレート helper `parseInt64Bound`（`std::strtoll` + `errno == ERANGE` + end-pointer + empty-string check）を追加し、`src/parser/parser_decl.cpp:951-955` の固定長配列サイズと同じパターンで `codegenError` 経由の通常診断を返すように変更（single literal / range low / range high / int-literal union member の 4 サイト）。
- 検出テスト `CodeGenTest.TypeConstraintIntOverflow` を `tests/test_codegen_stmt.cpp` に追加（正/負オーバーフロー、INT64_MAX±1 境界、range 上下境界、union メンバー、INT64_MAX sanity の 9 ケース）。

## Test plan

- [x] Red 確認: 修正前は `unknown C++ exception thrown` で test process abort
- [x] Green 確認: 新規 `CodeGenTest.TypeConstraintIntOverflow` 9/9 pass
- [x] 隣接群: `CodeGenTest.RangeType* / IntLiteralType* / StrLiteralType* / TypeAliasRefinedTypes` 7/7 pass
- [x] フル: `CodeGenTest.*` 1107/1107 pass
- [x] Smoke: `./build-rust/ry run /tmp/repro2307_lit.ry` / `…_range.ry` が exit 1 で `error: integer literal out of range in type constraint: …` / `range low bound out of range in type constraint: …` を表示（libc++abi abort 134 ではない）
- [x] `/pre-commit-checklist`: tests 219/219, ASan 219/219, TSan 219/219, static-analysis advisory のみ（`main.cpp` 既存 dead-store 警告で変更箇所と無関係）

Closes #2307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when type constraints contained overflowing integer values. Out-of-range integers in type constraints now produce proper compile diagnostics instead of terminating the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->