### PR TITLE
fix(codegen): reject overflowing tuple field indices without aborting

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -166,8 +166,10 @@ entry above for integer literal parsing.
 - `src/parser/parser_decl.cpp:787` — fixed in #1259 (array size `T[N]`)
 - `src/codegen_type.cpp:133` — inline-array type resolution from
   string name; still unfixed (#1281 proposed a fix, closed not-planned)
-- `src/codegen_expr_literal.cpp:109` — tuple numeric field access
-  (`.0`, `.1`, ...); still unfixed (#1281 proposed a fix, closed not-planned)
+- `src/codegen_expr_literal.cpp` — tuple numeric field access
+  (`.0`, `.1`, ...); fixed in #2308 (inline `std::strtoul` + `errno` /
+  end-pointer guard, routing failures through the existing
+  `tuple index <field> out of range` diagnostic)
 
 **How to apply**: When you see a new `std::sto*` call anywhere in
 `src/parser*.cpp`, `src/codegen*.cpp`, or any frontend path that

--- a/changelog.d/2308-reject-overflowing-tuple-index.md
+++ b/changelog.d/2308-reject-overflowing-tuple-index.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `CodeGen::emitExprVariant(FieldAccessExpr)` (`src/codegen_expr_literal.cpp`) が `unsigned long` を超える数値タプルフィールドインデックス (例: `t.999999999999999999999999999999999999999999`) を受け取った際、`std::stoul` の uncaught `std::out_of_range` でプロセス全体が abort (`libc++abi: ... stoul: out of range`, exit 134) する問題を修正。`src/parser/parser_decl.cpp:951-955` の固定長配列サイズで既に確立されている `std::strtoul` + `errno == ERANGE` + end-pointer check のパターンを移植し、parse 失敗時は既存の `tuple index <field> out of range` 診断にルーティングする (ユーザー可視診断は不変)。 (#2308)

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -2,6 +2,9 @@
 #include "ry/llvm_emit/api.h"
 #include "ry/llvm_emit/cast_helpers.hpp"
 
+#include <cerrno>
+#include <cstdlib>
+
 
 namespace ry {
 
@@ -288,8 +291,14 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e)
 
     // Numeric index access for tuples (.0, .1, ...)
     if (!e->field.empty() && std::isdigit(static_cast<unsigned char>(e->field[0]))) {
-        auto idx = std::stoul(e->field);
-        if (idx >= structTy->getNumElements())
+        // std::stoul throws std::out_of_range on overflow, which propagates
+        // uncaught and aborts the process; use strtoul + errno/end-pointer.
+        char *end = nullptr;
+        errno = 0;
+        unsigned long idx = std::strtoul(e->field.c_str(), &end, 10);
+        bool parseFailed = (errno == ERANGE) ||
+                           (end != e->field.c_str() + e->field.size());
+        if (parseFailed || idx >= structTy->getNumElements())
             codegenError("tuple index " + e->field + " out of range");
         llvm::Value *fieldVal = builder_.CreateExtractValue(
             obj, static_cast<unsigned>(idx), "tuple." + e->field);

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -2645,6 +2645,28 @@ TEST_F(CodeGenTest, TypeConstraintIntOverflow) {
               "9223372036854775807\n");
 }
 
+// ===== Tuple field index integer overflow (#2308) =====
+
+TEST_F(CodeGenTest, TupleIndexOverflow) {
+    // Oversized decimal index (42 nines) used to abort via uncaught
+    // std::out_of_range from std::stoul; must surface the normal diagnostic.
+    expectCompileError(
+        "t = (1, 2)\nprint(t.999999999999999999999999999999999999999999)",
+        {"tuple index", "out of range"});
+
+    // ULONG_MAX + 1 — just past the strtoul boundary on 64-bit unsigned long.
+    expectCompileError("t = (1, 2)\nprint(t.18446744073709551616)",
+                       "tuple index");
+
+    // In-bounds-but-too-large index keeps the existing wording untouched.
+    expectCompileError("t = (1, 2)\nprint(t.2)",
+                       "tuple index 2 out of range");
+
+    // In-bounds numeric field access still works.
+    EXPECT_EQ(runSource("t = (10, 20)\nprint(t.0)\nprint(t.1)"),
+              "10\n20\n");
+}
+
 // ===== Function type alias =====
 
 TEST_F(CodeGenTest, TypeAliasFnType) {


### PR DESCRIPTION
## Summary

- `emitExprVariant(FieldAccessExpr)` (`src/codegen_expr_literal.cpp`) parsed tuple numeric field names (`.0`, `.1`, …) with `std::stoul`, which threw `std::out_of_range` on overflow and aborted the JIT (exit 134 / `libc++abi: ... stoul: out of range`) before the existing `tuple index <field> out of range` diagnostic could fire.
- Replaced with `std::strtoul` + `errno == ERANGE` + end-pointer check (mirroring `src/parser/parser_decl.cpp:951-955`); failures route through the same `codegenError` so the user-visible diagnostic is unchanged.
- Closes the last unfixed entry in `.claude/rules/parser-conventions.md` "Known hit sites" for the `std::sto*` exception-safety rule (`codegen_type.cpp:133` remains a separately tracked open hit site).

## Test plan

- [x] Red→Green confirmed: `CodeGenTest.TupleIndexOverflow` fails pre-fix with "Unknown C++ exception thrown" (uncaught `std::out_of_range`), passes post-fix.
- [x] Tuple regression: `CodeGenTest.Tuple*` (9 tests) all green.
- [x] CLI repro: `t = (1, 2); print(t.999…)` now exits 1 with `error: tuple index ... out of range` (was exit 134).
- [x] `/pre-commit-checklist`: host tests (219 self-tests + C++), scan-build, ASan+UBSan (Docker), TSan (Docker), prompt-refs lint — all green.

Closes #2308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compiler crash when accessing tuple fields with extremely large indices. The compiler now produces a proper error message (`tuple index out of range`) instead of aborting unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->