### PR TITLE
ci(codeql): focus C/C++ analysis on production target

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -2,6 +2,7 @@
 paths:
   - ".github/workflows/**/*.yml"
   - ".github/actions/**/*.yml"
+  - ".github/codeql/**/*.yml"
 ---
 
 # CI Workflows
@@ -52,7 +53,9 @@ Release gating on CodeQL must filter runs to `event=push`, poll first for run ex
 
 **Tags**: ci, codeql, static-analysis, performance, target
 
-C/C++ CodeQL builds target `ry` on `pull_request`; pushes to `main` build all. Do not narrow the push side.
+C/C++ CodeQL builds target `ry` on both `pull_request` and push to `main`. This keeps Code Scanning focused on production CLI/runtime TUs; tests, fuzz harnesses, and generated build-tree probes are covered by their own jobs. For compiled languages with manual builds, the build step is the enforcement point; `.github/codeql/codeql-config.yml` `paths-ignore` is a supporting filter.
+
+Verify: `grep -n 'cmake --build build --target ry --parallel' .github/workflows/codeql.yml` matches.
 
 ### Artifact patterns
 

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+# CodeQL Advanced config: focus Code Scanning dashboard on production
+# C/C++ code under src/ and include/. Test / fuzz / generated trees are
+# covered by asan / ubsan / fuzz jobs and do not need a second pass via
+# CodeQL.
+paths-ignore:
+  - tests
+  - build
+  - 'build-*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,6 +63,7 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         trap-caching: false
+        config-file: .github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
@@ -79,12 +80,13 @@ jobs:
     - name: Build
       if: matrix.build-mode == 'manual'
       shell: bash
-      # PR runs analyse only the `ry` target (~76 TU) for faster feedback;
-      # push-to-main keeps full default-target coverage. See
-      # .claude/rules/ci-workflows.md "Static-analysis PR scope: --target ry on PR ...".
+      env:
+        RY_ENV: internal
+      # Analyze the production CLI/runtime target only; tests, fuzz harnesses,
+      # and build-tree probes are covered by their own CI jobs.
       run: |
         cmake --preset default
-        cmake --build build ${{ github.event_name == 'pull_request' && '--target ry' || '' }} --parallel
+        cmake --build build --target ry --parallel
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- Add `.github/codeql/codeql-config.yml` with `paths-ignore` for tests, build trees, and generated build directories.
- Wire the CodeQL workflow to that config file.
- Build only the production `ry` target for C/C++ CodeQL analysis on both PR and push-to-main runs.
- Update the CI workflow rule to keep the CodeQL scope decision aligned with the workflow.

## Rationale

For compiled languages with a manual build, the build command determines which C/C++ translation units CodeQL traces. The config file is still useful as a supporting filter, but the effective exclusion of tests, fuzz harnesses, and generated build-tree probes comes from building `--target ry`.

Closes #2346.

## Verification

- `ruby -ryaml -e 'YAML.load_file(".claude/rules/ci-workflows.md"); YAML.load_file(".github/workflows/codeql.yml"); YAML.load_file(".github/codeql/codeql-config.yml"); puts "yaml ok"'`
- `git diff --check origin/main..HEAD`
- `./.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh`

## Follow-up validation

The Code Scanning dashboard impact requires the pushed workflow to run on GitHub; local verification cannot prove the dashboard alert delta.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL configuration to focus scanning on production by excluding test and build paths.
  * Updated the CodeQL workflow to use the new configuration and standardized the build target to consistently build the production CLI/runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->