### PR TITLE
feat: extend ry.* allowlist to include ry.net and ry.json5

### DIFF
--- a/changelog.d/2309-ry-namespace-net-json5.md
+++ b/changelog.d/2309-ry-namespace-net-json5.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `ry.*` 予約 namespace の公開 allowlist に `ry.net` と `ry.json5` を追加し、13 モジュールに拡張。`from ry.net import bind` / `import ry.net` / `from ry.json5 import load, stringify` / `import ry.json5` が canonical な書き方として解決するようになる。bare 形式 (`from net import …` / `from json5 import …`) は compatibility alias として引き続き動作。`ry.bogus` 等を reject する際の `available: …` リストも 13 件表示に追従する。 (#2309)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -58,7 +58,7 @@ See [Module Reference — Visibility](modules.md#visibility) for the practical v
 
 The **canonical reserved namespace** for the official standard library, introduced in v0.0.30 (#1769). Documented public stdlib modules are addressable under the `ry.*` path: the implicit prelude is `ry.lang`, and each public submodule lives under `ry.<module>`.
 
-The full set of public modules accepted via `ry.*` is the 11 documented entries: `ry.lang`, `ry.math`, `ry.io`, `ry.path`, `ry.filesystem`, `ry.json`, `ry.http`, `ry.thread`, `ry.regex`, `ry.testing`, `ry.base64`. Anything else under the `ry.*` prefix — including internal stdlib helpers such as `ry.builtins`, `ry.gc`, `ry.core`, `ry.runtime_internal`, and any module not on the documented list — is **rejected** with an error that lists the public modules. Bare modules that exist as compatibility aliases (e.g. `net`, `json5`) are not part of the `ry.*` surface and must be imported with their bare names.
+The full set of public modules accepted via `ry.*` is the 13 documented entries: `ry.lang`, `ry.math`, `ry.io`, `ry.path`, `ry.filesystem`, `ry.json`, `ry.http`, `ry.thread`, `ry.regex`, `ry.testing`, `ry.base64`, `ry.net`, `ry.json5`. Anything else under the `ry.*` prefix — including internal stdlib helpers such as `ry.builtins`, `ry.gc`, `ry.core`, `ry.runtime_internal`, and any module not on the documented list — is **rejected** with an error that lists the public modules. Every documented module is also addressable through its bare alias (`math`, `net`, `json5`, …) for source-level compatibility; the canonical `ry.*` form is recommended for new code.
 
 Two import shapes resolve through this namespace:
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -265,6 +265,8 @@ Since v0.0.30 (#1769) the canonical namespace for all official stdlib modules is
 | `ry.regex` | `regex` / `std.regex` | Regular expressions |
 | `ry.testing` | `testing` / `std.testing` | Test framework intrinsics |
 | `ry.base64` | `base64` / `std.base64` | Base64 encode / decode |
+| `ry.net` | `net` / `std.net` | TCP / TLS socket primitives |
+| `ry.json5` | `json5` / `std.json5` | JSON5 parse / stringify |
 
 All three spellings resolve to the same physical modules; the canonical `ry.*` form is recommended for new code.
 

--- a/src/module/module_loader.cpp
+++ b/src/module/module_loader.cpp
@@ -23,14 +23,16 @@ using ry::emitTraceDiagnostic;
 using ry::emitTraceEvent;
 
 // #2297: 公開 stdlib モジュール許可リスト。#1769 で `ry.*` の public surface
-// として列挙された 11 モジュールのみ受理し、それ以外は internal とみなして
+// として列挙された 13 モジュールのみ受理し、それ以外は internal とみなして
 // reject する。`StdlibRegistry` は codegen dispatch table で「dispatcher を持つ
 // package」を列挙するもので意図が異なるため、ここで独立に policy を維持する
 // (例: `runtime_internal` は dispatch を持つが internal、逆に `lang` / `regex` /
-// `filesystem` / `testing` は dispatcher を持たないが public)。
-static constexpr std::array<std::string_view, 11> kPublicRyModules = {
+// `filesystem` / `testing` は dispatcher を持たないが public)。v0.0.30 で
+// `net` / `json5` を追加 (#2309)。
+static constexpr std::array<std::string_view, 13> kPublicRyModules = {
     "lang", "math", "io", "path", "filesystem", "json",
     "http", "thread", "regex", "testing", "base64",
+    "net", "json5",
 };
 
 static bool isPublicRyModule(std::string_view first_segment) {
@@ -576,7 +578,7 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
                 "use 'ry.<module>' (e.g. 'ry.lang', 'ry.math')");
         }
 
-        // #2297: stdlib allowlist — `ry/<sub>` の `<sub>` が #1769 列挙の 11
+        // #2297: stdlib allowlist — `ry/<sub>` の `<sub>` が #1769 列挙の 13
         // module のいずれでなければ reject。`ry.builtins` / `ry.gc` / `ry.core`
         // 等の internal module だけでなく、`ry.math.internal` のようなネスト
         // パスも reject する (public surface は **完全な enumeration** であり、

--- a/tests/spec/ry_namespace/ry_module_import.test.ry
+++ b/tests/spec/ry_namespace/ry_module_import.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe, expect
+from testing import it, describe, expect, fail
 
 # #1769: ry.<module> form resolves to the same physical modules as the
 # legacy flat / std spellings. The three intrinsic gating paths
@@ -6,6 +6,12 @@ from testing import it, describe, expect
 # accept the ry.* spelling as canonical.
 from ry.math import sqrt, PI
 from ry.regex import Match, regexFindAll
+
+# #2309: ry.net / ry.json5 joined the public allowlist in v0.0.30 alongside
+# ry.base64. The canonical spelling must resolve to the same physical modules
+# as the bare aliases (`from net import ...` / `from json5 import ...`).
+from ry.net import bind, listenerPort
+from ry.json5 import load, stringify
 
 # coexistence: importing the same physical module via both ry.* and flat
 # must round-trip to identical values.
@@ -28,3 +34,21 @@ fn ryModuleImportTests():
     expect(len(matches)).toEq(2)
     expect(matches[0].full).toEq("123")
     expect(matches[1].full).toEq("456")
+
+  @it("from ry.net import bind exposes the net primitives (#2309)")
+  fn shouldResolveNetBind():
+    case bind("127.0.0.1", 0):
+      Ok(server):
+        port = listenerPort(server)
+        close(server)
+        expect(port > 0).toEq(true)
+      Err(e):
+        fail("ry.net bind unexpectedly failed: " + e.message)
+
+  @it("from ry.json5 import load + stringify roundtrips through the json5 module (#2309)")
+  fn shouldResolveJson5Roundtrip():
+    case load[int]("42"):
+      Ok(v):
+        expect(stringify(v)).toEq("42")
+      Err(e):
+        fail("ry.json5 load unexpectedly failed: " + e.message)

--- a/tests/spec/ry_namespace/ry_qualified_import.test.ry
+++ b/tests/spec/ry_namespace/ry_qualified_import.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe, expect
+from testing import it, describe, expect, fail
 
 # #1769: `import ry.<mod>` is the qualified form of the canonical
 # reserved-namespace import. The bare name (`math`) is the last segment,
@@ -8,6 +8,10 @@ import ry.math
 # Alias form: rebind ry.math under a different bare name so it could coexist
 # alongside a hypothetical `import math` without parser collision.
 import ry.math as ryMath
+
+# #2309: ry.net / ry.json5 joined the public allowlist in v0.0.30.
+import ry.net
+import ry.json5
 
 @describe("import ry.* qualified namespace (#1769)")
 fn ryQualifiedImportTests():
@@ -22,3 +26,17 @@ fn ryQualifiedImportTests():
     # contract documented in docs/reference/modules.md.
     expect(ryMath.sqrt(16.0)).toEq(4.0)
     expect(ryMath.PI).toEq(math.PI)
+
+  @it("import ry.net exposes the net namespace at its bare last segment (#2309)")
+  fn shouldExposeNetSegment():
+    case net.bind("127.0.0.1", 0):
+      Ok(server):
+        port = net.listenerPort(server)
+        close(server)
+        expect(port > 0).toEq(true)
+      Err(e):
+        fail("ry.net qualified bind unexpectedly failed: " + e.message)
+
+  @it("import ry.json5 exposes the json5 namespace at its bare last segment (#2309)")
+  fn shouldExposeJson5Segment():
+    expect(json5.stringify(42)).toEq("42")

--- a/tests/test_ry_namespace_warning.cpp
+++ b/tests/test_ry_namespace_warning.cpp
@@ -241,6 +241,12 @@ TEST_F(RyNamespaceWarningTest, InternalStdlibModuleRejectedWithHint) {
         << "error should list 'ry.lang' in available modules: " << r.err;
     EXPECT_NE(r.err.find("ry.math"), std::string::npos)
         << "error should list 'ry.math' in available modules: " << r.err;
+    // #2309: net / json5 を allowlist に追加した後、エラーリストの 13 件表示
+    // (`ry.base64, ry.net, ry.json5` を含む) を回帰でロックする。
+    EXPECT_NE(r.err.find("ry.net"), std::string::npos)
+        << "error should list 'ry.net' in available modules (#2309): " << r.err;
+    EXPECT_NE(r.err.find("ry.json5"), std::string::npos)
+        << "error should list 'ry.json5' in available modules (#2309): " << r.err;
 }
 
 TEST_F(RyNamespaceWarningTest, BogusRyModuleErrorUsesDotSpelling) {


### PR DESCRIPTION
## Summary

`kPublicRyModules` allowlist に `net` / `json5` を追加し、canonical な `ry.<mod>` 表記での import を 13 モジュールに揃える。

- `from ry.net import bind` / `import ry.net` / `from ry.json5 import load, stringify` / `import ry.json5` がすべて解決
- bare alias (`from net import …` / `from json5 import …`) は引き続き compat として動作
- エラーメッセージの "available: …" リストは 13 件表示に自動追従 (動的生成)

Closes #2309

## Test plan

- [x] `./build-rust/ry_tests --gtest_filter='RyNamespaceWarningTest.*'` — 10/10 pass (新しい `ry.net` / `ry.json5` の positive assertion 含む)
- [x] `./build-rust/ry_tests` フル — 2939/2939 pass
- [x] `./build-rust/ry test -p` — 219 ファイル / 0 failure
- [x] `./build-rust/ry test tests/spec/ry_namespace/{ry_module_import,ry_qualified_import,ry_lang_import}.test.ry` — 12/12 pass
- [x] `./build-rust/ry test tests/spec/{net,json5}.test.ry` — bare 形式 regression なし (11/11, 68/68)
- [x] Manual: `from ry.bogus import x` のエラーが `available: ry.lang, …, ry.base64, ry.net, ry.json5` の 13 件表示
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended the public standard library to include `ry.net` and `ry.json5` modules, bringing the total public namespace to 13 modules.
  * `ry.net` provides TCP/TLS socket primitives via `bind` and related functions.
  * `ry.json5` enables JSON5 parsing and serialization via `load` and `stringify` functions.
  * Both modules support canonical import forms and bare compatibility aliases for existing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->