### PR TITLE
feat(module): warn on legacy stdlib import forms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,6 +497,7 @@ add_executable(ry_tests
     tests/test_emit_llvm_ir.cpp
     tests/test_deprecated_warnings.cpp
     tests/test_ry_namespace_warning.cpp
+    tests/test_legacy_import_warnings.cpp
     tests/test_codegen_call_json_reject.cpp
     tests/test_codegen_call_json5_reject.cpp
     tests/test_spec_timeout.cpp

--- a/changelog.d/2350-deprecate-legacy-stdlib-imports.md
+++ b/changelog.d/2350-deprecate-legacy-stdlib-imports.md
@@ -1,0 +1,3 @@
+### Changed
+
+- legacy な stdlib import 形式 (`from math import …` / `from std.math import …` / `from std import …` / `import math` 等) を import 解決時に検出し、stderr へ one-time deprecation warning を発するようにした。canonical な `ry.*` 形式 (`from ry.math import …` / `import ry.math` / `from ry.lang import …` 等) を提示する。動作は変わらず legacy 形式は引き続き解決可能 (将来のリリースで reject 予定)。dedup は元の spelling 単位で 1 回のみ。`ry.lang` 自動 prelude (`print` / `len` / `range` 等) と明示 `from ry.lang import …` は canonical の一形態として warn 対象外。`tests/spec/` 配下の既存テストは引き続き exit code 0 で pass する (出力に warning が混ざるのは deprecation 期間中の意図された動作)。`import std.math` 形式は parser 段階で hard error のため本検出経路は通らない。 (#2350)

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -252,7 +252,7 @@ Importing a non-`@public` symbol from another package is a compile error. Wildca
 
 Since v0.0.30 (#1769) the canonical namespace for all official stdlib modules is the reserved `ry.*` path:
 
-| Canonical | Compatibility alias | Notes |
+| Canonical | Compatibility alias (deprecated since #2350) | Notes |
 |---|---|---|
 | `ry.lang` | implicit prelude / `from std import` | The explicit prelude module; symbols loaded into every program |
 | `ry.math` | `math` / `std.math` | Mathematical constants and functions |
@@ -268,14 +268,14 @@ Since v0.0.30 (#1769) the canonical namespace for all official stdlib modules is
 | `ry.net` | `net` / `std.net` | TCP / TLS socket primitives |
 | `ry.json5` | `json5` / `std.json5` | JSON5 parse / stringify |
 
-All three spellings resolve to the same physical modules; the canonical `ry.*` form is recommended for new code.
+All three spellings resolve to the same physical modules. The canonical `ry.*` form is required for new code; the compatibility aliases now emit a one-time deprecation warning on import and will be rejected in a future release.
 
 ```ry
 # Recommended (canonical):
 from ry.math import sqrt, PI
 import ry.math               # binds the bare last segment `math`
 
-# Still supported (legacy):
+# Deprecated (compatibility alias — emits warning):
 from math import sqrt        # flat form
 from std.math import NAN     # dotted std form
 ```

--- a/include/ry/module/module_loader.hpp
+++ b/include/ry/module/module_loader.hpp
@@ -135,6 +135,11 @@ private:
     // The probe does two filesystem stats per `ry/*` import; caching by
     // referrer collapses N stats into one for files with multiple `ry.*` imports.
     std::unordered_set<std::string> probed_ry_shadow_dirs_;
+    // #2350: legacy stdlib import 形式 (`from math`, `from std.math`,
+    // `from std`, `import math`) を検出した時に発行した deprecation warning の
+    // dedup 用 set。key は元の resolve 文字列 (`"math"` / `"std/math"` / `"std"`)。
+    // 同一スペリングに対して loader 生存期間中 1 回のみ警告する。
+    std::unordered_set<std::string> warned_legacy_imports_;
 
     // Cached fs::canonical — populates ec with original error on failure
     std::string cachedCanonical(const std::string &raw, std::error_code &ec);

--- a/src/module/module_loader.cpp
+++ b/src/module/module_loader.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
@@ -74,6 +75,28 @@ static std::string toRyDotForm(const std::string &slash_path) {
 static std::string toUserFacingPath(const std::string &module_path) {
     return ModuleLoader::isRyPath(module_path) ? toRyDotForm(module_path)
                                                 : module_path;
+}
+
+// #2350: legacy stdlib import (`from math import …` / `from std.math import …` /
+// `from std import …` / `import math`) を canonical な user-facing `ry.<…>` 形式
+// に変換する。legacy 形式でなければ `nullopt`。Phase 1 では呼び出し元が戻り値
+// を deprecation warning として surface し、Phase 2 で hard error 化予定。
+// 前提: caller は rp.from_stdlib==true でゲートする — bogus 形式は resolve() が
+// 例外を投げて detector に到達しないため、ここに来る時点で実モジュールに解決済み。
+//   "std"       -> "ry.lang"   (flat std → explicit prelude)
+//   "std/math"  -> "ry.math"   (std.dotted → public submodule)
+//   "math"      -> "ry.math"   (bare flat → public submodule)
+static std::optional<std::string>
+tryLegacyToCanonical(const std::string &resolve_path) {
+    if (ModuleLoader::isRyPath(resolve_path)) return std::nullopt;
+    // "std" → "ry.lang"。canonical 物理パス定数を dot 形式に変換して経由
+    // することで、`kRyLangPreludePath` / `canonicalStdlibName` と同期する。
+    if (resolve_path == "std")
+        return toRyDotForm(ModuleLoader::kRyLangPreludePath);
+    if (resolve_path.size() > 4 && resolve_path.compare(0, 4, "std/") == 0)
+        return "ry." + resolve_path.substr(4);
+    if (isPublicRyModule(resolve_path)) return "ry." + resolve_path;
+    return std::nullopt;
 }
 
 // Check if a statement is an exportable definition
@@ -846,6 +869,19 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
             ResolvedPath rp = resolve(resolve_path, referrer_dir);
             const std::string &abs_path = rp.path;
 
+            // #2350: legacy `import math` を deprecation warning として surface する。
+            // dedup key は元の spelling — ファイル内で同じ `import math` が複数回
+            // 出ても (typically まず無いが) 1 回のみ。
+            if (rp.from_stdlib) {
+                if (auto canon = tryLegacyToCanonical(resolve_path);
+                    canon && warned_legacy_imports_.insert(resolve_path).second) {
+                    loader_warnings_.push_back(
+                        "warning: 'import " + toRyDotForm(resolve_path) +
+                        "' is a deprecated stdlib path; use 'import " +
+                        *canon + "' instead");
+                }
+            }
+
             // Propagate stdlib origin to codegen — Task 9 uses this to gate
             // qualified-call routing (stdlib → existing dispatch chain;
             // user-defined → "not yet supported" error in v0.0.23).
@@ -963,6 +999,20 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
 
         ResolvedPath rp = resolve(imp.module_path, referrer_dir);
         const std::string &abs_path = rp.path;
+
+        // #2350: legacy `from math import …` / `from std.math import …` /
+        // `from std import …` を deprecation warning として surface する。
+        // dedup key は元の spelling — `from math import a` と `from math import b`
+        // の両方が同ファイルにあっても 1 回のみ。
+        if (rp.from_stdlib) {
+            if (auto canon = tryLegacyToCanonical(imp.module_path);
+                canon && warned_legacy_imports_.insert(imp.module_path).second) {
+                loader_warnings_.push_back(
+                    "warning: 'from " + toRyDotForm(imp.module_path) +
+                    " import …' is a deprecated stdlib path; use 'from " +
+                    *canon + " import …' instead");
+            }
+        }
 
         // Record testing-module intrinsics observed in the import statement
         // ONLY when the import resolved to the stdlib testing module. A

--- a/tests/test_legacy_import_warnings.cpp
+++ b/tests/test_legacy_import_warnings.cpp
@@ -1,0 +1,257 @@
+#include <gtest/gtest.h>
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+#include <unistd.h>
+#include <sys/wait.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct RunResult {
+    std::string out;
+    std::string err;
+    int exit_code = -1;
+};
+
+RunResult runRy(std::vector<const char *> args) {
+    int pipeOut[2];
+    int pipeErr[2];
+    if (pipe(pipeOut) != 0) return {};
+    if (pipe(pipeErr) != 0) {
+        close(pipeOut[0]);
+        close(pipeOut[1]);
+        return {};
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipeOut[0]); close(pipeOut[1]);
+        close(pipeErr[0]); close(pipeErr[1]);
+        return {};
+    }
+
+    if (pid == 0) {
+        close(pipeOut[0]);
+        close(pipeErr[0]);
+        dup2(pipeOut[1], STDOUT_FILENO);
+        dup2(pipeErr[1], STDERR_FILENO);
+        close(pipeOut[1]);
+        close(pipeErr[1]);
+        close(STDIN_FILENO);
+
+        // argv[0] must be the full RY_BINARY_PATH so Linux glibc's
+        // fs::canonical(parent_path(argv[0])) resolves the exe-adjacent
+        // stdlib search path (.claude/rules/tests-cpp-conventions.md).
+        std::vector<const char *> argv{RY_BINARY_PATH};
+        argv.insert(argv.end(), args.begin(), args.end());
+        argv.push_back(nullptr);
+
+        execv(RY_BINARY_PATH, const_cast<char *const *>(argv.data()));
+        _exit(127);
+    }
+
+    close(pipeOut[1]);
+    close(pipeErr[1]);
+
+    auto readAll = [](int fd) -> std::string {
+        std::string result;
+        std::array<char, 4096> buf{};
+        ssize_t n;
+        while ((n = read(fd, buf.data(), buf.size())) > 0)
+            result.append(buf.data(), static_cast<size_t>(n));
+        close(fd);
+        return result;
+    };
+
+    RunResult r;
+    std::thread outReader([&]() { r.out = readAll(pipeOut[0]); });
+    std::thread errReader([&]() { r.err = readAll(pipeErr[0]); });
+    outReader.join();
+    errReader.join();
+    int status = 0;
+    waitpid(pid, &status, 0);
+    r.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    return r;
+}
+
+size_t countOccurrences(const std::string &haystack, const std::string &needle) {
+    if (needle.empty()) return 0;
+    size_t count = 0;
+    size_t pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+        ++count;
+        pos += needle.size();
+    }
+    return count;
+}
+
+class LegacyImportWarningsTest : public ::testing::Test {
+protected:
+    fs::path tmpDir_;
+
+    void SetUp() override {
+        tmpDir_ = fs::path(RY_BINARY_PATH).parent_path() / "legacy_import_warnings_test";
+        fs::remove_all(tmpDir_);
+        fs::create_directories(tmpDir_);
+    }
+
+    void TearDown() override { fs::remove_all(tmpDir_); }
+
+    fs::path writeScript(const std::string &name, const std::string &content) {
+        auto p = tmpDir_ / name;
+        std::ofstream(p) << content;
+        return p;
+    }
+};
+
+} // namespace
+
+TEST_F(LegacyImportWarningsTest, FlatFormEmitsWarning) {
+    auto p = writeScript("flat_math.ry",
+        "from math import sqrt\n"
+        "print(sqrt(4.0))\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "stderr should contain 'deprecated': " << r.err;
+    EXPECT_NE(r.err.find("ry.math"), std::string::npos)
+        << "stderr should suggest 'ry.math': " << r.err;
+    EXPECT_NE(r.err.find("'from math import"), std::string::npos)
+        << "stderr should quote the legacy form: " << r.err;
+}
+
+TEST_F(LegacyImportWarningsTest, StdDottedFormEmitsWarning) {
+    auto p = writeScript("std_dotted_math.ry",
+        "from std.math import NAN\n"
+        "print(NAN)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "stderr should contain 'deprecated': " << r.err;
+    EXPECT_NE(r.err.find("ry.math"), std::string::npos)
+        << "stderr should suggest 'ry.math': " << r.err;
+    EXPECT_NE(r.err.find("'from std.math import"), std::string::npos)
+        << "stderr should quote the legacy form with dot spelling: " << r.err;
+}
+
+TEST_F(LegacyImportWarningsTest, FlatStdFormEmitsWarning) {
+    // `print` is exported from share/std/builtins.ry; confirm `from std import print`
+    // (the flat-std legacy form) warns and suggests `ry.lang`.
+    auto p = writeScript("flat_std.ry",
+        "from std import print\n"
+        "print(\"hi\")\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "stderr should contain 'deprecated': " << r.err;
+    EXPECT_NE(r.err.find("ry.lang"), std::string::npos)
+        << "stderr should suggest 'ry.lang': " << r.err;
+}
+
+TEST_F(LegacyImportWarningsTest, QualifiedFlatFormEmitsWarning) {
+    auto p = writeScript("qualified_flat_math.ry",
+        "import math\n"
+        "print(math.sqrt(9.0))\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "stderr should contain 'deprecated': " << r.err;
+    EXPECT_NE(r.err.find("ry.math"), std::string::npos)
+        << "stderr should suggest 'ry.math': " << r.err;
+    EXPECT_NE(r.err.find("'import math'"), std::string::npos)
+        << "stderr should quote the legacy form: " << r.err;
+}
+
+TEST_F(LegacyImportWarningsTest, CanonicalFormNoWarning) {
+    auto p = writeScript("canonical.ry",
+        "from ry.math import sqrt\n"
+        "print(sqrt(4.0))\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_EQ(r.err.find("deprecated"), std::string::npos)
+        << "canonical form must not emit deprecation warning: " << r.err;
+}
+
+TEST_F(LegacyImportWarningsTest, RyLangExplicitFormNoWarning) {
+    // Explicit `from ry.lang import …` is canonical, not legacy.
+    auto p = writeScript("ry_lang_explicit.ry",
+        "from ry.lang import print\n"
+        "print(\"hi\")\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_EQ(r.err.find("deprecated"), std::string::npos)
+        << "ry.lang explicit form must not emit deprecation warning: " << r.err;
+}
+
+TEST_F(LegacyImportWarningsTest, FlatFormDeduplicatedAcrossMultipleImports) {
+    auto p = writeScript("dedup_math.ry",
+        "from math import sqrt\n"
+        "from math import PI\n"
+        "print(sqrt(PI))\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_EQ(countOccurrences(r.err, "deprecated"), 1u)
+        << "same legacy spelling must warn at most once, stderr was: " << r.err;
+}
+
+TEST_F(LegacyImportWarningsTest, UserDefinedModuleNoFalsePositive) {
+    // A user-defined `math.ry` shadows the stdlib name. Loader resolves to the
+    // local file (rp.from_stdlib == false) — detector must NOT fire.
+    std::ofstream(tmpDir_ / "math.ry")
+        << "@public\nfn add(a: int, b: int) -> int:\n    return a + b\n";
+
+    auto p = writeScript("uses_local_math.ry",
+        "from math import add\n"
+        "print(add(2, 3))\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_EQ(r.out, "5\n");
+    EXPECT_EQ(r.err.find("deprecated"), std::string::npos)
+        << "user-defined module must not trigger deprecation warning: " << r.err;
+}
+
+TEST_F(LegacyImportWarningsTest, AliasedImportEmitsWarning) {
+    // Alias (`as flatPI`) does not affect detection — module_path is still "math".
+    // Use a constant (`PI`) because stdlib `@native` fn alias is not yet
+    // supported (see tests/spec/ry_namespace/ry_module_import.test.ry:18).
+    auto p = writeScript("aliased_math.ry",
+        "from math import PI as flatPI\n"
+        "print(flatPI)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "aliased legacy import must still warn: " << r.err;
+    EXPECT_NE(r.err.find("ry.math"), std::string::npos)
+        << "stderr should suggest 'ry.math': " << r.err;
+}
+
+TEST_F(LegacyImportWarningsTest, MultipleDistinctLegacyModulesEachWarnOnce) {
+    auto p = writeScript("multi_distinct.ry",
+        "from math import sqrt\n"
+        "from testing import it\n"
+        "print(sqrt(4.0))\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_EQ(countOccurrences(r.err, "deprecated"), 2u)
+        << "two distinct legacy modules should each warn once, stderr was: " << r.err;
+    EXPECT_NE(r.err.find("ry.math"), std::string::npos)
+        << "stderr should mention ry.math: " << r.err;
+    EXPECT_NE(r.err.find("ry.testing"), std::string::npos)
+        << "stderr should mention ry.testing: " << r.err;
+}

--- a/tests/test_read_line_builtin.cpp
+++ b/tests/test_read_line_builtin.cpp
@@ -108,7 +108,7 @@ static std::pair<std::string, int> runRyWithStdin(const std::string &ry_source,
 }
 
 // Common driver: prints "line:<s>" / "EOF" / "ERR:<msg>" for one readLine call.
-static const char *driver_print_line = R"(from io import readLine
+static const char *driver_print_line = R"(from ry.io import readLine
 case readLine():
     Ok(opt):
         case opt:
@@ -124,7 +124,7 @@ TEST(ReadLineBuiltin, EOFReturnsOkNone) {
 }
 
 TEST(ReadLineBuiltin, EmptyLineReturnsOkSomeEmpty) {
-    auto [out, rc] = runRyWithStdin(R"(from io import readLine
+    auto [out, rc] = runRyWithStdin(R"(from ry.io import readLine
 case readLine():
     Ok(opt):
         case opt:
@@ -144,7 +144,7 @@ TEST(ReadLineBuiltin, NormalLineReturnsOkSome) {
 }
 
 TEST(ReadLineBuiltin, MultiLineReturnsSomeSomeNone) {
-    auto [out, rc] = runRyWithStdin(R"(from io import readLine
+    auto [out, rc] = runRyWithStdin(R"(from ry.io import readLine
 fn one():
     case readLine():
         Ok(opt):
@@ -162,7 +162,7 @@ one()
 }
 
 TEST(ReadLineBuiltin, MissingTrailingNewlineReturnsSomeThenNone) {
-    auto [out, rc] = runRyWithStdin(R"(from io import readLine
+    auto [out, rc] = runRyWithStdin(R"(from ry.io import readLine
 fn one():
     case readLine():
         Ok(opt):


### PR DESCRIPTION
## Summary

- import 解決時に legacy 形式 (`from math import …` / `from std.math import …` / `from std import …` / `import math`) を検出し、stderr へ one-time deprecation warning を発する
- canonical `ry.*` 形式 (`from ry.math import …` / `import ry.math` / `from ry.lang import …` 等) を提示。動作は変えず、legacy 形式は引き続き解決可能 (将来 reject 予定)
- `rp.from_stdlib==true` ゲートでユーザ定義モジュールへの false positive を防ぐ。dedup は元 spelling 単位で loader 生存期間中 1 回
- `tests/test_read_line_builtin.cpp` は exact stdout 検査のため canonical 化 (Phase 1 必須 collateral)。他の tests/spec/, examples/, docs/ snippet は Phase 2 へ

## Test plan

- [x] 新規 gtest 10 ケース pass (`./build-rust/ry_tests --gtest_filter='LegacyImportWarningsTest.*'`)
- [x] 既存 gtest 2949/2949 pass (`./build-rust/ry_tests`)
- [x] spec suite 219/219 pass (`./build-rust/ry test -p`) — 出力に warning が混ざるのは deprecation 期間中の意図された動作
- [x] 手動確認: legacy → warning + 動作維持、canonical → warning なし
- [x] prompt-refs lint clean

## 既知の gap

- `import std.math` は parser (`src/parser/parser.cpp`) が `firstSegment != "ry"` を hard error にするため、本検出経路は通らない (Phase 2 でも同様にスコープ外)

Closes #2350