### PR TITLE
feat(json5): accept ECMAScript IdentifierName as unquoted object keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,29 @@ corrosion_import_crate(
 set_target_properties(ry_base64 PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 
-set(RY_NATIVE_LIBS ry_base64 ry_path ry_convert ry_filesystem ry_gc ry_testing ry_io ry_json ry_json5 ry_net ry_thread ry_http)
+# ===== xid: ECMAScript IdentifierName predicates for json5 (#2314) =====
+# Tiny Rust cdylib (`unicode-ident` wrapper) exposing
+# `__ry_xid_start(u32)` / `__ry_xid_continue(u32)`. Unlike ry_base64 this
+# is NOT a JIT-callable @native module — it's a C++ runtime dependency
+# of libry_json5. We follow the `emit` pattern (linked into the `ry` /
+# `ry_tests` executables so its symbols live process-wide) rather than
+# a libry_json5 → libry_xid inter-library link: that would have given
+# libry_json5 an `LC_LOAD_DYLIB` pointing at the transient cargo deps
+# path (Rust sets the cdylib install_name there, not `@rpath`), which
+# breaks on `cargo clean` or relocation. With the process-link approach,
+# libry_xid is loaded at `ry` startup and `__ry_xid_*` resolves into
+# dlopen'd libry_json5 via macOS `-undefined dynamic_lookup` / Linux
+# `-rdynamic` — the same mechanism that resolves `__ry_set_last_error`.
+# This keeps the "no inter-library link dependencies between native
+# libs" invariant (CMakeLists ~277) intact.
+corrosion_import_crate(
+    MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/crates/xid/Cargo.toml"
+    CRATES xid
+)
+set_target_properties(ry_xid PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
+set(RY_NATIVE_LIBS ry_base64 ry_xid ry_path ry_convert ry_filesystem ry_gc ry_testing ry_io ry_json ry_json5 ry_net ry_thread ry_http)
 
 # Linker-arg form of RY_NATIVE_LIBS. corrosion's IMPORTED CMake target
 # (`ry_base64`) is a UTILITY/INTERFACE-style target — CMake refuses both the
@@ -390,6 +412,7 @@ set(RY_NATIVE_LIBS ry_base64 ry_path ry_convert ry_filesystem ry_gc ry_testing r
 # corrosion (cargo build) guarantee the file exists before this is linked.
 set(RY_NATIVE_LIBS_LINK
     "${CMAKE_BINARY_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}ry_base64${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    "${CMAKE_BINARY_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}ry_xid${CMAKE_SHARED_LIBRARY_SUFFIX}"
     ry_path ry_convert ry_filesystem ry_gc ry_testing ry_io ry_json ry_json5 ry_net ry_thread ry_http)
 
 # ===== メイン実行ファイル =====
@@ -397,16 +420,21 @@ set(RY_NATIVE_LIBS_LINK
 # via find_native_library() + DynamicLibrarySearchGenerator::Load() (see main.cpp).
 add_executable(ry src/app/main.cpp)
 add_dependencies(ry ${RY_NATIVE_LIBS})
-# emit is referenced at compile time by ry_lib's shim layer (#1949),
-# so it must be linked explicitly into the executable (unlike RY_NATIVE_LIBS
-# which the JIT loads on demand).
+# emit is referenced at compile time by ry_lib's shim layer (#1949), so
+# it must be linked explicitly into the executable (unlike RY_NATIVE_LIBS
+# which the JIT loads on demand). ry_xid follows the same process-link
+# model for the reasons in the xid corrosion block above (#2314); its
+# absolute artifact path is required because corrosion's IMPORTED target
+# rejects -Wl,--no-as-needed and the $<TARGET_FILE:> generator expression.
+set(RY_XID_LINK "${CMAKE_BINARY_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}ry_xid${CMAKE_SHARED_LIBRARY_SUFFIX}")
 if(APPLE)
-    target_link_libraries(ry PRIVATE -Wl,-force_load,$<TARGET_FILE:ry_lib> ry_lib emit)
+    target_link_libraries(ry PRIVATE -Wl,-force_load,$<TARGET_FILE:ry_lib> ry_lib emit ${RY_XID_LINK})
 else()
-    # --no-as-needed for atomic: JIT-generated code may reference __atomic_load
-    # (from LLVM atomicrmw lowering), so libatomic must stay linked even though
-    # ry_lib has no direct references to it.
-    target_link_libraries(ry PRIVATE -Wl,--whole-archive ry_lib -Wl,--no-whole-archive emit -Wl,--no-as-needed atomic -Wl,--as-needed)
+    # --no-as-needed keeps both atomic (LLVM atomicrmw lowering reaches
+    # __atomic_load at JIT time) and ry_xid (no static caller in ry_lib —
+    # libry_json5 references __ry_xid_* but is dlopen'd later) from being
+    # dropped despite no link-time references.
+    target_link_libraries(ry PRIVATE -Wl,--whole-archive ry_lib -Wl,--no-whole-archive emit -Wl,--no-as-needed ${RY_XID_LINK} atomic -Wl,--as-needed)
     # -rdynamic: export process symbols so JIT DynamicLibrarySearchGenerator and
     # dlopen'd native libs can find __ry_set_last_error etc. from the process
     target_link_options(ry PRIVATE -rdynamic)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,3 +81,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "xid"
+version = "0.0.0"
+dependencies = [
+ "unicode-ident",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@
 
 [workspace]
 resolver = "2"
-members = ["crates/emit", "crates/native_base64"]
+members = ["crates/emit", "crates/native_base64", "crates/xid"]
 
 # Profiles live at the workspace root (cargo ignores package-level
 # profiles in workspace members). See:

--- a/crates/xid/Cargo.toml
+++ b/crates/xid/Cargo.toml
@@ -1,0 +1,31 @@
+# Rust cdylib exposing ECMAScript IdentifierName predicates for the json5
+# unquoted-key parser (#2314).
+#
+# Two FFI symbols only — `__ry_xid_start(u32) -> bool` and
+# `__ry_xid_continue(u32) -> bool` — backed by the `unicode-ident` crate's
+# compile-time XID_Start / XID_Continue tables. The C++ caller
+# (`src/runtime/native/json5.cpp`) decodes UTF-8, applies an ASCII fast
+# path, then hands non-ASCII codepoints to these predicates.
+#
+# Unlike `crates/native_base64` (#2282), this crate is NOT a JIT-callable
+# stdlib module — it's pure C++ runtime support. There is no
+# `@native("xid")` declaration, no codegen dispatcher, and no
+# module_loader registration. Output filename is `libry_xid.{dylib,so}`
+# via `[lib].name = "ry_xid"`, matching the host's static-link expectation
+# in CMakeLists.txt.
+
+[package]
+name = "xid"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "ry_xid"
+crate-type = ["cdylib"]
+
+[dependencies]
+unicode-ident = "1"
+
+[lints]
+workspace = true

--- a/crates/xid/build.rs
+++ b/crates/xid/build.rs
@@ -1,0 +1,10 @@
+// Mirrors `crates/native_base64/build.rs`. The cdylib has no undefined
+// host symbols today (unicode-ident is self-contained), but keeping the
+// link arg matches the runtime ABI posture and leaves room for future
+// host-shim use without a second build.rs edit.
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "macos" {
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");
+    }
+}

--- a/crates/xid/src/lib.rs
+++ b/crates/xid/src/lib.rs
@@ -1,0 +1,25 @@
+// ECMAScript IdentifierName predicates for json5 unquoted keys (#2314).
+//
+// The C++ caller in `src/runtime/native/json5.cpp` decodes a UTF-8
+// codepoint, short-circuits on ASCII, and only invokes these for cp >=
+// 0x80. Surrogate-half codepoints (U+D800..=U+DFFF) and out-of-range
+// values fail `char::from_u32`, so both predicates return `false` for
+// them — same outcome as the C++ side returning before the FFI hop, kept
+// here as a belt-and-suspenders guard against any caller that hasn't
+// already filtered.
+//
+// XID vs ID: the ECMAScript spec literally references ID_Start /
+// ID_Continue, but XID_Start / XID_Continue are the NFKC-stable subset
+// (the difference is a handful of obscure characters that other JSON5
+// implementations also exclude in practice). If strict ID conformance
+// becomes a requirement, swap the dependency without changing the FFI.
+
+#[no_mangle]
+pub extern "C" fn __ry_xid_start(cp: u32) -> bool {
+    char::from_u32(cp).is_some_and(unicode_ident::is_xid_start)
+}
+
+#[no_mangle]
+pub extern "C" fn __ry_xid_continue(cp: u32) -> bool {
+    char::from_u32(cp).is_some_and(unicode_ident::is_xid_continue)
+}

--- a/docs/reference/json5.md
+++ b/docs/reference/json5.md
@@ -43,17 +43,21 @@ accepts, plus the JSON5 spec extensions below:
 | Trailing commas in arrays / objects | `[1, 2, 3,]`, `{a: 1,}` |
 | Single-quoted strings | `'hello'` |
 | Multi-line strings (line continuation) | `'foo\<LF>bar'` → `"foobar"` |
-| Unquoted object keys (ASCII identifier) | `{x: 1, _foo: 2, $ref: 3}` |
+| Unquoted object keys (ECMAScript IdentifierName) | `{x: 1, _foo: 2, $ref: 3, 名前: "ry"}` |
 | Hex integer literals | `0xFF`, `-0xDEADBEEF` |
 | Leading / trailing decimal point | `.5`, `5.` |
 | IEEE 754 special values | `Infinity`, `-Infinity`, `NaN` |
 | Explicit positive sign | `+5`, `+3.14`, `+Infinity` |
 
-Unquoted keys are restricted to the ASCII subset of ECMAScript
-`IdentifierName` in this release: first character is a letter,
-underscore, or dollar sign; following characters add digits. Unicode
-identifier characters are accepted only inside single- or
-double-quoted keys.
+Unquoted keys accept ECMAScript `IdentifierName`. The first character
+is a Unicode letter, `_`, `$`, or a `\uHHHH` escape resolving to one;
+subsequent characters add Unicode digits, combining marks, connector
+punctuation, and `<ZWNJ>` / `<ZWJ>`. Surrogate-pair
+`\uHHHH\uHHHH` escapes resolve to non-BMP codepoints. The classifier
+follows XID_Start / XID_Continue (the NFKC-stable subset of
+ID_Start / ID_Continue); the difference from strict ECMAScript ID is a
+handful of obscure characters with no practical impact, and matches the
+behavior of common JSON5 implementations in other languages.
 
 ## Stringify Output Format
 

--- a/share/std/json5/json5.ry
+++ b/share/std/json5/json5.ry
@@ -7,7 +7,9 @@
 #   - Trailing commas in arrays and objects
 #   - Single-quoted strings in addition to double-quoted
 #   - Multi-line strings via `\<newline>` line continuation
-#   - Unquoted object keys (ASCII IdentifierName: [a-zA-Z_$][a-zA-Z0-9_$]*)
+#   - Unquoted object keys (ECMAScript IdentifierName; Unicode letters
+#     and digits via XID_Start/XID_Continue plus ZWNJ/ZWJ; `\uHHHH`
+#     escapes and surrogate pairs accepted)
 #   - Hex integer literals (`0xABCDEF`)
 #   - Leading and trailing decimal points (`.5`, `5.`)
 #   - IEEE 754 special values: `Infinity`, `-Infinity`, `NaN`

--- a/src/runtime/native/json5.cpp
+++ b/src/runtime/native/json5.cpp
@@ -11,6 +11,7 @@
 #include <cctype>
 #include <cerrno>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -21,6 +22,80 @@
 
 
 namespace ry {
+
+// ECMAScript IdentifierName predicates for unquoted object keys (#2314).
+// Implementation lives in `crates/xid/` (libry_xid.{dylib,so}). The C++
+// callers (`is_id_start` / `is_id_part`) apply an ASCII fast path first
+// and only invoke these for cp >= 0x80.
+extern "C" bool __ry_xid_start(uint32_t cp);
+extern "C" bool __ry_xid_continue(uint32_t cp);
+
+// Decode one UTF-8 codepoint from `p[0..avail]`. Returns bytes consumed
+// (1-4) on success and writes the scalar to `cp_out`; returns 0 on
+// incomplete / invalid input (RFC 3629 strict — rejects overlong forms,
+// surrogate halves U+D800..U+DFFF, and codepoints above U+10FFFF). The
+// caller must treat a 0 return as "no valid codepoint here" without
+// advancing.
+static size_t decode_utf8_cp(const char *p, size_t avail, uint32_t &cp_out) {
+    if (avail == 0) return 0;
+    uint32_t b0 = static_cast<unsigned char>(p[0]);
+    if (b0 < 0x80) { cp_out = b0; return 1; }
+    if ((b0 & 0xE0) == 0xC0) {
+        if (avail < 2) return 0;
+        uint32_t b1 = static_cast<unsigned char>(p[1]);
+        if ((b1 & 0xC0) != 0x80) return 0;
+        uint32_t cp = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+        if (cp < 0x80) return 0;
+        cp_out = cp;
+        return 2;
+    }
+    if ((b0 & 0xF0) == 0xE0) {
+        if (avail < 3) return 0;
+        uint32_t b1 = static_cast<unsigned char>(p[1]);
+        uint32_t b2 = static_cast<unsigned char>(p[2]);
+        if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) return 0;
+        uint32_t cp = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+        if (cp < 0x800) return 0;
+        if (cp >= 0xD800 && cp <= 0xDFFF) return 0;
+        cp_out = cp;
+        return 3;
+    }
+    if ((b0 & 0xF8) == 0xF0) {
+        if (avail < 4) return 0;
+        uint32_t b1 = static_cast<unsigned char>(p[1]);
+        uint32_t b2 = static_cast<unsigned char>(p[2]);
+        uint32_t b3 = static_cast<unsigned char>(p[3]);
+        if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) return 0;
+        uint32_t cp = ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12)
+                    | ((b2 & 0x3F) << 6) | (b3 & 0x3F);
+        if (cp < 0x10000) return 0;
+        if (cp > 0x10FFFF) return 0;
+        cp_out = cp;
+        return 4;
+    }
+    return 0;
+}
+
+// Append the UTF-8 encoding of `cp` to `out`. Caller guarantees `cp` is
+// a valid scalar (0..=0x10FFFF, not in the surrogate range) — typically
+// from `decode_utf8_cp` or a fully-combined `\uHHHH(\uHHHH)?` escape.
+static void append_utf8(std::string &out, uint32_t cp) {
+    if (cp < 0x80) {
+        out += static_cast<char>(cp);
+    } else if (cp < 0x800) {
+        out += static_cast<char>(0xC0 | (cp >> 6));
+        out += static_cast<char>(0x80 | (cp & 0x3F));
+    } else if (cp < 0x10000) {
+        out += static_cast<char>(0xE0 | (cp >> 12));
+        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        out += static_cast<char>(0x80 | (cp & 0x3F));
+    } else {
+        out += static_cast<char>(0xF0 | (cp >> 18));
+        out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        out += static_cast<char>(0x80 | (cp & 0x3F));
+    }
+}
 
 // ===== JSON5 string escape helper (used by stringify_any) =====
 //
@@ -219,20 +294,100 @@ struct Json5AnyParser {
         return true;
     }
 
-    // ECMAScript IdentifierStart (ASCII subset): letter, underscore, dollar.
-    static bool is_id_start(char c) {
-        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-            || c == '_' || c == '$';
+    // ECMAScript IdentifierStart: '$' | '_' | UnicodeLetter.
+    // UnicodeLetter is approximated by XID_Start (#2314) — the NFKC-stable
+    // subset of ID_Start that other JSON5 implementations effectively use.
+    static bool is_id_start(uint32_t cp) {
+        if (cp == '$' || cp == '_') return true;
+        if (cp < 0x80) {
+            return (cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z');
+        }
+        return __ry_xid_start(cp);
     }
-    // ECMAScript IdentifierPart (ASCII subset): id_start or digit.
-    static bool is_id_part(char c) {
-        return is_id_start(c) || (c >= '0' && c <= '9');
+    // ECMAScript IdentifierPart: IdentifierStart | UnicodeDigit
+    // | UnicodeCombiningMark | UnicodeConnectorPunctuation | <ZWNJ> | <ZWJ>.
+    // XID_Continue covers letter / digit / combining mark / connector
+    // punctuation; ZWNJ (U+200C) and ZWJ (U+200D) are Cf (Format) and must
+    // be added explicitly.
+    static bool is_id_part(uint32_t cp) {
+        if (cp == '$' || cp == '_') return true;
+        if (cp == 0x200C || cp == 0x200D) return true;
+        if (cp < 0x80) {
+            return (cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z')
+                || (cp >= '0' && cp <= '9');
+        }
+        return __ry_xid_continue(cp);
+    }
+    // Decode the codepoint at byte offset `p` and return whether it is an
+    // IdentifierPart. False at end-of-input or on invalid UTF-8 — both
+    // cases mean "no identifier-continuation here", which is what every
+    // trailing-guard caller (parse_bool / parse_null / parse_number hex)
+    // wants.
+    bool trailing_codepoint_is_id_part(size_t p) const {
+        if (p >= src_len) return false;
+        uint32_t cp;
+        size_t step = decode_utf8_cp(src + p, src_len - p, cp);
+        return step != 0 && is_id_part(cp);
     }
     static int hex_digit_value(char c) {
         if (c >= '0' && c <= '9') return c - '0';
         if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
         if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
         return -1;
+    }
+
+    // Parse 4 hex digits starting at `pos` (caller has already consumed
+    // the `\u` prefix). Advances `pos` past the digits on success.
+    bool parse_hex4(uint32_t &cp_out) {
+        if (pos + 4 > src_len) {
+            error = "incomplete unicode escape at ";
+            error += formatPosition(pos);
+            return false;
+        }
+        uint32_t v = 0;
+        for (size_t i = 0; i < 4; i++) {
+            int d = hex_digit_value(src[pos + i]);
+            if (d < 0) {
+                error = "invalid hex digit in unicode escape at ";
+                error += formatPosition(pos + i);
+                return false;
+            }
+            v = (v << 4) | static_cast<uint32_t>(d);
+        }
+        pos += 4;
+        cp_out = v;
+        return true;
+    }
+
+    // Parse `\uHHHH` (caller has already consumed `\u`); join a following
+    // `\uHHHH` low surrogate if the first half is a high surrogate.
+    // Rejects unpaired surrogates on either side. Returns the combined
+    // scalar in `cp_out`.
+    bool parse_unicode_escape(uint32_t &cp_out) {
+        uint32_t cp;
+        if (!parse_hex4(cp)) return false;
+        if (cp >= 0xD800 && cp <= 0xDBFF) {
+            if (pos + 2 > src_len || src[pos] != '\\' || src[pos + 1] != 'u') {
+                error = "unpaired high surrogate in unicode escape at ";
+                error += formatPosition(pos);
+                return false;
+            }
+            pos += 2;
+            uint32_t low;
+            if (!parse_hex4(low)) return false;
+            if (low < 0xDC00 || low > 0xDFFF) {
+                error = "invalid low surrogate in unicode escape at ";
+                error += formatPosition(pos);
+                return false;
+            }
+            cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
+        } else if (cp >= 0xDC00 && cp <= 0xDFFF) {
+            error = "unpaired low surrogate in unicode escape at ";
+            error += formatPosition(pos);
+            return false;
+        }
+        cp_out = cp;
+        return true;
     }
 
     bool parse_value(RyAny &out) {
@@ -349,64 +504,9 @@ struct Json5AnyParser {
                         break;
                     }
                     case 'u': {
-                        auto parse_hex4 = [&](unsigned &cp_out) -> bool {
-                            if (pos + 4 > src_len) {
-                                error = "incomplete unicode escape at ";
-                                error += formatPosition(pos);
-                                return false;
-                            }
-                            unsigned v = 0;
-                            for (size_t hi = 0; hi < 4; hi++) {
-                                int d = hex_digit_value(src[pos + hi]);
-                                if (d < 0) {
-                                    error = "invalid hex digit in unicode escape at ";
-                                    error += formatPosition(pos + static_cast<size_t>(hi));
-                                    return false;
-                                }
-                                v = (v << 4) | (unsigned)d;
-                            }
-                            pos += 4;
-                            cp_out = v;
-                            return true;
-                        };
-                        unsigned cp;
-                        if (!parse_hex4(cp)) return false;
-                        // Surrogate pair handling — identical to json.cpp.
-                        if (cp >= 0xD800 && cp <= 0xDBFF) {
-                            if (pos + 2 > src_len || src[pos] != '\\' || src[pos + 1] != 'u') {
-                                error = "unpaired high surrogate in unicode escape at ";
-                                error += formatPosition(pos);
-                                return false;
-                            }
-                            pos += 2;
-                            unsigned low;
-                            if (!parse_hex4(low)) return false;
-                            if (low < 0xDC00 || low > 0xDFFF) {
-                                error = "invalid low surrogate in unicode escape at ";
-                                error += formatPosition(pos);
-                                return false;
-                            }
-                            cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
-                        } else if (cp >= 0xDC00 && cp <= 0xDFFF) {
-                            error = "unpaired low surrogate in unicode escape at ";
-                            error += formatPosition(pos);
-                            return false;
-                        }
-                        if (cp < 0x80) {
-                            out += (char)cp;
-                        } else if (cp < 0x800) {
-                            out += (char)(0xC0 | (cp >> 6));
-                            out += (char)(0x80 | (cp & 0x3F));
-                        } else if (cp < 0x10000) {
-                            out += (char)(0xE0 | (cp >> 12));
-                            out += (char)(0x80 | ((cp >> 6) & 0x3F));
-                            out += (char)(0x80 | (cp & 0x3F));
-                        } else {
-                            out += (char)(0xF0 | (cp >> 18));
-                            out += (char)(0x80 | ((cp >> 12) & 0x3F));
-                            out += (char)(0x80 | ((cp >> 6) & 0x3F));
-                            out += (char)(0x80 | (cp & 0x3F));
-                        }
+                        uint32_t cp;
+                        if (!parse_unicode_escape(cp)) return false;
+                        append_utf8(out, cp);
                         break;
                     }
                     default:
@@ -443,22 +543,62 @@ struct Json5AnyParser {
         return true;
     }
 
-    // Read an ECMAScript ASCII IdentifierName into `out`. Caller has
-    // already verified the next character is a valid id_start.
-    void scan_identifier(std::string &out) {
-        size_t start = pos;
-        pos++; // consume id_start
-        while (!at_end() && is_id_part(src[pos])) pos++;
-        out.assign(src + start, pos - start);
-    }
-
+    // Parse an unquoted object key as an ECMAScript IdentifierName (#2314).
+    // Accepts UTF-8 codepoints classified by IdentifierStart / Part as
+    // well as `\uHHHH` escapes (with surrogate-pair joining) that resolve
+    // to such codepoints. Raw bytes between escapes are bulk-copied as
+    // a single slice instead of being decoded and re-encoded per
+    // codepoint — the ASCII-only common case becomes a memcpy of the
+    // whole key.
     bool parse_identifier_key(std::string &out) {
-        if (at_end() || !is_id_start(src[pos])) {
+        out.clear();
+        if (at_end()) {
             error = "expected object key at ";
             error += formatPosition(pos);
             return false;
         }
-        scan_identifier(out);
+        bool first = true;
+        size_t run_start = pos;
+        while (true) {
+            if (!at_end() && src[pos] == '\\') {
+                // Flush the pending raw run before consuming the escape.
+                if (pos > run_start) out.append(src + run_start, pos - run_start);
+                if (pos + 1 >= src_len || src[pos + 1] != 'u') {
+                    error = "invalid escape in object key at ";
+                    error += formatPosition(pos);
+                    return false;
+                }
+                size_t esc_start = pos;
+                pos += 2;
+                uint32_t cp;
+                if (!parse_unicode_escape(cp)) return false;
+                if (first ? !is_id_start(cp) : !is_id_part(cp)) {
+                    error = "escape \\u resolves to non-identifier codepoint at ";
+                    error += formatPosition(esc_start);
+                    return false;
+                }
+                append_utf8(out, cp);
+                run_start = pos;
+                first = false;
+                continue;
+            }
+            if (at_end()) break;
+            // Decode for validation only — raw bytes are bulk-copied at flush.
+            uint32_t cp;
+            size_t step = decode_utf8_cp(src + pos, src_len - pos, cp);
+            bool ok = step != 0 && (first ? is_id_start(cp) : is_id_part(cp));
+            if (!ok) {
+                if (first) {
+                    error = "expected object key at ";
+                    error += formatPosition(pos);
+                    return false;
+                }
+                break;
+            }
+            pos += step;
+            first = false;
+        }
+        if (pos > run_start) out.append(src + run_start, pos - run_start);
         return true;
     }
 
@@ -511,8 +651,8 @@ struct Json5AnyParser {
             if (pos == hex_start) return fail("invalid hex literal at ");
             // Reject identifier-trailing characters (e.g. 0xZZ already caught by
             // hex_digit_value; an alphanumeric immediately after hex is a syntax
-            // error).
-            if (!at_end() && is_id_part(src[pos])) return fail("invalid hex literal at ");
+            // error). Unicode identifier chars after the hex digits also reject.
+            if (trailing_codepoint_is_id_part(pos)) return fail("invalid hex literal at ");
             // 64-bit u64 fits in at most 16 hex digits. Anything longer would
             // silently wrap during the shift-accumulate loop below (matches the
             // decimal path's `strtoll` ERANGE check).
@@ -604,13 +744,13 @@ struct Json5AnyParser {
 
     bool parse_bool(RyAny &out) {
         if (src_len - pos >= 4 && memcmp(src + pos, "true", 4) == 0 &&
-            (pos + 4 >= src_len || !is_id_part(src[pos + 4]))) {
+            !trailing_codepoint_is_id_part(pos + 4)) {
             pos += 4;
             out = anyFromBool(1);
             return true;
         }
         if (src_len - pos >= 5 && memcmp(src + pos, "false", 5) == 0 &&
-            (pos + 5 >= src_len || !is_id_part(src[pos + 5]))) {
+            !trailing_codepoint_is_id_part(pos + 5)) {
             pos += 5;
             out = anyFromBool(0);
             return true;
@@ -622,7 +762,7 @@ struct Json5AnyParser {
 
     bool parse_null(RyAny &out) {
         if (src_len - pos >= 4 && memcmp(src + pos, "null", 4) == 0 &&
-            (pos + 4 >= src_len || !is_id_part(src[pos + 4]))) {
+            !trailing_codepoint_is_id_part(pos + 4)) {
             pos += 4;
             out = anyFromUnit();
             return true;
@@ -747,13 +887,11 @@ struct Json5AnyParser {
             char kc = peek();
             if (kc == '"' || kc == '\'') {
                 if (!parse_string_bytes(keybuf)) { cleanup(); return false; }
-            } else if (is_id_start(kc)) {
-                if (!parse_identifier_key(keybuf)) { cleanup(); return false; }
             } else {
-                error = "expected object key at ";
-                error += formatPosition(pos);
-                cleanup();
-                return false;
+                // Identifier key: UTF-8 codepoint or `\uHHHH` escape.
+                // parse_identifier_key emits "expected object key" if the
+                // input cannot start one.
+                if (!parse_identifier_key(keybuf)) { cleanup(); return false; }
             }
             char *key = makeString(keybuf.data(), keybuf.size());
 

--- a/tests/spec/json5.test.ry
+++ b/tests/spec/json5.test.ry
@@ -456,6 +456,113 @@ fn json5UnquotedKeyTests():
       Err(e): expect(byteLen(e.message) > 0).toEq(true)
 
 # ============================================================================
+# JSON5-specific feature: unquoted object keys — Unicode (#2314)
+# ============================================================================
+
+@describe("json5 — unquoted object keys — Unicode")
+fn json5UnicodeUnquotedKeyTests():
+  @it("should accept Japanese CJK unquoted key")
+  fn shouldAcceptJapaneseKey():
+    case load[Map<str, any>]("{名前: \"John\"}"):
+      Ok(v): expect(stringify(v)).toEq("{\"名前\":\"John\"}")
+      Err(e): fail("Japanese key failed: " + e.message)
+
+  @it("should accept Chinese CJK unquoted key")
+  fn shouldAcceptChineseKey():
+    case load[Map<str, any>]("{姓名: \"Li\"}"):
+      Ok(v): expect(stringify(v)).toEq("{\"姓名\":\"Li\"}")
+      Err(e): fail("Chinese key failed: " + e.message)
+
+  @it("should accept Korean Hangul unquoted key")
+  fn shouldAcceptKoreanKey():
+    case load[Map<str, any>]("{이름: \"Kim\"}"):
+      Ok(v): expect(stringify(v)).toEq("{\"이름\":\"Kim\"}")
+      Err(e): fail("Korean key failed: " + e.message)
+
+  @it("should accept Greek-letter unquoted key")
+  fn shouldAcceptGreekKey():
+    case load[Map<str, any>]("{αλφα: 1}"):
+      Ok(v): expect(stringify(v)).toEq("{\"αλφα\":1}")
+      Err(e): fail("Greek key failed: " + e.message)
+
+  @it("should accept Arabic-Indic digit in middle position")
+  fn shouldAcceptArabicIndicDigitInMiddle():
+    case load[Map<str, any>]("{a١b: 1}"):
+      Ok(v): expect(stringify(v)).toEq("{\"a١b\":1}")
+      Err(e): fail("Arabic digit in middle failed: " + e.message)
+
+  @it("should accept combining-mark in middle position")
+  fn shouldAcceptCombiningMarkInMiddle():
+    # ́ = combining acute (XID_Continue). JSON5 escape decodes to
+    # UTF-8 bytes 0xCC 0x81. Output key bytes: e (0x65) + combining (0xCC 0x81).
+    case load[Map<str, any>]("{e\\u0301: 1}"):
+      Ok(v): expect(toBytes(stringify(v))).toEq([0x7Bu8, 0x22u8, 0x65u8, 0xCCu8, 0x81u8, 0x22u8, 0x3Au8, 0x31u8, 0x7Du8])
+      Err(e): fail("combining-mark key failed: " + e.message)
+
+  @it("should accept \\uHHHH escape in unquoted key")
+  fn shouldAcceptUnicodeEscapeInKey():
+    # 名 = 名, 前 = 前. Output key is the raw UTF-8 of 名前.
+    case load[Map<str, any>]("{\\u540D\\u524D: \"x\"}"):
+      Ok(v): expect(stringify(v)).toEq("{\"名前\":\"x\"}")
+      Err(e): fail("\\uHHHH escape in key failed: " + e.message)
+
+  @it("should accept ZWNJ (U+200C) in middle position")
+  fn shouldAcceptZwnjInKey():
+    # ZWNJ encodes as UTF-8 0xE2 0x80 0x8C.
+    case load[Map<str, any>]("{a\\u200Cb: 1}"):
+      Ok(v): expect(toBytes(stringify(v))).toEq([0x7Bu8, 0x22u8, 0x61u8, 0xE2u8, 0x80u8, 0x8Cu8, 0x62u8, 0x22u8, 0x3Au8, 0x31u8, 0x7Du8])
+      Err(e): fail("ZWNJ key failed: " + e.message)
+
+  @it("should accept ZWJ (U+200D) in middle position")
+  fn shouldAcceptZwjInKey():
+    # ZWJ encodes as UTF-8 0xE2 0x80 0x8D.
+    case load[Map<str, any>]("{a\\u200Db: 1}"):
+      Ok(v): expect(toBytes(stringify(v))).toEq([0x7Bu8, 0x22u8, 0x61u8, 0xE2u8, 0x80u8, 0x8Du8, 0x62u8, 0x22u8, 0x3Au8, 0x31u8, 0x7Du8])
+      Err(e): fail("ZWJ key failed: " + e.message)
+
+  @it("should accept surrogate-pair \\uHHHH\\uHHHH for non-BMP letter")
+  fn shouldAcceptSurrogatePairInKey():
+    # 𠀋 joins to U+2000B (CJK Extension B letter, XID_Start).
+    # UTF-8 encoding: 0xF0 0xA0 0x80 0x8B.
+    case load[Map<str, any>]("{\\uD840\\uDC0B: 1}"):
+      Ok(v): expect(toBytes(stringify(v))).toEq([0x7Bu8, 0x22u8, 0xF0u8, 0xA0u8, 0x80u8, 0x8Bu8, 0x22u8, 0x3Au8, 0x31u8, 0x7Du8])
+      Err(e): fail("surrogate-pair key failed: " + e.message)
+
+  @it("should reject Unicode digit at key start")
+  fn shouldRejectUnicodeDigitFirstKey():
+    # ١ (Arabic-Indic digit one, U+0661) is XID_Continue but not XID_Start.
+    case load[Map<str, any>]("{١abc: 1}"):
+      Ok(_): fail("expected Err for Unicode-digit-first key")
+      Err(e): expect(e.message).toContain("expected object key")
+
+  @it("should reject punctuation at key start")
+  fn shouldRejectPunctuationStartKey():
+    case load[Map<str, any>]("{,abc: 1}"):
+      Ok(_): fail("expected Err for punctuation-first key")
+      Err(e): expect(e.message).toContain("expected object key")
+
+  @it("should reject malformed \\u escape in key")
+  fn shouldRejectMalformedUnicodeEscape():
+    case load[Map<str, any>]("{\\uZZZZ: 1}"):
+      Ok(_): fail("expected Err for malformed \\u escape")
+      Err(e): expect(e.message).toContain("invalid hex digit")
+
+  @it("should reject \\u escape that resolves to a digit at key start")
+  fn shouldRejectEscapeResolvingToDigit():
+    # 1 = '1' — IdentifierStart rejects it just like a literal '1'.
+    case load[Map<str, any>]("{\\u0031abc: 1}"):
+      Ok(_): fail("expected Err for escape-to-digit at start")
+      Err(e): expect(e.message).toContain("non-identifier codepoint")
+
+  @it("should reject 'true' followed by Unicode identifier character")
+  fn shouldRejectTrueWithUnicodeSuffix():
+    # '名' (U+540D, XID_Continue) is identifier-continuation, so 'true名'
+    # is not the boolean literal — parse_bool's trailing guard rejects it.
+    case load[Map<str, any>]("{a: true名}"):
+      Ok(_): fail("expected Err for true+Unicode-suffix")
+      Err(e): expect(e.message).toContain("invalid literal")
+
+# ============================================================================
 # JSON5-specific feature: hex literals
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- Extend json5 unquoted object keys from ASCII subset to ECMAScript `IdentifierName` (Unicode letters/digits via XID_Start/XID_Continue, plus `$`, `_`, ZWNJ, ZWJ, and `\uHHHH` escapes with surrogate-pair joining). Closes the cross-language interop gap with JavaScript `JSON5.parse`, Python `pyjson5`, and the Rust `json5` crate.
- New Rust cdylib `crates/xid/` (`unicode-ident` wrapper) exposing `__ry_xid_start(u32)` / `__ry_xid_continue(u32)`. Linked into `ry` / `ry_tests` via the `emit` pattern so symbols resolve process-wide into dlopen'd libry_json5 without an inter-library link dependency.
- json5.cpp gains an RFC 3629 strict UTF-8 codepoint decoder + encoder, a Unicode-aware `parse_identifier_key` (bulk-copies non-escape runs so ASCII keys stay FFI-free), and ECMAScript-aware trailing guards for `parse_bool` / `parse_null` / `parse_number` hex literals.

## Test plan

- [x] `./build-rust/ry test tests/spec/json5.test.ry` — 98 / 98 pass including the new `@describe("json5 — unquoted object keys — Unicode")` block (15 cases: Japanese/Chinese/Korean/Greek/Arabic-Indic-digit/combining-mark/`\uHHHH`/ZWNJ/ZWJ/surrogate-pair plus reject cases for Unicode-digit-first, punctuation-start, malformed escape, escape-to-digit, `true`+Unicode suffix).
- [x] `./build-rust/ry test -p` — 219 spec files, 0 failures.
- [x] `./build-rust/ry_tests --gtest_filter='*Json5*:*JSON5*'` — 37 / 37 pass.
- [x] ASan + UBSan via `./docker/run.sh asan ry_tests` and `./docker/run.sh asan ry test -p` — 2944 + 219 cases, 0 sanitizer findings.
- [x] `cargo clippy --release -- -D warnings` on `crates/xid/` — clean.

Closes #2314