### PR TITLE
feat(any): warn on direct arithmetic and ordering operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,7 @@ add_executable(ry_tests
     tests/test_emit_llvm_ir.cpp
     tests/test_deprecated_warnings.cpp
     tests/test_ry_namespace_warning.cpp
+    tests/test_any_op_warnings.cpp
     tests/test_codegen_call_json_reject.cpp
     tests/test_codegen_call_json5_reject.cpp
     tests/test_spec_timeout.cpp

--- a/changelog.d/2316-restrict-any-operators.md
+++ b/changelog.d/2316-restrict-any-operators.md
@@ -1,0 +1,3 @@
+### Deprecated
+
+- `any` 値への直接算術演算子 (`+`, `-`, `*`, `/`, `//`, `%`, `**`, 単項 `-`) と順序比較演算子 (`<`, `<=`, `>`, `>=`) を deprecated とし、コンパイル時に stderr へ one-time 警告を発するようにした。`==` / `!=` と `print` / `str` / f-string 補間は retained-and-documented として警告対象外 (`__ry_any_eq` は型不一致で `false` を返すのみで trap しないため安全、文字列化は migration boundary として保持)。移行は #2315 で追加した `asType[T](v: any) -> Result<T, Error>` を使い narrow してから操作する。dedup は演算子単位で 1 回 (`+` を 5 回使っても警告は 1 行のみ)。動作は変わらず、警告のみで rejection は行わない (`tests/spec/any.test.ry` の既存テストは引き続き exit code 0 で pass する; 出力に warning が混ざるのは deprecation 期間中の意図された動作)。strict mode への昇格 (toggle 導入 + 既定の reject 化) は #2322 予定。compound assignment (`x += 5` where `x: any`) は `emitBinaryOp` 経由で同じ gate を通るためカバー済み。 (#2316)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -951,6 +951,29 @@ x = true       # OK: now holds bool
 
 ### Arithmetic Operations
 
+> **Deprecated (#2316)**: Direct arithmetic operators (`+`, `-`, `*`, `/`, `//`, `%`, `**`, unary `-`) on `any` values are deprecated and emit a compile-time warning on stderr. They continue to work during the deprecation window. Use [`asType[T]`](#explicit-any-conversion-astype--istype) to narrow before operating:
+>
+> ```ry
+> x: any = 10
+> y: any = 3
+> # Deprecated: direct arithmetic on any
+> # z: any = x + y
+>
+> # Preferred: narrow first
+> case asType[int](x):
+>     Ok(xi):
+>         case asType[int](y):
+>             Ok(yi):
+>                 z: int = xi + yi
+>                 print(z)
+>             Err(e):
+>                 print(e.message)
+>     Err(e):
+>         print(e.message)
+> ```
+>
+> The warning is per-operator, deduplicated, and one-time per compilation. Strict-mode escalation to a hard error is planned for #2322.
+
 When both operands are `any`, arithmetic operations dispatch at runtime based on the actual types:
 
 | Operation | Types | Result |
@@ -981,10 +1004,30 @@ Incompatible type combinations (e.g., `str - int`) cause a **runtime error**.
 
 ### Comparison Operations
 
+`==` and `!=` on `any` are **retained** and do not emit a deprecation warning. The runtime returns `false` on type mismatch (different tags) rather than trapping, so dynamic equality is safe. For collections held in `any`, equality reduces to pointer identity — see [Element-Type Metadata is Erased](#element-type-metadata-is-erased) for the rationale.
+
+> **Deprecated (#2316)**: Ordering comparisons (`<`, `<=`, `>`, `>=`) on `any` values are deprecated and emit a compile-time warning on stderr. They trap at runtime on type mismatch (e.g., `int < str`). Use [`asType[T]`](#explicit-any-conversion-astype--istype) to narrow before comparing:
+>
+> ```ry
+> x: any = 3
+> y: any = 4
+> # Deprecated: direct ordering on any
+> # print(x < y)
+>
+> # Preferred: narrow first
+> case asType[int](x):
+>     Ok(xi):
+>         case asType[int](y):
+>             Ok(yi):
+>                 print(xi < yi)
+>             Err(e): print(e.message)
+>     Err(e): print(e.message)
+> ```
+
 | Operation | Behavior |
 |-----------|----------|
-| `==`, `!=` | Works for same types; int/float mixing is allowed |
-| `<`, `<=`, `>`, `>=` | Numeric (int/float mixing allowed) and string (lexicographic) |
+| `==`, `!=` | Retained. Same-type compare; int/float mixing allowed; type-mismatch returns `false` |
+| `<`, `<=`, `>`, `>=` | Deprecated (warned). Numeric (int/float mixing allowed) and string (lexicographic); type-mismatch traps at runtime |
 
 ```ry
 x: any = 3
@@ -992,9 +1035,9 @@ y: any = 3.0
 print(x == y)    # true (int/float comparison)
 ```
 
-Type mismatches in comparison (e.g., `int < str`) cause a **runtime error**.
-
 ### String Conversion
+
+`print(anyVal)`, `str(anyVal)`, and f-string interpolation `f"{anyVal}"` on `any` values are **retained** and do not emit a deprecation warning (#2316).
 
 `any` values support `print()` and f-string interpolation:
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1198,8 +1198,16 @@ public:
     std::unordered_set<std::string> deprecated_variables_;
     std::unordered_set<std::string> deprecated_fields_;  // "TypeName.fieldName"
     std::vector<std::string> warnings_;
+    // #2316: keyed by operator spelling ("+", "<", "unary -") to avoid pushing
+    // one string per call site into warnings_ when an op repeats. jit_runner
+    // content-dedups warnings_ at surface time too, so this only prunes the
+    // per-site allocation cost — observable output is the same either way.
+    std::unordered_set<std::string> warned_any_ops_;
 
     void emitDeprecationWarning(const std::string &name);
+    // #2316: push a deprecation warning for direct `<op>` on `any`, deduped
+    // by `opKey` (operator spelling). #2322 will flip the body to codegenError.
+    void warnAnyOpDeprecated(std::string opKey, std::string message);
 
     // @native let constants
     std::unordered_set<std::string> native_constants_;

--- a/src/codegen_any.cpp
+++ b/src/codegen_any.cpp
@@ -2214,6 +2214,19 @@ llvm::Value *CodeGen::emitAnyBinaryOp(const std::string &op,
         {">", "__ry_any_gt"},  {">=", "__ry_any_ge"},
     };
 
+    // #2316: arithmetic and ordering comparison on any are deprecated; use
+    // asType[T] to narrow first. == / != are intentionally retained because
+    // __ry_any_eq returns 0 on type mismatch (safe), while orderCompare traps.
+    const bool isArith = arithOps.count(op) > 0;
+    const bool isOrdering =
+        (op == "<" || op == "<=" || op == ">" || op == ">=");
+    if (isArith || isOrdering) {
+        warnAnyOpDeprecated(op,
+            "warning: operator '" + op + "' on 'any' is deprecated; "
+            "use asType[T] to unwrap before operating "
+            "(see docs/reference/types.md 'Explicit any conversion')");
+    }
+
     auto ait = arithOps.find(op);
     if (ait != arithOps.end()) {
         llvm::AllocaInst *resultPtr = builder_.CreateAlloca(anyTy_, nullptr, "any.result");
@@ -2395,7 +2408,18 @@ llvm::Value *CodeGen::emitAnyPathStep(llvm::Value *anyVal,
     return phi;
 }
 
+void CodeGen::warnAnyOpDeprecated(std::string opKey, std::string message) {
+    if (warned_any_ops_.insert(std::move(opKey)).second)
+        warnings_.push_back(std::move(message));
+}
+
 llvm::Value *CodeGen::emitAnyUnaryNeg(llvm::Value *operand) {
+    // #2316: unary `-` on any is deprecated; use asType[int] / asType[float]
+    // to narrow first. Keyed as "unary -" to avoid colliding with binary `-`.
+    warnAnyOpDeprecated("unary -",
+        "warning: unary operator '-' on 'any' is deprecated; "
+        "use asType[int] or asType[float] to unwrap before negating "
+        "(see docs/reference/types.md 'Explicit any conversion')");
     llvm::AllocaInst *opPtr = builder_.CreateAlloca(anyTy_, nullptr, "any.neg.op");
     builder_.CreateStore(operand, opPtr);
     llvm::AllocaInst *resultPtr = builder_.CreateAlloca(anyTy_, nullptr, "any.neg.result");

--- a/tests/test_any_op_warnings.cpp
+++ b/tests/test_any_op_warnings.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <array>
+#include <cerrno>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -75,8 +76,11 @@ RunResult runRy(std::vector<const char *> args) {
     outReader.join();
     errReader.join();
     int status = 0;
-    waitpid(pid, &status, 0);
-    r.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    pid_t waited = -1;
+    do {
+        waited = waitpid(pid, &status, 0);
+    } while (waited == -1 && errno == EINTR);
+    r.exit_code = (waited == pid && WIFEXITED(status)) ? WEXITSTATUS(status) : -1;
     return r;
 }
 

--- a/tests/test_any_op_warnings.cpp
+++ b/tests/test_any_op_warnings.cpp
@@ -1,0 +1,260 @@
+#include <gtest/gtest.h>
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+#include <unistd.h>
+#include <sys/wait.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct RunResult {
+    std::string out;
+    std::string err;
+    int exit_code = -1;
+};
+
+RunResult runRy(std::vector<const char *> args) {
+    int pipeOut[2];
+    int pipeErr[2];
+    if (pipe(pipeOut) != 0) return {};
+    if (pipe(pipeErr) != 0) {
+        close(pipeOut[0]);
+        close(pipeOut[1]);
+        return {};
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipeOut[0]); close(pipeOut[1]);
+        close(pipeErr[0]); close(pipeErr[1]);
+        return {};
+    }
+
+    if (pid == 0) {
+        close(pipeOut[0]);
+        close(pipeErr[0]);
+        dup2(pipeOut[1], STDOUT_FILENO);
+        dup2(pipeErr[1], STDERR_FILENO);
+        close(pipeOut[1]);
+        close(pipeErr[1]);
+        close(STDIN_FILENO);
+
+        // argv[0] must be the full RY_BINARY_PATH so Linux glibc's
+        // fs::canonical(parent_path(argv[0])) resolves the exe-adjacent
+        // stdlib search path (.claude/rules/tests-cpp-conventions.md).
+        std::vector<const char *> argv{RY_BINARY_PATH};
+        argv.insert(argv.end(), args.begin(), args.end());
+        argv.push_back(nullptr);
+
+        execv(RY_BINARY_PATH, const_cast<char *const *>(argv.data()));
+        _exit(127);
+    }
+
+    close(pipeOut[1]);
+    close(pipeErr[1]);
+
+    auto readAll = [](int fd) -> std::string {
+        std::string result;
+        std::array<char, 4096> buf{};
+        ssize_t n;
+        while ((n = read(fd, buf.data(), buf.size())) > 0)
+            result.append(buf.data(), static_cast<size_t>(n));
+        close(fd);
+        return result;
+    };
+
+    RunResult r;
+    std::thread outReader([&]() { r.out = readAll(pipeOut[0]); });
+    std::thread errReader([&]() { r.err = readAll(pipeErr[0]); });
+    outReader.join();
+    errReader.join();
+    int status = 0;
+    waitpid(pid, &status, 0);
+    r.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    return r;
+}
+
+size_t countOccurrences(const std::string &haystack, const std::string &needle) {
+    if (needle.empty()) return 0;
+    size_t count = 0;
+    size_t pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+        ++count;
+        pos += needle.size();
+    }
+    return count;
+}
+
+class AnyOpWarningsTest : public ::testing::Test {
+protected:
+    fs::path tmpDir_;
+
+    void SetUp() override {
+        tmpDir_ = fs::path(RY_BINARY_PATH).parent_path() / "any_op_warnings_test";
+        fs::remove_all(tmpDir_);
+        fs::create_directories(tmpDir_);
+    }
+
+    void TearDown() override { fs::remove_all(tmpDir_); }
+
+    fs::path writeScript(const std::string &name, const std::string &content) {
+        auto p = tmpDir_ / name;
+        std::ofstream(p) << content;
+        return p;
+    }
+};
+
+} // namespace
+
+// Arithmetic on `any` emits a deprecation warning and mentions the
+// `asType` migration path. The program still runs and produces the
+// expected result — this is warn-only during the deprecation window.
+TEST_F(AnyOpWarningsTest, ArithmeticPlusEmitsWarning) {
+    auto p = writeScript("any_plus.ry",
+        "x: any = 10\n"
+        "y: any = 20\n"
+        "z: any = x + y\n"
+        "print(z)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "stderr should contain 'deprecated': " << r.err;
+    EXPECT_NE(r.err.find("asType"), std::string::npos)
+        << "stderr should suggest 'asType' for migration: " << r.err;
+    EXPECT_NE(r.err.find("'+'"), std::string::npos)
+        << "stderr should quote the offending operator: " << r.err;
+    EXPECT_NE(r.out.find("30"), std::string::npos)
+        << "program must still produce the result: " << r.out;
+}
+
+TEST_F(AnyOpWarningsTest, OrderingLtEmitsWarning) {
+    auto p = writeScript("any_lt.ry",
+        "x: any = 3\n"
+        "y: any = 4\n"
+        "print(x < y)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "stderr should contain 'deprecated': " << r.err;
+    EXPECT_NE(r.err.find("'<'"), std::string::npos)
+        << "stderr should quote the offending operator: " << r.err;
+    EXPECT_NE(r.out.find("true"), std::string::npos)
+        << "program must still produce the result: " << r.out;
+}
+
+TEST_F(AnyOpWarningsTest, UnaryNegEmitsWarning) {
+    auto p = writeScript("any_neg.ry",
+        "x: any = 5\n"
+        "print(-x)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "stderr should contain 'deprecated': " << r.err;
+    EXPECT_NE(r.err.find("unary"), std::string::npos)
+        << "stderr should label the operator as unary: " << r.err;
+    EXPECT_NE(r.out.find("-5"), std::string::npos)
+        << "program must still negate: " << r.out;
+}
+
+// Equality is explicitly retained per #2316 acceptance criteria —
+// `__ry_any_eq` returns 0 (false) on type mismatch rather than trapping,
+// so it's safe dynamic. No warning expected.
+TEST_F(AnyOpWarningsTest, EqualityNoWarning) {
+    auto p = writeScript("any_eq.ry",
+        "x: any = 3\n"
+        "y: any = 3\n"
+        "print(x == y)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_EQ(r.err.find("deprecated"), std::string::npos)
+        << "equality on any must NOT warn (retained-and-documented): " << r.err;
+    EXPECT_NE(r.out.find("true"), std::string::npos) << r.out;
+}
+
+TEST_F(AnyOpWarningsTest, InequalityNoWarning) {
+    auto p = writeScript("any_ne.ry",
+        "x: any = 3\n"
+        "y: any = 4\n"
+        "print(x != y)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_EQ(r.err.find("deprecated"), std::string::npos)
+        << "inequality on any must NOT warn (retained-and-documented): " << r.err;
+    EXPECT_NE(r.out.find("true"), std::string::npos) << r.out;
+}
+
+// String conversion is retained too — `print(any)` and f-string
+// interpolation must not warn.
+TEST_F(AnyOpWarningsTest, PrintAnyNoWarning) {
+    auto p = writeScript("any_print.ry",
+        "x: any = 42\n"
+        "print(x)\n"
+        "print(f\"value={x}\")\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_EQ(r.err.find("deprecated"), std::string::npos)
+        << "print(any) and f-string must NOT warn (retained-and-documented): "
+        << r.err;
+}
+
+// Compound assignment routes through emitBinaryOp -> emitAnyBinaryOp,
+// so the warning at the binary-op gate covers it for free.
+TEST_F(AnyOpWarningsTest, CompoundAssignEmitsWarning) {
+    auto p = writeScript("any_compound.ry",
+        "x: any = 10\n"
+        "x += 5\n"
+        "print(x)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "compound assignment must warn (routes through emitAnyBinaryOp): "
+        << r.err;
+    EXPECT_NE(r.out.find("15"), std::string::npos) << r.out;
+}
+
+// Per-operator dedup: five `+` uses on `any` in one program produce
+// exactly one warning.
+TEST_F(AnyOpWarningsTest, WarningDedupedPerOperator) {
+    auto p = writeScript("any_dedup.ry",
+        "x: any = 1\n"
+        "a: any = x + x\n"
+        "b: any = x + x\n"
+        "c: any = x + x\n"
+        "d: any = x + x\n"
+        "e: any = x + x\n"
+        "print(e)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_EQ(countOccurrences(r.err, "deprecated"), 1u)
+        << "same operator must warn at most once, stderr was: " << r.err;
+}
+
+// One operand `any` + one concrete: the concrete is auto-wrapped at the
+// binary-op gate (codegen_expr.cpp:1716-1717), so the warning still
+// fires inside emitAnyBinaryOp.
+TEST_F(AnyOpWarningsTest, MixedAnyAndConcreteEmitsWarning) {
+    auto p = writeScript("any_mixed.ry",
+        "x: any = 10\n"
+        "print(x + 20)\n");
+
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0) << "stderr: " << r.err;
+    EXPECT_NE(r.err.find("deprecated"), std::string::npos)
+        << "mixed any+concrete must warn (concrete is auto-wrapped): "
+        << r.err;
+    EXPECT_NE(r.out.find("30"), std::string::npos) << r.out;
+}


### PR DESCRIPTION
## Summary

- `any` 値への直接算術 (`+ - * / // % **`, 単項 `-`) と順序比較 (`< <= > >=`) を deprecated とし、codegen 時に stderr へ one-time 警告を発する。`== !=` と `print` / `str` / f-string 補間は retained-and-documented として警告対象外 (`__ry_any_eq` は型不一致で `false` を返すのみで trap しないため安全、文字列化は migration boundary として保持)。
- 移行は #2315 で追加した `asType[T](v: any) -> Result<T, Error>` を使う。`CodeGen::warnAnyOpDeprecated(opKey, message)` helper + `warned_any_ops_` set で operator 単位の dedup。compound assignment (`x += 5` where `x: any`) は `emitBinaryOp` 経由で同じ gate を通るためカバー済み。
- 動作は変わらず、警告のみで rejection は行わない。`tests/spec/any.test.ry` の既存 213 テストは引き続き exit code 0 で pass する。strict mode への昇格 (toggle 導入 + 既定の reject 化) は #2322 予定。

Closes #2316

## Test plan

- [x] `./build-rust/ry_tests --gtest_filter='AnyOpWarningsTest.*'` — 9/9 pass (arith / ordering / unary が warn, equality / print が non-warn, dedup, compound, mixed-any-and-concrete を verify)
- [x] `./build-rust/ry_tests` — 2963/2963 pass (回帰なし)
- [x] `./build-rust/ry test -p` — 219 files / 0 failures
- [x] `./build-rust/ry test tests/spec/any.test.ry` — 213 / 0 failures (既存 arith / ordering テストは warning が stderr に出るが pass)
- [x] ASan — 219 files / 0 failures
- [x] scan-build / cppcheck — No bugs found
- [x] Manual smoke: `x + 20` → warning + `30` / `x == y` → silent + `true` / `x += 5` → warning + `15`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compile-time warnings for direct `any` arithmetic and ordering operations, with guidance to narrow values before using operators.
  * Expanded test coverage for warning behavior, including deduplication and mixed-type cases.
* **Bug Fixes**
  * Equality and inequality on `any` now remain supported without warnings.
  * String conversion and interpolation with `any` continue to work as expected.
* **Documentation**
  * Updated reference docs and changelog notes to explain the new `any` operator behavior and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->