### PR TITLE
feat(lint): warn on broad any usage before strict semantics ship

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ add_executable(ry_tests
     tests/test_codegen_type_safety.cpp
     tests/test_emit_llvm_ir.cpp
     tests/test_deprecated_warnings.cpp
+    tests/test_any_usage_warnings.cpp
     tests/test_ry_namespace_warning.cpp
     tests/test_any_op_warnings.cpp
     tests/test_codegen_call_json_reject.cpp

--- a/include/ry/ast/ast.hpp
+++ b/include/ry/ast/ast.hpp
@@ -46,6 +46,14 @@ struct TypeNode {
 
     std::string toString() const;
 
+    // #2317: source-level "is the user-written type the bare name 'any'?".
+    // Returns false for type aliases that resolve to any, generics, etc. —
+    // intentionally syntactic for any-usage lint, not semantic.
+    bool isBareAnyName() const {
+        const auto *b = std::get_if<BasicType>(&data);
+        return b && b->name == "any";
+    }
+
     static TypeNodePtr makeBasic(std::string name); // NOLINT(performance-unnecessary-value-param)
     static TypeNodePtr makeGeneric(std::string name, std::vector<TypeNodePtr> args); // NOLINT(performance-unnecessary-value-param)
     static TypeNodePtr makeArray(TypeNodePtr elem, uint64_t size);
@@ -260,7 +268,7 @@ struct CallStmt   { std::string callee; std::vector<ExprPtr> args; std::vector<N
 struct ExprStmt   { ExprPtr expr; SourceLocation loc; };
 
 struct ReturnStmt { ExprPtr value; SourceLocation loc; };
-struct FnParam { std::string name; TypeNodePtr type; ExprPtr default_value; };
+struct FnParam { std::string name; TypeNodePtr type; ExprPtr default_value; bool has_explicit_type = false; };
 
 struct ImportName {
     std::string name;                       // original symbol name from the module

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -53,6 +53,18 @@ public:
     llvm::orc::ThreadSafeModule compile(Program &prog);
     const std::vector<std::string>& getWarnings() const { return warnings_; }
 
+    // #2317: arm any-usage lint warnings and supply the set of file_ids whose
+    // definitions should be exempt (stdlib + cross-package imports — code the
+    // importer cannot act on). Called once by jit_runner after import
+    // resolution. In-process codegen unit tests skip this call, leaving lint
+    // disabled so their `warnings_` vector stays empty. The user's
+    // intra-package multi-file project is NOT in `external_ids` and stays
+    // subject to lint.
+    void enableAnyUsageLint(std::unordered_set<int> external_ids) {
+        any_lint_enabled_ = true;
+        external_file_ids_ = std::move(external_ids);
+    }
+
     // --- @native fn signature types ---
 
     struct NativeFnParam {
@@ -1172,6 +1184,20 @@ public:
     const SourceManager *sm_ = nullptr;
     SourceLocation current_loc_;
     std::string current_function_name_;
+    // #2317: lint state (see enableAnyUsageLint comment).
+    bool any_lint_enabled_ = false;
+    std::unordered_set<int> external_file_ids_;
+    bool shouldEmitAnyLintAt(int file_id) const {
+        // Off: in-process tests that never called enableAnyUsageLint.
+        // file_id in external_file_ids_: stdlib / cross-package import.
+        return any_lint_enabled_ && external_file_ids_.count(file_id) == 0;
+    }
+    // Centralized prefix for any-usage lint messages (analogue of
+    // emitDeprecationWarning) so the "warning: " prefix and future
+    // formatting changes live at one site.
+    void emitAnyUsageWarning(std::string msg) {
+        warnings_.push_back("warning: " + std::move(msg));
+    }
     std::unordered_set<int64_t> registered_coverage_lines_;
 
     // ======== Coverage & Tracing ========

--- a/include/ry/module/module_loader.hpp
+++ b/include/ry/module/module_loader.hpp
@@ -76,6 +76,16 @@ public:
         return loader_warnings_;
     }
 
+    // #2317: file_ids belonging to stdlib or cross-package modules that
+    // were inlined into the resolved program. CodeGen uses this set to
+    // suppress any-usage lint warnings on definitions the importer cannot
+    // act on (third-party / stdlib). Definitions from the user's own
+    // package (intra-package multi-file projects) are NOT added here, so
+    // they remain subject to lint.
+    const std::unordered_set<int> &externalFileIds() const {
+        return external_file_ids_;
+    }
+
 private:
     struct ResolvedPath {
         std::string path;
@@ -131,6 +141,8 @@ private:
 
     // Warnings emitted during import resolution; surfaced by `loaderWarnings()`.
     std::vector<std::string> loader_warnings_;
+    // #2317: see externalFileIds() comment for usage.
+    std::unordered_set<int> external_file_ids_;
     // #1769: referrer dirs whose `ry/` shadow probe has already been performed.
     // The probe does two filesystem stats per `ry/*` import; caching by
     // referrer collapses N stats into one for files with multiple `ry.*` imports.

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -747,6 +747,38 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         return;
     }
 
+    // #2317: warn on broad `any` usage. shouldEmitAnyLintAt suppresses
+    // warnings for stdlib / cross-package definitions (the importer
+    // cannot act on third-party code) while keeping warnings on for
+    // the user's own intra-package multi-file project. @native fns and
+    // generic templates are already short-circuited above.
+    if (shouldEmitAnyLintAt(s->loc.file_id)) {
+        const bool isPublic = hasDirective(s->directives, "public");
+        // Single pass: each param is either implicit-any (Pattern 3)
+        // or explicit-any on a @public fn (Pattern 2 param). The two
+        // arms are mutually exclusive on has_explicit_type.
+        for (const auto &p : s->params) {
+            if (!p.has_explicit_type) {
+                emitAnyUsageWarning("parameter '" + p.name +
+                    "' of function '" + s->name +
+                    "' has no type annotation and defaults to 'any'; "
+                    "add an explicit annotation, a union, "
+                    "or a generic type parameter");
+            } else if (isPublic && p.type && p.type->isBareAnyName()) {
+                emitAnyUsageWarning("public function '" + s->name +
+                    "' parameter '" + p.name + "' is typed 'any'; "
+                    "prefer a concrete type, union, "
+                    "or generic type parameter");
+            }
+        }
+        if (isPublic && s->return_type && s->return_type->isBareAnyName()) {
+            emitAnyUsageWarning("public function '" + s->name +
+                "' returns 'any'; "
+                "prefer a concrete return type, union, "
+                "or generic type parameter");
+        }
+    }
+
     // #1889: reject silent shadow of stdlib built-ins at the top-level.
     // Nested fns are scope-local closures and never feed the global
     // hardcoded-dispatch chain that the guard defends against, so the

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -600,6 +600,18 @@ void CodeGen::emitVarDecl(const std::string &name,
                             "' does not match expression type for variable '" + name + "'");
                     }
                 } else if (isAnyType(annotTy)) {
+                    // #2317 Pattern 1: explicit ': any' on a concrete RHS erases
+                    // statically inferred type information. The outer guard at
+                    // line 568 (annotTy != newTy) ensures newTy is non-any here.
+                    // shouldEmitAnyLintAt excludes stdlib / cross-package code;
+                    // current_loc_ is updated by emitStmt(AssignStmt&) before
+                    // the chain reaches here, so its file_id is the decl's.
+                    if (shouldEmitAnyLintAt(current_loc_.file_id)) {
+                        emitAnyUsageWarning("variable '" + name +
+                            "' is annotated 'any' but its initializer has a concrete type; "
+                            "remove the annotation to keep the inferred type, "
+                            "or replace 'any' with the concrete type");
+                    }
                     val = wrapInAny(val);
                     newTy = anyTy_;
                 } else if (isAnyType(newTy) &&
@@ -613,6 +625,17 @@ void CodeGen::emitVarDecl(const std::string &name,
                             (llvm::isa<llvm::StructType>(annotTy) &&
                              findRecordInfoForType(
                                  llvm::cast<llvm::StructType>(annotTy))))) {
+                    // #2317 Pattern 4: assigning any to a concrete-annotated
+                    // variable performs an implicit runtime unwrap. Warn
+                    // before the unwrap so users move to checked casts.
+                    // See Pattern 1 above for the gate rationale.
+                    if (shouldEmitAnyLintAt(current_loc_.file_id)) {
+                        emitAnyUsageWarning("assigning 'any' to variable '" + name +
+                            "' of type '" + *annot +
+                            "' performs an implicit runtime unwrap; "
+                            "use a checked cast such as 'asType[" + *annot +
+                            "](...)' or 'case' narrowing for safety");
+                    }
                     // any → narrow unwrap. The gate accepts every shape
                     // unwrapFromAny knows how to dispatch on annotTy:
                     //   - i64 + simple-enum metadata → descriptor-checked

--- a/src/jit/jit_runner.cpp
+++ b/src/jit/jit_runner.cpp
@@ -213,6 +213,12 @@ int runRySource(const std::string &src, const std::string &source_name,
                            {ry::TraceField("file", source_name)});
     auto cg = std::make_unique<CodeGen>(test_mode, &sm, coverage_mode, coverage_offset, outline_mode);
     cg->setTestingIntrinsicsImported(loader.importedTestingIntrinsics());
+    // #2317: arm any-usage lint for the user's package. The set of
+    // exempt file_ids (stdlib + cross-package imports) was accumulated
+    // by ModuleLoader while resolving imports; everything else,
+    // including the user's own intra-package multi-file project,
+    // stays subject to lint.
+    cg->enableAnyUsageLint(loader.externalFileIds());
     ThreadSafeModule tsm = [&]() {
         try {
             auto module = cg->compile(prog);

--- a/src/module/module_loader.cpp
+++ b/src/module/module_loader.cpp
@@ -116,6 +116,25 @@ static bool isExportable(const StmtNode &stmt) {
            std::holds_alternative<DirectiveDefStmt>(stmt);
 }
 
+// #2317: file_id of an exportable definition's source location. Used to
+// register stdlib / cross-package definitions as "external" so CodeGen
+// can gate any-usage lint warnings.
+static int getStmtFileId(const StmtNode &stmt) {
+    if (std::holds_alternative<std::unique_ptr<FnStmt>>(stmt))
+        return std::get<std::unique_ptr<FnStmt>>(stmt)->loc.file_id;
+    if (std::holds_alternative<RecordStmt>(stmt))
+        return std::get<RecordStmt>(stmt).loc.file_id;
+    if (std::holds_alternative<EnumStmt>(stmt))
+        return std::get<EnumStmt>(stmt).loc.file_id;
+    if (std::holds_alternative<TypeAliasStmt>(stmt))
+        return std::get<TypeAliasStmt>(stmt).loc.file_id;
+    if (std::holds_alternative<AssignStmt>(stmt))
+        return std::get<AssignStmt>(stmt).loc.file_id;
+    if (std::holds_alternative<DirectiveDefStmt>(stmt))
+        return std::get<DirectiveDefStmt>(stmt).loc.file_id;
+    return -1;
+}
+
 // Get the name of an exportable definition
 static std::string getExportName(const StmtNode &stmt) {
     if (std::holds_alternative<std::unique_ptr<FnStmt>>(stmt))
@@ -358,7 +377,8 @@ static void extractDefinitions(Program &source, Program &dest,
                                 bool cross_package, bool from_stdlib,
                                 std::unordered_map<std::string, bool> *out_names = nullptr,
                                 std::unordered_map<std::string, ExportableKind> *out_kinds = nullptr,
-                                int file_id = 0) {
+                                int file_id = 0,
+                                std::unordered_set<int> *out_external_file_ids = nullptr) {
     // REQ-B3 (#1560): code availability is decoupled from name visibility.
     // Every exportable definition is copied to the importer's program so a
     // `@public` facade can call its non-`@public` helpers in the same JIT
@@ -371,6 +391,13 @@ static void extractDefinitions(Program &source, Program &dest,
         requested.insert(item.name);
     std::unordered_map<std::string, bool> found;
     std::unordered_map<std::string, ExportableKind> found_kinds;
+    // #2317: stdlib and cross-package definitions are inlined into the
+    // importer's program with their original file_id. Track those so
+    // CodeGen can suppress any-usage lint warnings on code the importer
+    // cannot act on. Intra-package imports propagate file_ids unchanged
+    // (no marking) so the user's multi-file project still gets warnings.
+    const bool mark_external =
+        out_external_file_ids != nullptr && (cross_package || from_stdlib);
     for (auto &stmt : source) {
         if (!isExportable(stmt)) continue;
         std::string name = getExportName(stmt);
@@ -382,6 +409,10 @@ static void extractDefinitions(Program &source, Program &dest,
         if (requested.count(name)) {
             found[name] = is_pub;
             found_kinds[name] = kind;
+        }
+        if (mark_external) {
+            int fid = getStmtFileId(stmt);
+            if (fid >= 0) out_external_file_ids->insert(fid);
         }
         dest.push_back(std::move(stmt));
     }
@@ -976,7 +1007,8 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                                    rp.from_stdlib,
                                    &exports_cache_[abs_path],
                                    &exports_kinds_cache_[abs_path],
-                                   qimp.loc.file_id);
+                                   qimp.loc.file_id,
+                                   &external_file_ids_);
             } else {
                 loading_.insert(abs_path);
                 auto sub_prog = loadAndParse(abs_path, sm_);
@@ -990,7 +1022,8 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                                    rp.from_stdlib,
                                    &exports_cache_[abs_path],
                                    &exports_kinds_cache_[abs_path],
-                                   qimp.loc.file_id);
+                                   qimp.loc.file_id,
+                                   &external_file_ids_);
             }
 
             result.push_back(std::move(stmt));
@@ -1138,7 +1171,8 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                                imp.loc.line, cross_package, rp.from_stdlib,
                                &exports_cache_[abs_path],
                                &exports_kinds_cache_[abs_path],
-                               imp.loc.file_id);
+                               imp.loc.file_id,
+                               &external_file_ids_);
         } else {
             loading_.insert(abs_path);
             auto sub_prog = loadAndParse(abs_path, sm_);
@@ -1151,7 +1185,8 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                                imp.loc.line, cross_package, rp.from_stdlib,
                                &exports_cache_[abs_path],
                                &exports_kinds_cache_[abs_path],
-                               imp.loc.file_id);
+                               imp.loc.file_id,
+                               &external_file_ids_);
         }
     }
 

--- a/src/parser/parser_decl.cpp
+++ b/src/parser/parser_decl.cpp
@@ -193,7 +193,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
                     "(all parameters after a default parameter must also have defaults)");
             }
 
-            fnStmt->params.push_back({paramName.value, std::move(paramType), std::move(default_value)});
+            fnStmt->params.push_back({paramName.value, std::move(paramType), std::move(default_value), has_explicit_type});
 
             if (lex_.peek().kind != TokenKind::Comma)
                 break;
@@ -452,7 +452,7 @@ StmtNode Parser::parseDirectiveDefStatement(const Directive *dirAnnot,
                     "(all parameters after a default parameter must also have defaults)");
             }
 
-            result.params.push_back({paramName.value, std::move(paramType), std::move(default_value)});
+            result.params.push_back({paramName.value, std::move(paramType), std::move(default_value), has_explicit_type});
 
             if (lex_.peek().kind != TokenKind::Comma)
                 break;

--- a/src/parser/parser_expr.cpp
+++ b/src/parser/parser_expr.cpp
@@ -1093,14 +1093,16 @@ ExprPtr Parser::parseParenLambdaExpr() {
             lex_.next(); // consume param name
 
             TypeNodePtr paramType = TypeNode::makeBasic("any");
+            bool has_explicit_type = false;
             if (lex_.peek().kind == TokenKind::Colon) {
                 lex_.next(); // consume ':'
                 paramType = parseTypeName();
+                has_explicit_type = true;
             }
             if (lex_.peek().kind == TokenKind::Equals)
                 parseError(paramName.line, "default arguments are not supported in lambda expressions");
 
-            lambda->params.push_back({paramName.value, std::move(paramType), nullptr});
+            lambda->params.push_back({paramName.value, std::move(paramType), nullptr, has_explicit_type});
             paramNameTokens.push_back(paramName);
             if (lex_.peek().kind != TokenKind::Comma)
                 break;

--- a/tests/test_any_usage_warnings.cpp
+++ b/tests/test_any_usage_warnings.cpp
@@ -1,0 +1,371 @@
+#include <gtest/gtest.h>
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+#include <unistd.h>
+#include <sys/wait.h>
+
+namespace fs = std::filesystem;
+
+struct RunResult {
+    std::string out;
+    std::string err;
+    int exit_code = -1;
+};
+
+static RunResult runRy(std::vector<const char *> args) {
+    int pipeOut[2];
+    int pipeErr[2];
+    if (pipe(pipeOut) != 0)
+        return {};
+    if (pipe(pipeErr) != 0) {
+        close(pipeOut[0]);
+        close(pipeOut[1]);
+        return {};
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipeOut[0]);
+        close(pipeOut[1]);
+        close(pipeErr[0]);
+        close(pipeErr[1]);
+        return {};
+    }
+
+    if (pid == 0) {
+        close(pipeOut[0]);
+        close(pipeErr[0]);
+        dup2(pipeOut[1], STDOUT_FILENO);
+        dup2(pipeErr[1], STDERR_FILENO);
+        close(pipeOut[1]);
+        close(pipeErr[1]);
+        close(STDIN_FILENO);
+        setenv("RY_ENV", "internal", 1);
+
+        // Full RY_BINARY_PATH as argv[0] — `.claude/rules/tests-cpp-conventions.md`
+        // notes bare "ry" breaks exe-adjacent stdlib resolution on Linux.
+        std::vector<const char *> argv{RY_BINARY_PATH};
+        argv.insert(argv.end(), args.begin(), args.end());
+        argv.push_back(nullptr);
+
+        execv(RY_BINARY_PATH, const_cast<char *const *>(argv.data()));
+        _exit(127);
+    }
+
+    close(pipeOut[1]);
+    close(pipeErr[1]);
+
+    auto readAll = [](int fd) -> std::string {
+        std::string result;
+        std::array<char, 4096> buf{};
+        ssize_t n;
+        while ((n = read(fd, buf.data(), buf.size())) > 0)
+            result.append(buf.data(), static_cast<size_t>(n));
+        close(fd);
+        return result;
+    };
+
+    RunResult r;
+    std::thread outReader([&]() { r.out = readAll(pipeOut[0]); });
+    std::thread errReader([&]() { r.err = readAll(pipeErr[0]); });
+    outReader.join();
+    errReader.join();
+    int status = 0;
+    waitpid(pid, &status, 0);
+    r.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    return r;
+}
+
+class AnyUsageWarningsTest : public ::testing::Test {
+protected:
+    fs::path tmpDir_;
+
+    void SetUp() override {
+        // Build-adjacent so the package.toml ancestor chain resolves stdlib.
+        tmpDir_ = fs::path(RY_BINARY_PATH).parent_path() / "ry_any_usage_warnings_test";
+        fs::create_directories(tmpDir_);
+    }
+
+    void TearDown() override { fs::remove_all(tmpDir_); }
+
+    fs::path writeTmp(const std::string &name, const std::string &content) {
+        auto p = tmpDir_ / name;
+        std::ofstream(p) << content;
+        return p;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Pattern 1: x: any = <concrete RHS>
+// ---------------------------------------------------------------------------
+
+TEST_F(AnyUsageWarningsTest, Pattern1ConcreteLiteralFiresWarning) {
+    auto p = writeTmp("p1_fire.ry",
+        "x: any = 42\n"
+        "print(x)\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.err.find("warning: variable 'x' is annotated 'any' but its initializer has a concrete type"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+    EXPECT_NE(r.err.find("remove the annotation"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, Pattern1AnyRhsSuppressed) {
+    auto p = writeTmp("p1_any_rhs.ry",
+        "fn getAny() -> any:\n"
+        "    return 42\n"
+        "x: any = getAny()\n"
+        "print(x)\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.err.find("annotated 'any' but its initializer has a concrete type"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 2: @public function exposes any in its signature
+// ---------------------------------------------------------------------------
+
+TEST_F(AnyUsageWarningsTest, Pattern2PublicFnAnyParamFiresWarning) {
+    auto p = writeTmp("p2_param.ry",
+        "@public\n"
+        "fn process(data: any) -> int:\n"
+        "    return 1\n"
+        "print(process(42))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.err.find("warning: public function 'process' parameter 'data' is typed 'any'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, Pattern2PublicFnAnyReturnFiresWarning) {
+    auto p = writeTmp("p2_return.ry",
+        "@public\n"
+        "fn getVal() -> any:\n"
+        "    return 42\n"
+        "print(getVal())\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.err.find("warning: public function 'getVal' returns 'any'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, Pattern2NonPublicFnSuppressed) {
+    auto p = writeTmp("p2_private.ry",
+        "fn process(data: any) -> int:\n"
+        "    return 1\n"
+        "print(process(42))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.err.find("public function"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 3: unannotated fn params (implicit any)
+// ---------------------------------------------------------------------------
+
+TEST_F(AnyUsageWarningsTest, Pattern3UnannotatedParamFiresWarning) {
+    auto p = writeTmp("p3_fire.ry",
+        "fn addOne(x) -> int:\n"
+        "    return 1\n"
+        "print(addOne(42))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.err.find("warning: parameter 'x' of function 'addOne' has no type annotation"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+    EXPECT_NE(r.err.find("defaults to 'any'"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, Pattern3ExplicitAnyParamSuppressed) {
+    // Explicit `x: any` annotation marks an intentional type-erasure use case;
+    // Pattern 3 (which targets implicit any) should not fire.
+    auto p = writeTmp("p3_explicit_any.ry",
+        "fn process(x: any) -> int:\n"
+        "    return 1\n"
+        "print(process(42))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.err.find("has no type annotation"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, Pattern3LambdaUnannotatedSuppressed) {
+    // Unannotated lambda params are idiomatic — Pattern 3 only targets named fns.
+    auto p = writeTmp("p3_lambda.ry",
+        "f = (x) => 1\n"
+        "print(f(42))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.err.find("has no type annotation"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, Pattern3AnnotatedParamSuppressed) {
+    auto p = writeTmp("p3_annotated.ry",
+        "fn addOne(x: int) -> int:\n"
+        "    return x + 1\n"
+        "print(addOne(42))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.err.find("has no type annotation"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 4: implicit any → concrete unwrap (variable declaration)
+// ---------------------------------------------------------------------------
+
+TEST_F(AnyUsageWarningsTest, Pattern4AnyToConcreteFiresWarning) {
+    auto p = writeTmp("p4_fire.ry",
+        "fn getAny() -> any:\n"
+        "    return 42\n"
+        "v: int = getAny()\n"
+        "print(v)\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.err.find("warning: assigning 'any' to variable 'v' of type 'int'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+    EXPECT_NE(r.err.find("implicit runtime unwrap"), std::string::npos)
+        << "stderr was: " << r.err;
+    EXPECT_NE(r.err.find("asType[int]"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, Pattern4ConcreteToConcreteSuppressed) {
+    auto p = writeTmp("p4_concrete.ry",
+        "fn getInt() -> int:\n"
+        "    return 42\n"
+        "v: int = getInt()\n"
+        "print(v)\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.err.find("implicit runtime unwrap"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+// ---------------------------------------------------------------------------
+// Cross-pattern interactions
+// ---------------------------------------------------------------------------
+
+TEST_F(AnyUsageWarningsTest, Pattern2And3NoDoubleFireOnUnannotatedPublicFn) {
+    // `@public fn f(x)` triggers Pattern 3 (unannotated) but NOT Pattern 2
+    // (which is gated on has_explicit_type to avoid duplicate noise on the
+    // same param).
+    auto p = writeTmp("p2_3_dedup.ry",
+        "@public\n"
+        "fn f(x) -> int:\n"
+        "    return 1\n"
+        "print(f(42))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.err.find("parameter 'x' of function 'f' has no type annotation"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+    EXPECT_EQ(r.err.find("public function 'f' parameter 'x' is typed 'any'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+// ---------------------------------------------------------------------------
+// Scope gate: warnings must fire on the user's whole package (multi-file
+// projects included) but NOT on stdlib / cross-package definitions the
+// user cannot edit.
+// ---------------------------------------------------------------------------
+
+TEST_F(AnyUsageWarningsTest, IntraPackageImportWarnsOnSecondaryFile) {
+    // The user's own `util.ry` lives in the same package as `main.ry`.
+    // Even though it is reached via `from util import ...`, its definitions
+    // must warn — strict-any in #2322 will eventually apply to the user's
+    // full package, so the warning phase must point them out now.
+    writeTmp("util_intra.ry",
+        "fn helper(x) -> int:\n"          // Pattern 3 in user's own lib
+        "    return 1\n"
+        "\n"
+        "@public\n"
+        "fn pub(v: any) -> any:\n"        // Pattern 2 in user's own lib
+        "    return v\n");
+    auto p = writeTmp("main_intra.ry",
+        "from util_intra import helper\n"
+        "print(helper(42))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.err.find("parameter 'x' of function 'helper'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+    EXPECT_NE(r.err.find("public function 'pub' parameter 'v' is typed 'any'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+    EXPECT_NE(r.err.find("public function 'pub' returns 'any'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, StdlibImportsDoNotWarn) {
+    // Stdlib modules use `any` in many @public signatures
+    // (json.stringify, map.getPath, ...). Importing them must not produce
+    // warnings the user cannot act on. `from ry.math import sqrt` exercises
+    // the from-stdlib gate (ModuleLoader marks stdlib file_ids as external).
+    auto p = writeTmp("uses_stdlib.ry",
+        "from ry.math import sqrt\n"
+        "print(sqrt(16.0))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.err.find("warning: "), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, IntraPackageImportWarnsOnBodyLevelPatterns) {
+    // Pin the file_id gate for AssignStmt sites inside an imported body
+    // (Patterns 1 / 4). The imported file's stmts share file_id with the
+    // enclosing fn, so suppression at the FnStmt level extends to nested
+    // var decls — but only because current_loc_ updates via emitStmt
+    // (AssignStmt&). Lock in that intra-package code also warns body-level.
+    writeTmp("util_body.ry",
+        "fn run(x: int) -> int:\n"
+        "    erased: any = x\n"           // Pattern 1 in user's own lib
+        "    recovered: int = erased\n"  // Pattern 4 in user's own lib
+        "    return recovered\n");
+    auto p = writeTmp("main_body.ry",
+        "from util_body import run\n"
+        "print(run(7))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.err.find("variable 'erased' is annotated 'any'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+    EXPECT_NE(r.err.find("assigning 'any' to variable 'recovered' of type 'int'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(AnyUsageWarningsTest, MainFileWarningsStillFireWithImports) {
+    // Even when imports are present, the user's OWN code in main must still
+    // surface warnings — the gate filters by file_id, not by program shape.
+    writeTmp("libMain.ry",
+        "fn helper(x: int) -> int:\n"
+        "    return x + 1\n");
+    auto p = writeTmp("main_mixed.ry",
+        "from libMain import helper\n"
+        "fn local(y) -> int:\n"
+        "    return helper(1)\n"
+        "print(local(42))\n");
+    auto r = runRy({"run", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.err.find("parameter 'y' of function 'local'"),
+              std::string::npos)
+        << "stderr was: " << r.err;
+}

--- a/tests/test_regression_2248_positive_str_predicate.cpp
+++ b/tests/test_regression_2248_positive_str_predicate.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <sys/wait.h>
@@ -25,24 +26,40 @@ namespace {
 struct RunResult {
     int exit_code;
     std::string out;
+    std::string err;
 };
 
 RunResult runScript(const std::string &scriptPath) {
-    int pipefd[2];
-    if (pipe(pipefd) != 0) return {-1, ""};
+    int outPipe[2];
+    int errPipe[2];
+    if (pipe(outPipe) != 0) return {-1, "", ""};
+    if (pipe(errPipe) != 0) {
+        close(outPipe[0]);
+        close(outPipe[1]);
+        return {-1, "", ""};
+    }
 
     pid_t pid = fork();
     if (pid < 0) {
-        close(pipefd[0]);
-        close(pipefd[1]);
-        return {-1, ""};
+        close(outPipe[0]);
+        close(outPipe[1]);
+        close(errPipe[0]);
+        close(errPipe[1]);
+        return {-1, "", ""};
     }
 
     if (pid == 0) {
-        close(pipefd[0]);
-        dup2(pipefd[1], STDOUT_FILENO);
-        dup2(pipefd[1], STDERR_FILENO);
-        close(pipefd[1]);
+        close(outPipe[0]);
+        close(errPipe[0]);
+        // #2317: stdout and stderr go to separate pipes. The script uses
+        // `aLoad: any = s` / `aMap: any = m["k"]`, both of which trigger
+        // the Pattern 1 / Pattern 4 lint warnings. Splitting the streams
+        // keeps the equality assertion on stdout clean while preserving
+        // stderr (ASan / UBSan output) for failure diagnostics.
+        dup2(outPipe[1], STDOUT_FILENO);
+        dup2(errPipe[1], STDERR_FILENO);
+        close(outPipe[1]);
+        close(errPipe[1]);
         close(STDIN_FILENO);
 
         // `RY_BINARY_PATH` is the absolute path to the built `ry` binary
@@ -58,14 +75,27 @@ RunResult runScript(const std::string &scriptPath) {
         _exit(127);
     }
 
-    close(pipefd[1]);
+    close(outPipe[1]);
+    close(errPipe[1]);
+    auto readAll = [](int fd) -> std::string {
+        std::string s;
+        std::array<char, 4096> buf;
+        ssize_t n;
+        while ((n = read(fd, buf.data(), buf.size())) > 0)
+            s.append(buf.data(), static_cast<size_t>(n));
+        close(fd);
+        return s;
+    };
+    // Drain both pipes concurrently. Sequential draining would deadlock
+    // if the child fills the unread pipe's kernel buffer (~64 KB) while
+    // the parent is blocked on the other — same pattern as
+    // tests/test_any_usage_warnings.cpp / test_deprecated_warnings.cpp.
     std::string out;
-    std::array<char, 4096> buf;
-    ssize_t n;
-    while ((n = read(pipefd[0], buf.data(), buf.size())) > 0) {
-        out.append(buf.data(), static_cast<size_t>(n));
-    }
-    close(pipefd[0]);
+    std::string err;
+    std::thread outReader([&]() { out = readAll(outPipe[0]); });
+    std::thread errReader([&]() { err = readAll(errPipe[0]); });
+    outReader.join();
+    errReader.join();
 
     int status = 0;
     pid_t wp;
@@ -75,7 +105,7 @@ RunResult runScript(const std::string &scriptPath) {
     int code = -1;
     if (wp != -1 && WIFEXITED(status))
         code = WEXITSTATUS(status);
-    return {code, out};
+    return {code, out, err};
 }
 
 } // namespace
@@ -126,7 +156,8 @@ TEST_F(Regression2248PositiveStrPredicate,
         auto r = runScript(scriptPath_.string());
         if (r.exit_code != 0) {
             ++fails;
-            if (sample_fail_output.empty()) sample_fail_output = r.out;
+            if (sample_fail_output.empty())
+                sample_fail_output = r.out + "\n--- stderr ---\n" + r.err;
         } else if (r.out != "ab\nef\na=3\n") {
             ++mismatches;
             if (sample_mismatch_output.empty())


### PR DESCRIPTION
## Summary

Adds warning diagnostics that steer users away from unnecessary `any` ahead of the stricter defaults planned for #2322. Four patterns fire on the user's package (main + intra-package multi-file projects); stdlib and cross-package imports are exempt because the importer cannot act on them.

| # | Pattern | Hook |
|---|---|---|
| 1 | `x: any = <concrete RHS>` | `codegen_stmt.cpp emitVarDecl` |
| 2 | `@public` fn with `any` param or return | `codegen_fn.cpp` |
| 3 | unannotated fn param defaulting to `any` | `codegen_fn.cpp` |
| 4 | `n: <concrete> = <any source>` (variable-decl unwrap) | `codegen_stmt.cpp emitVarDecl` |

**Out of scope** (deferred to sibling issues):
- direct arithmetic on `any` → #2316
- call-site `f(v)` with `v: any` → #2321

## Scope rule — note divergence from the approved plan

The plan was "always on." This PR ships **on for the user's whole package, off for stdlib + cross-package imports**. Without the exemption, `from json import stringify` would emit warnings the user cannot fix. `ModuleLoader::extractDefinitions` marks the file_ids of definitions inlined under `cross_package || from_stdlib`, exposed via `externalFileIds()`. `CodeGen::shouldEmitAnyLintAt(file_id)` is the per-site gate.

## Mechanism

- **AST**: `FnParam` gains `bool has_explicit_type` (plumbed through fn-decl, operator-def, paren-lambda parse sites; bare-lambda relies on the struct default). `TypeNode::isBareAnyName()` is a cheap structural predicate that replaces `toString() == "any"`.
- **ModuleLoader**: tracks external file_ids during import resolution.
- **CodeGen**: `enableAnyUsageLint(external_ids)` arms lint atomically. `emitAnyUsageWarning(msg)` centralizes the `"warning: "` prefix (analogue of `emitDeprecationWarning`).
- **jit_runner**: wires the loader's set into codegen post-resolution.

## Tests

- 16 cases in `tests/test_any_usage_warnings.cpp`: each pattern positive + suppression, intra-package vs stdlib scope, body-level Patterns 1/4 inside imported fns, Pattern 2/3 dedup interaction.
- `tests/test_regression_2248_positive_str_predicate.cpp` now splits stdout/stderr into two pipes (drained on threads to avoid deadlock) so the Pattern 1/4 warnings on the test script's `aLoad: any = s` lines don't pollute its exact-output assertion.

## Test plan

- [x] `./build-rust/ry_tests` (2970/2970)
- [x] `./build-rust/ry test` (219/219)
- [x] `./docker/run.sh asan ry_tests --gtest_filter='AnyUsageWarningsTest.*:Regression2248PositiveStrPredicate.*:DeprecatedWarningsTest.*'` (clean)
- [x] Clean rebuild under `-Wall -Wextra -Wpedantic -Wconversion -Wshadow` (zero warnings)
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` (clean)
- [x] Manual: `from ry.math import sqrt` emits no warnings; user's `main.ry + util.ry` (intra-package) both warn.

Closes #2317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings for broad `any` usage in functions, parameters, return types, and variable assignments.
  * Warnings now also highlight unsafe conversions from `any` to concrete types.

* **Bug Fixes**
  * Improved warning coverage across multi-file projects while avoiding warnings for imported standard library or external code.
  * Reduced duplicate warnings for the same source pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->