### PR TITLE
refactor(codegen): carve type-driven natives to compiler builtins

### DIFF
--- a/changelog.d/2340-native-call-boundary-installment-3.md
+++ b/changelog.d/2340-native-call-boundary-installment-3.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Type-driven `@native` dispatches that always required hand-written customEmitters — `math::abs` / `log` / `pow` / `floor` / `ceil` / `round` / `digits`, `json::stringify` / `stringifySafe` (and the `json5` variants), and `thread::threadSpawn` / `threadJoin` — are now compiler builtins (Pattern B) instead of `math_table` / `json_table` / `json5_table` / `thread_table` entries. The user-visible consequence is that those eleven names are now reserved: declaring a user `fn abs(...)` etc. raises `cannot declare function 'X': name is reserved for a built-in function` at parse time. Function behaviour, argument shapes, error channels, `Result` wrapping, and `mock` / `spy` interception (including `mock("pow(int, int)", ...)`) are unchanged. (#2340)

--- a/docs/architecture/native-call-boundary.md
+++ b/docs/architecture/native-call-boundary.md
@@ -163,10 +163,10 @@ These issues are **drafts**, not yet filed. Per the AGENTS.md "User Permission G
 6. **Pilot confirmation: path** (six A1 entries, no wrapping / no resource).
 7. Installment 2-a: io / filesystem (resource_kind + module error channels).
 8. Installment 2-b: net / http (resource_kind + multi-channel `__ry_net_*` / `__ry_tls_*` / `__ry_http_*` error channels).
-9. Installment 3-a carve-out: math A2 type-driven entries → `emitBuiltinMath` (Pattern B).
-10. Installment 3-b carve-out: `json::stringify` / `json::stringifySafe` → `emitBuiltinJson`.
-11. Installment 3-c carve-out: `thread::threadSpawn` / `threadJoin` → `emitBuiltinThread`.
-12. `used_native_libraries_` consolidation (descriptor-driven registration, retire the general dispatcher-registration rule, keep the §"Pattern B carve-out" exception).
+9. Installment 3-a carve-out: math A2 type-driven entries → `emitBuiltinMath` (Pattern B). **(#2340)**
+10. Installment 3-b carve-out: `json::stringify` / `json::stringifySafe` (and the json5 mirrors) → `emitBuiltinJson` / `emitBuiltinJson5`. **(#2340)**
+11. Installment 3-c carve-out: `thread::threadSpawn` / `threadJoin` → `emitBuiltinThread`. **(#2340)**
+12. `used_native_libraries_` consolidation (descriptor-driven registration, retire the general dispatcher-registration rule, keep the §"Pattern B carve-out" exception). **(#2340)** — the auto-register lives at `src/codegen_call_native.cpp` `emitTableDrivenNativeCall` entry; the previous customEmitter mock dispatch helper was generalised to accept any `NativeEmitterFn` so Pattern B carve-outs keep #1682 mock/spy semantics.
 13. Mock / spy v2 argument recording across customEmitter callers (current v1 limitation at `src/codegen_call_native.cpp:797`); separate from descriptor work.
 14. Upper codegen migration kickoff: descriptor consumers move to Rust; native knowledge stays in C++ descriptor producers only. This is the issue that #2231 protects, and it is **out of scope of this design**.
 

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -33,7 +33,7 @@ Postconditions are checked before every `return`. They specify what the function
 `ensure` requires a variable name that binds the return value. This variable can be used in the postcondition expressions.
 
 ```ry
-fn abs(x: int) -> int:
+fn myAbs(x: int) -> int:
     ensure v:
         v >= 0
     if x < 0:

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -179,7 +179,7 @@ The directive takes exactly one positional string argument. Empty strings (`@doc
 ```ry
 @doc("Returns the absolute value of x.")
 @public
-fn abs(x: int) -> int:
+fn myAbs(x: int) -> int:
   if x < 0:
     return -x
   return x

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -44,7 +44,7 @@ The table below shows the most common compile errors; it is not exhaustive.
 | Non-exhaustive match | `case` does not cover all patterns | Some enum variants uncovered, missing `None` for Option, missing `Ok`/`Err` for Result, no `_` for literals |
 | `?` on non-Result/Option type | Applied `?` to an expression that is not a `Result` or `Option` type (`'?' operator requires a Result or Option type operand`) | `x = 42` -> `x?` |
 | `?` in non-Result function | Used `?` on a `Result` in a function that does not return `Result` (`'?' on Result can only be used in a fn that returns Result`) | `fn foo() -> int:` with `bar()?` inside |
-| `ensure` on Unit-return function | Used `ensure` in a function with no return value (`'ensure' requires a non-Unit return type`) | `fn log():` with `ensure v:` |
+| `ensure` on Unit-return function | Used `ensure` in a function with no return value (`'ensure' requires a non-Unit return type`) | `fn greet():` with `ensure v:` |
 
 ### Compile Error Examples
 

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -364,7 +364,7 @@ The check does **not** apply to:
 Functions without a return value return `Unit`. The return type can be omitted (inferred as `Unit`) or explicitly specified with `-> Unit`.
 
 ```ry
-fn log(msg: str) -> Unit:
+fn greet(msg: str) -> Unit:
     print(msg)
 ```
 

--- a/include/ry/builtin_names.hpp
+++ b/include/ry/builtin_names.hpp
@@ -6,13 +6,17 @@
 
 namespace ry {
 
-// Reserved stdlib built-in function names; see .claude/rules/codegen-stdlib-dispatcher.md for maintenance.
+// Reserved stdlib built-in function names. New entries reach this list when an
+// `@native` dispatch is carved out of a Pattern A table into a Pattern B
+// `emitBuiltin*` helper (compiler builtin), at which point the name becomes
+// claimed at parse time so user fns cannot shadow it. Keep this list sorted.
 inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames = {
     "Err",
     "Error",
     "None",
     "Ok",
     "Some",
+    "abs",
     "all",
     "any",
     "args",
@@ -20,6 +24,7 @@ inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames 
     "availableParallelism",
     "blockOn",
     "byteLen",
+    "ceil",
     "charAt",
     "checkedAdd",
     "checkedMul",
@@ -27,6 +32,7 @@ inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames 
     "close",
     "contains",
     "count",
+    "digits",
     "distinct",
     "endsWith",
     "enumerate",
@@ -37,6 +43,7 @@ inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames 
     "first",
     "flat",
     "float",
+    "floor",
     "fold",
     "get",
     "getPath",
@@ -51,10 +58,12 @@ inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames 
     "len",
     "lines",
     "load",
+    "log",
     "map",
     "max",
     "min",
     "pop",
+    "pow",
     "print",
     "range",
     "readAll",
@@ -70,6 +79,7 @@ inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames 
     "replace",
     "reverse",
     "reverse!",
+    "round",
     "saturatingAdd",
     "saturatingMul",
     "saturatingSub",
@@ -81,9 +91,13 @@ inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames 
     "sort!",
     "split",
     "startsWith",
+    "stringify",
+    "stringifySafe",
     "substr",
     "sum",
     "tap",
+    "threadJoin",
+    "threadSpawn",
     "toLower",
     "toUpper",
     "trim",

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1931,16 +1931,32 @@ public:
 
     // Emit the tri-block mock dispatch for a customEmitter native call. The
     // mockBB emits args fresh and dispatches through __ry_mock_get; origBB
-    // delegates to the customEmitter (which emits its own args). Returns the
-    // PHI-merged result. Pre-condition: caller has already verified
+    // delegates to the supplied emitter (which emits its own args). Returns
+    // the PHI-merged result. Pre-condition: caller has already verified
     // (mocked || spied) for this canonicalSig.
+    //
+    // The emitter callback is `entry->customEmitter` for Pattern A2 callsites
+    // and the carved-out compiler builtin (e.g. `emitMathPow`) for Pattern B
+    // callsites (#2340). Both share the `CodeGenCustomEmitterFn` shape so the
+    // indirection is a pure generalisation — mock/spy semantics are unchanged.
     llvm::Value *emitNativeCustomEmitterMockDispatch(
         const CallExpr &e,
-        const NativeDispatchEntry *entry,
+        CodeGenCustomEmitterFn emitter,
         const NativeFnSignature &sig,
         const std::string &canonicalSig,
         bool isMocked,
         bool isSpied);
+
+    // Pattern B (compiler-builtin) wrapper: looks the call up under
+    // `package::e.callee` to drive the AST-level overload picker, runs the
+    // mock/spy gate, and falls back to a direct `emitter(*this, e)` call when
+    // no mock is registered. Use from emitBuiltinMath / emitBuiltinJson /
+    // emitBuiltinThread to keep the #1682 mock/spy behaviour after the #2340
+    // carve-out moved the dispatch off the table path.
+    llvm::Value *emitBuiltinNativeOrMock(
+        const CallExpr &e,
+        const std::string &package,
+        CodeGenCustomEmitterFn emitter);
 
     llvm::Value *toBool(llvm::Value *v);
 
@@ -2554,6 +2570,24 @@ public:
     // callees so the dispatch chain can continue.
     llvm::Value *emitBuiltinAnyCast(const CallExpr &e);
     llvm::Value *emitBuiltinRegex(const CallExpr &e);
+    // Type-driven @native carve-outs (#2340 / native-call-boundary §"Installment
+    // 3"). Each helper intercepts the named callee only when the matching
+    // module's signatures are present, then leaves the corresponding `libry_*`
+    // library registration to its own body — the table path no longer reaches
+    // these names.
+    llvm::Value *emitBuiltinMath(const CallExpr &e);
+    llvm::Value *emitBuiltinJson(const CallExpr &e);
+    llvm::Value *emitBuiltinJson5(const CallExpr &e);
+    llvm::Value *emitBuiltinThread(const CallExpr &e);
+    // Shared body for emitBuiltinJson and emitBuiltinJson5 — both modules
+    // expose the same `stringify` / `stringifySafe` callees, differing only in
+    // the package name and the runtime entry-point emitter pointers. Lives in
+    // codegen_call_json.cpp.
+    llvm::Value *emitBuiltinJsonModuleStringify(
+        const CallExpr &e,
+        const char *package,
+        CodeGenCustomEmitterFn stringifyEmitter,
+        CodeGenCustomEmitterFn stringifySafeEmitter);
     // Generic dispatch for @native("libname") functions not covered by
     // self-registering stdlib dispatch tables. Uses the signature registry
     // to derive the C calling convention from Ry type annotations.

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -8,7 +8,14 @@
 namespace ry {
 
 // ===== Builtin Conversion =====
-
+//
+// Pattern B carve-out (#2340): int(s) / float(s) are reserved compiler
+// builtins, not @native dispatched. The descriptor-driven library auto-
+// registration in emitTableDrivenNativeCall / emitGenericNativeCall never
+// reaches them — the reserved-name guard claims the callee before any
+// descriptor lookup runs — so the `libry_convert` load has to be expressed
+// directly with `used_native_libraries_.insert("convert")` here. The same
+// rationale applies to input() / close() in emitBuiltinCore below.
 llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
     // int(s) → Result<int, Error>.  Parses a str; for number→int use `x as int`.
     if (e.callee == "int") {
@@ -18,6 +25,8 @@ llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
             codegenError("int() requires a str argument; use 'value as int' to convert a number to int");
         llvm::AllocaInst *outSlot = builder_.CreateAlloca(i64Ty_, nullptr, "to_int_out");
         auto fn = getRuntimeFn("__ry_str_to_int", i64Ty_, {ptrTy_, ptrTy_});
+        // Pattern B carve-out: see the file-header comment above for why this
+        // insert is not removed by the descriptor-driven consolidation.
         used_native_libraries_.insert("convert");
         llvm::Value *status = builder_.CreateCall(fn, {s, outSlot}, "to_int_status");
         llvm::Value *isErr = builder_.CreateICmpNE(status,
@@ -39,6 +48,7 @@ llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
             codegenError("float() requires a str argument; use 'value as float' to convert a number to float");
         llvm::AllocaInst *outSlot = builder_.CreateAlloca(f64Ty_, nullptr, "to_float_out");
         auto fn = getRuntimeFn("__ry_str_to_float", i64Ty_, {ptrTy_, ptrTy_});
+        // Pattern B carve-out: see emitBuiltinConversion header comment above.
         used_native_libraries_.insert("convert");
         llvm::Value *status = builder_.CreateCall(fn, {s, outSlot}, "to_float_status");
         llvm::Value *isErr = builder_.CreateICmpNE(status,
@@ -608,10 +618,11 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
     if (e.callee == "input") {
         if (e.args.size() > 1)
             codegenError("input() takes 0 or 1 arguments");
-        // Runtime lives in libry_io — without this insert the JIT fails to
-        // resolve __ry_io_read_line / __ry_io_input_prompt for programs that
-        // never `import` from io. Bare builtins are not declared as
-        // @native("io"), so library registration must happen here.
+        // Pattern B carve-out (#2340): `input` is a reserved compiler builtin,
+        // not @native("io"). The descriptor-driven library auto-registration
+        // never reaches this name, so the JIT load of libry_io has to be
+        // expressed directly so that __ry_io_read_line / __ry_io_input_prompt
+        // resolve for programs that never `import` io.
         used_native_libraries_.insert("io");
 
         llvm::Value *outAlloca = emitAlloca(ptrTy_, "inp_out");
@@ -721,8 +732,10 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
             // happens at scope exit (or when the last alias drops); decoupling
             // the user-facing close from refcount-drop keeps lines()/readLine()
             // iterators valid after close (they observe fp==nullptr and finish).
-            // The io runtime symbol lives in libry_io — register the library so
-            // bare close(f) calls (no enclosing io import path) resolve.
+            // Pattern B carve-out (#2340): `close` is a reserved compiler
+            // builtin, not @native("io"). The descriptor-driven library
+            // auto-registration never reaches this name, so the libry_io load
+            // for __ry_io_file_close is expressed directly here.
             used_native_libraries_.insert("io");
             auto fn = getRuntimeFn("__ry_io_file_close", llvm::Type::getVoidTy(*ctx_), {ptrTy_});
             builder_.CreateCall(fn, {val});
@@ -1480,7 +1493,13 @@ static llvm::Value *emitMathDigits(CodeGen &cg, const CallExpr &e) {
 }
 
 // ===== Math dispatch table =====
-
+//
+// abs / floor / ceil / round / log / pow / digits were carved out to
+// emitBuiltinMath (Pattern B) per #2340 — they are type-driven and never
+// matched a declarative descriptor. isNan / isInf stay here because they are
+// declarative single-arity float predicates and have no Pattern B home.
+// math has no `libry_math` artifact, so no library auto-registration is needed
+// either before or after the carve-out.
 static const CodeGen::NativeDispatchEntry math_table[] = {
     // 1-arg float->float (bare C library names)
     {"sqrt",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "sqrt"},
@@ -1496,23 +1515,41 @@ static const CodeGen::NativeDispatchEntry math_table[] = {
     // 2-arg float->float
     {"atan2", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, nullptr, "atan2"},
     {"hypot", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, nullptr, "hypot"},
-    // Custom emitters (arity is metadata for the 1-arg legacy overload —
-    // actual arity dispatch happens via registered @native sigs at the
-    // custom-emitter gate in emitTableDrivenNativeCall; see codegen_call_native.cpp).
-    {"abs",    nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathAbs},
-    {"floor",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathFloorCeilRound},
-    {"ceil",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathFloorCeilRound},
-    {"round",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathFloorCeilRound},
-    {"log",    nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathLog},
-    {"pow",    nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitMathPow},
+    // Single-arity float predicates — declarative; remain in the table.
     {"isNan",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathIsNan},
     {"isInf",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathIsInf},
-    {"digits", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathDigits},
 };
 
 RY_REGISTER_STDLIB_PACKAGE(math, "share/std/math/math.ry", dispatchMath)
 static llvm::Value *dispatchMath(CodeGen &cg, const CallExpr &e) {
     return cg.emitTableDrivenNativeCall(e, "math", math_table, std::size(math_table));
+}
+
+// ===== Builtin Math (Pattern B carve-out, #2340) =====
+//
+// Type-driven entries (int/float overload, multi-arity rounding, do-while
+// digit extraction) that cannot become a declarative descriptor.  Intercepts
+// only when the matching `math::<name>` sig is registered so that user fns
+// named `abs` / `log` / etc. with no `import math` reach `emitUserFnCall`
+// (#1889 reserved-name guard rejects user fn definitions at parse time, but
+// keeping the sig gate lets a same-named identifier still resolve through
+// indirect-call paths when the name is bound to a variable / lambda).
+llvm::Value *CodeGen::emitBuiltinMath(const CallExpr &e) {
+    const auto hasSig = [&](const std::string &name) {
+        return native_fn_sigs_.count(ry::util::nativeSigKey("math", name)) > 0;
+    };
+    if (e.callee == "abs"    && hasSig("abs"))
+        return emitBuiltinNativeOrMock(e, "math", &emitMathAbs);
+    if ((e.callee == "floor" || e.callee == "ceil" || e.callee == "round") &&
+        hasSig(e.callee))
+        return emitBuiltinNativeOrMock(e, "math", &emitMathFloorCeilRound);
+    if (e.callee == "log"    && hasSig("log"))
+        return emitBuiltinNativeOrMock(e, "math", &emitMathLog);
+    if (e.callee == "pow"    && hasSig("pow"))
+        return emitBuiltinNativeOrMock(e, "math", &emitMathPow);
+    if (e.callee == "digits" && hasSig("digits"))
+        return emitBuiltinNativeOrMock(e, "math", &emitMathDigits);
+    return nullptr;
 }
 
 // Math constants self-registration

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -192,6 +192,15 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
         if (auto *v = emitBuiltinCollection(*e))  return v;
         if (auto *v = emitBuiltinSetOps(*e))      return v;
         if (auto *v = emitBuiltinRegex(*e))       return v;
+        // Type-driven @native carve-outs (#2340).  Order: json before json5 so
+        // that programs importing both modules resolve `stringify` to the json
+        // dispatcher — same precedence as the table-driven path used before
+        // the carve-out (`dispatchJson` runs before `dispatchJson5` because of
+        // alphabetical package ordering).
+        if (auto *v = emitBuiltinMath(*e))        return v;
+        if (auto *v = emitBuiltinJson(*e))        return v;
+        if (auto *v = emitBuiltinJson5(*e))       return v;
+        if (auto *v = emitBuiltinThread(*e))      return v;
     }
 
     // Dispatch to self-registering stdlib module helpers

--- a/src/codegen_call_json.cpp
+++ b/src/codegen_call_json.cpp
@@ -169,18 +169,14 @@ static llvm::Value *emitJsonDumpFile(CodeGen &cg, const CallExpr &e) {
 
 
 // ===== JSON dispatch table =====
-
+//
+// `stringify` / `stringifySafe` were carved out to emitBuiltinJson (Pattern B)
+// per #2340 — they are polymorphic over the Ry value type and never matched a
+// declarative descriptor. `load[T]` is intercepted by `dispatchJson` via
+// suffix match against `e.callee`; `dump` stays here because it remains a
+// declaration-driven 2/3-arity File-first call.
 static const CodeGen::NativeDispatchEntry json_table[] = {
-    // arity field is metadata only when customEmitter is set — actual arity
-    // dispatch happens via registered @native sigs at the custom-emitter gate
-    // in emitTableDrivenNativeCall (see codegen_call_native.cpp).
-    //
-    // `load[T]` is intercepted by `dispatchJson` via suffix match against
-    // `e.callee` (which is mangled to `load<T>` by the parser), so it has no
-    // entry in this table.
-    {"stringify",     nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJsonStringify},
-    {"stringifySafe", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJsonStringifySafe},
-    {"dump",          nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitJsonDumpFile},
+    {"dump", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitJsonDumpFile},
 };
 
 // Gate the dispatcher: only proceed if any json symbol is actually
@@ -241,6 +237,50 @@ static llvm::Value *dispatchJson(CodeGen &cg, const CallExpr &e) {
     }
 
     return cg.emitTableDrivenNativeCall(e, "json", json_table, std::size(json_table));
+}
+
+// ===== Builtin Json / Json5 shared body (Pattern B carve-out, #2340) =====
+//
+// stringify / stringifySafe are polymorphic over the Ry value type and never
+// fit the declarative descriptor shape, so they live here as compiler builtins.
+// json and json5 share the surface verbatim — same callee names, same sig-gate
+// pattern, only the package and runtime entry-point symbols differ. The chain
+// order in codegen_call_dispatch.cpp puts json before json5, matching the
+// pre-carve precedence (alphabetical package ordering put `dispatchJson` ahead
+// of `dispatchJson5`).
+//
+// Sig gate: intercept only when `<package>::<name>` is registered. Without the
+// gate every bare `stringify` call in a program that did not import json /
+// json5 would short-circuit user fns; the reserved-name guard in
+// builtin_names.hpp blocks user *definitions*, but a same-named identifier
+// bound to a variable / lambda must still reach the indirect-call path in
+// emitExprVariant.
+//
+// Library registration: the carved emitters register `<package>` directly so
+// the JIT loads `libry_<package>` before the runtime symbol is referenced.
+// dispatchJson / dispatchJson5 still cover the load[T] / dump paths.
+llvm::Value *CodeGen::emitBuiltinJsonModuleStringify(
+    const CallExpr &e,
+    const char *package,
+    CodeGenCustomEmitterFn stringifyEmitter,
+    CodeGenCustomEmitterFn stringifySafeEmitter) {
+    const std::string pkgPrefix = std::string(package) + "::";
+    if (e.callee == "stringify" &&
+        native_fn_sigs_.count(pkgPrefix + "stringify")) {
+        used_native_libraries_.insert(package);
+        return emitBuiltinNativeOrMock(e, package, stringifyEmitter);
+    }
+    if (e.callee == "stringifySafe" &&
+        native_fn_sigs_.count(pkgPrefix + "stringifySafe")) {
+        used_native_libraries_.insert(package);
+        return emitBuiltinNativeOrMock(e, package, stringifySafeEmitter);
+    }
+    return nullptr;
+}
+
+llvm::Value *CodeGen::emitBuiltinJson(const CallExpr &e) {
+    return emitBuiltinJsonModuleStringify(
+        e, "json", &emitJsonStringify, &emitJsonStringifySafe);
 }
 
 } // namespace ry

--- a/src/codegen_call_json5.cpp
+++ b/src/codegen_call_json5.cpp
@@ -149,11 +149,11 @@ static llvm::Value *emitJson5DumpFile(CodeGen &cg, const CallExpr &e) {
 
 
 // ===== JSON5 dispatch table =====
-
+//
+// stringify / stringifySafe were carved out to emitBuiltinJson5 (Pattern B)
+// per #2340 — see emitBuiltinJson5 below for the rationale shared with json.
 static const CodeGen::NativeDispatchEntry json5_table[] = {
-    {"stringify",     nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJson5Stringify},
-    {"stringifySafe", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJson5StringifySafe},
-    {"dump",          nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitJson5DumpFile},
+    {"dump", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitJson5DumpFile},
 };
 
 // Gate the dispatcher: only proceed if any json5 symbol is actually
@@ -205,6 +205,15 @@ static llvm::Value *dispatchJson5(CodeGen &cg, const CallExpr &e) {
     }
 
     return cg.emitTableDrivenNativeCall(e, "json5", json5_table, std::size(json5_table));
+}
+
+// ===== Builtin Json5 (Pattern B carve-out, #2340) =====
+//
+// Delegates to the shared emitBuiltinJsonModuleStringify body in
+// codegen_call_json.cpp; ordering and sig-gate rationale live there.
+llvm::Value *CodeGen::emitBuiltinJson5(const CallExpr &e) {
+    return emitBuiltinJsonModuleStringify(
+        e, "json5", &emitJson5Stringify, &emitJson5StringifySafe);
 }
 
 } // namespace ry

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -13,10 +13,24 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
 
     // Guard: check if this callee has any registered @native signature
     // for this package (or as a bare name for inline declarations).
-    // The sigKey is reused later for signature lookup (variadic + normal paths).
+    // The sigIt is reused later for signature lookup (variadic + normal paths).
     std::string sigKey = ry::util::nativeSigKey(package, e.callee);
-    if (!native_fn_sigs_.count(sigKey) && !native_fn_sigs_.count(e.callee))
-        return nullptr;
+    auto sigItHead = native_fn_sigs_.find(sigKey);
+    if (sigItHead == native_fn_sigs_.end()) {
+        sigItHead = native_fn_sigs_.find(e.callee);
+        if (sigItHead == native_fn_sigs_.end())
+            return nullptr;
+    }
+
+    // Descriptor-driven library auto-registration (#2340, criterion 5).
+    // Every sig under one callee belongs to a single declaring module, so
+    // pulling the library name off any registered sig — even before arity /
+    // type checks succeed — is sound. Doing it once up here retires the three
+    // per-branch hand-inserts that used to live in the variadic / customEmitter
+    // / normal paths and ensures the JIT loads `libry_<module>` before any
+    // early codegenError aborts the rest of the dispatch.
+    if (!sigItHead->second.empty() && !sigItHead->second[0].library.empty())
+        used_native_libraries_.insert(sigItHead->second[0].library);
 
     // Lookup entry in dispatch table
     const NativeDispatchEntry *entry = nullptr;
@@ -142,8 +156,6 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
                 args[i] = emitWideningConversion(args[i], argTypes[i]);
         }
 
-        if (!matchedSig->library.empty())
-            used_native_libraries_.insert(matchedSig->library);
 
         std::string rtName = (entry->rtNameOverride
             ? std::string(entry->rtNameOverride)
@@ -187,10 +199,6 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         bool hasCallArityMatch = false;
         for (const auto &sig : sigIt->second) {
             if (sig.params.size() == e.args.size()) {
-                // Track native library for the JIT — custom emitters return
-                // before the normal matchedSig tracking below.
-                if (!sig.library.empty())
-                    used_native_libraries_.insert(sig.library);
                 hasCallArityMatch = true;
                 break;
             }
@@ -216,7 +224,8 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
                 const bool isSpied = spied_functions_.count(canonicalSig) > 0;
                 if (isMocked || isSpied) {
                     return emitNativeCustomEmitterMockDispatch(
-                        e, entry, *picked, canonicalSig, isMocked, isSpied);
+                        e, entry->customEmitter, *picked, canonicalSig,
+                        isMocked, isSpied);
                 }
             }
         }
@@ -318,8 +327,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
             args[i] = emitWideningConversion(args[i], paramLLVMTypes[i]);
     }
 
-    if (!matchedSig->library.empty())
-        used_native_libraries_.insert(matchedSig->library);
+    // Library registration handled at function entry (#2340 auto-register).
 
     // Derive runtime function name
     std::string rtName = entry->rtNameOverride
@@ -758,6 +766,42 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
 
 // ===== #1682: mock/spy for @native customEmitter overloads =====
 
+llvm::Value *CodeGen::emitBuiltinNativeOrMock(
+    const CallExpr &e,
+    const std::string &package,
+    CodeGenCustomEmitterFn emitter) {
+    // #2340: Pattern B compiler-builtin wrapper. Looks the call up under the
+    // package key the carved-out emitter belongs to (e.g. "math" for
+    // emitMathPow), runs the same #1682 mock/spy gate the Pattern A2 path
+    // uses inside emitTableDrivenNativeCall, and falls back to a direct
+    // emitter call when no mock is registered. Without this the carve-out
+    // would silently bypass any `mock("pow(int, int)", ...)` registration.
+    if (test_mode_) {
+        std::string sigKey = ry::util::nativeSigKey(package, e.callee);
+        auto sigIt = native_fn_sigs_.find(sigKey);
+        if (sigIt == native_fn_sigs_.end())
+            sigIt = native_fn_sigs_.find(e.callee);
+        if (sigIt != native_fn_sigs_.end()) {
+            const NativeFnSignature *picked =
+                pickNativeOverloadByCallShape(e, sigIt->second);
+            if (picked) {
+                std::vector<std::string> pn;
+                pn.reserve(picked->params.size());
+                for (const auto &p : picked->params) pn.push_back(p.typeName);
+                const std::string canonicalSig =
+                    buildCanonicalSig(e.callee, pn);
+                const bool isMocked = mocked_functions_.count(canonicalSig) > 0;
+                const bool isSpied  = spied_functions_.count(canonicalSig) > 0;
+                if (isMocked || isSpied) {
+                    return emitNativeCustomEmitterMockDispatch(
+                        e, emitter, *picked, canonicalSig, isMocked, isSpied);
+                }
+            }
+        }
+    }
+    return emitter(*this, e);
+}
+
 const CodeGen::NativeFnSignature *CodeGen::pickNativeOverloadByCallShape(
     const CallExpr &e, const std::vector<NativeFnSignature> &sigs) {
     // Pass 1: arity-unique match. Covers the digits(n) / digits(n, base)
@@ -809,7 +853,7 @@ const CodeGen::NativeFnSignature *CodeGen::pickNativeOverloadByCallShape(
 
 llvm::Value *CodeGen::emitNativeCustomEmitterMockDispatch(
     const CallExpr &e,
-    const NativeDispatchEntry *entry,
+    CodeGenCustomEmitterFn emitter,
     const NativeFnSignature &sig,
     const std::string &canonicalSig,
     bool isMocked,
@@ -835,11 +879,11 @@ llvm::Value *CodeGen::emitNativeCustomEmitterMockDispatch(
     llvm::FunctionCallee mockIncFn =
         getRuntimeFn("__ry_mock_increment_call", llvm::Type::getVoidTy(*ctx_), {ptrTy_});
 
-    // Spy-only: emit linear increment, then delegate to the customEmitter
+    // Spy-only: emit linear increment, then delegate to the supplied emitter
     // (which emits args + the original call).
     if (isSpied && !isMocked) {
         builder_.CreateCall(mockIncFn, {nameStr});
-        return entry->customEmitter(*this, e);
+        return emitter(*this, e);
     }
 
     // Mocked (with or without spy). Use the mock-get probe BEFORE emitting
@@ -910,11 +954,11 @@ llvm::Value *CodeGen::emitNativeCustomEmitterMockDispatch(
     emitBranchUncond(mergeBB);
     llvm::BasicBlock *captureEndBB = builder_.GetInsertBlock();
 
-    // Original path: delegate to customEmitter (which emits its own args).
+    // Original path: delegate to the supplied emitter (which emits its own args).
     builder_.SetInsertPoint(origBB);
     if (isSpied)
         builder_.CreateCall(mockIncFn, {nameStr});
-    llvm::Value *origResult = entry->customEmitter(*this, e);
+    llvm::Value *origResult = emitter(*this, e);
     emitBranchUncond(mergeBB);
     llvm::BasicBlock *origEndBB = builder_.GetInsertBlock();
 

--- a/src/codegen_call_thread.cpp
+++ b/src/codegen_call_thread.cpp
@@ -662,10 +662,13 @@ static llvm::Value *emitThreadAtomicBoolOp(CodeGen &cg, const CallExpr &e) {
 }
 
 // ===== Thread dispatch table =====
-
+//
+// threadSpawn / threadJoin were carved out to emitBuiltinThread (Pattern B)
+// per #2340 — both synthesize an `llvm::Function` from the worker body, which
+// no declarative descriptor can express. The remaining sync / atomic entries
+// stay here as table-driven customEmitters; their `libry_thread` registration
+// is now handled by dispatchThread itself (see below).
 static const CodeGen::NativeDispatchEntry thread_table[] = {
-    {"threadSpawn",      nullptr, {}, 0, nullptr, emitThreadSpawn},
-    {"threadJoin",       nullptr, {}, 0, nullptr, emitThreadJoin},
     // Sync primitives: new
     {"lockNew",          nullptr, {}, 0, nullptr, emitThreadSyncNew},
     {"rwlockNew",        nullptr, {}, 0, nullptr, emitThreadSyncNew},
@@ -700,9 +703,50 @@ static const CodeGen::NativeDispatchEntry thread_table[] = {
     {"atomicBoolFree",   nullptr, {}, 0, nullptr, emitThreadSyncFree},
 };
 
+// Gate the dispatcher: only proceed if any thread sig is actually registered,
+// and in that case register `libry_thread` up-front so the JIT loads it before
+// any customEmitter in the table runs. The previous regime registered the
+// library from emitTableDrivenNativeCall's customEmitter branch; after the
+// generic auto-register lands (see codegen_call_native.cpp) the explicit
+// insert here remains as the dispatcher-level guarantee that JSON / JSON5
+// already provide (codegen_call_json.cpp / codegen_call_json5.cpp).
+//
+// Probe two representative anchors covering the carved-out (threadSpawn) and
+// table-driven (lockNew) sides of the module; a single sig from either side
+// is enough to confirm the user imported `thread`. Mirrors the O(1)
+// `sigs.count(...)` shape used by `isJsonImported` / `isJson5Imported`.
+static bool isThreadImported(CodeGen &cg) {
+    const auto &sigs = cg.getNativeFnSigs();
+    return sigs.count("thread::threadSpawn") || sigs.count("thread::lockNew");
+}
+
 RY_REGISTER_STDLIB_PACKAGE(thread, "share/std/thread/thread.ry", dispatchThread)
 static llvm::Value *dispatchThread(CodeGen &cg, const CallExpr &e) {
+    if (!isThreadImported(cg))
+        return nullptr;
+    cg.used_native_libraries_.insert("thread");
     return cg.emitTableDrivenNativeCall(e, "thread", thread_table, std::size(thread_table));
+}
+
+// ===== Builtin Thread (Pattern B carve-out, #2340) =====
+//
+// threadSpawn synthesizes an `llvm::Function` from the worker lambda body;
+// threadJoin reads back through a ThreadResult-tagged slot. Neither maps to a
+// declarative descriptor field. Sig gate mirrors emitBuiltinJson so a same-
+// named identifier bound to a variable / lambda still reaches the indirect-
+// call path when `thread` was not imported.
+llvm::Value *CodeGen::emitBuiltinThread(const CallExpr &e) {
+    if (e.callee == "threadSpawn" &&
+        native_fn_sigs_.count("thread::threadSpawn")) {
+        used_native_libraries_.insert("thread");
+        return emitBuiltinNativeOrMock(e, "thread", &emitThreadSpawn);
+    }
+    if (e.callee == "threadJoin" &&
+        native_fn_sigs_.count("thread::threadJoin")) {
+        used_native_libraries_.insert("thread");
+        return emitBuiltinNativeOrMock(e, "thread", &emitThreadJoin);
+    }
+    return nullptr;
 }
 
 } // namespace ry

--- a/tests/spec/doc_directive.test.ry
+++ b/tests/spec/doc_directive.test.ry
@@ -30,9 +30,9 @@ Returns the absolute value of `x`.
 
 ## Examples
 
-    abs(-3)  # 3
+    myAbs(-3)  # 3
 """)
-fn abs(x: int) -> int:
+fn myAbs(x: int) -> int:
   if x < 0:
     return -x
   return x
@@ -41,9 +41,9 @@ fn abs(x: int) -> int:
 fn docDirectiveTests():
   @it("compiles and runs documented functions normally")
   fn shouldExecuteDocumentedFn():
-    expect(abs(-7)).toEq(7)
-    expect(abs(5)).toEq(5)
-    expect(abs(0)).toEq(0)
+    expect(myAbs(-7)).toEq(7)
+    expect(myAbs(5)).toEq(5)
+    expect(myAbs(0)).toEq(0)
   @it("compiles and constructs documented records normally")
   fn shouldConstructDocumentedRecord():
     p = Point(3, 4)

--- a/tests/test_codegen_contract.cpp
+++ b/tests/test_codegen_contract.cpp
@@ -49,14 +49,16 @@ TEST_F(CodeGenTest, RequireMultipleConditionsSecondFails) {
 // ===== ensure (postcondition) with variable binding =====
 
 TEST_F(CodeGenTest, EnsureSatisfied) {
+    // `abs` was carved out to emitBuiltinMath (#2340) so it is now reserved.
+    // Use a fresh name to exercise the ensure-postcondition path in isolation.
     std::string src =
-        "fn abs(x: int) -> int:\n"
+        "fn myAbs(x: int) -> int:\n"
         "    ensure v:\n"
         "        v >= 0\n"
         "    if x < 0:\n"
         "        return -x\n"
         "    return x\n"
-        "print(abs(-5))";
+        "print(myAbs(-5))";
     EXPECT_EQ(runSource(src), "5\n");
 }
 

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -3041,14 +3041,16 @@ TEST_F(DirectiveTest, DescribeBeforeEachRunsBeforeItBody) {
 // @doc on a function — accepts a single string positional argument and the
 // declaration compiles without effect on emitted IR (metadata-only).
 TEST_F(DirectiveTest, DocDirectiveOnFn) {
+    // `abs` was reserved as a compiler builtin (#2340); use a fresh name so the
+    // test only exercises @doc directive acceptance on a user fn.
     EXPECT_NO_THROW({
         runSource(
             "@doc(\"Returns the absolute value of x.\")\n"
-            "fn abs(x: int) -> int:\n"
+            "fn myAbs(x: int) -> int:\n"
             "    if x < 0:\n"
             "        return -x\n"
             "    return x\n"
-            "print(abs(-3))\n"
+            "print(myAbs(-3))\n"
         );
     });
 }

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -330,18 +330,19 @@ TEST_F(CodeGenTest, NestedFunctionCannotModifyCapturedVariable) {
 // ============================================================
 // math.pow(int, int) with a negative exponent aborts at runtime.
 //
-// Declares `pow` via a bare `@native` so the dispatcher's fallback
-// bare-name lookup routes the call through `emitMathPow` in
-// `math_table` without needing `ModuleLoader` to resolve the real
-// stdlib import. CodeGenTest::runSource goes Parser → CodeGen
+// Declares the @native("math") signatures inline so emitBuiltinMath
+// (#2340 carve-out) sees `math::pow` / `math::digits` registered and
+// intercepts the call. CodeGenTest::runSource goes Parser → CodeGen
 // directly without invoking ModuleLoader, so `from math import ...`
-// would fail with "unresolved import".
+// would fail with "unresolved import"; the explicit `("math")` tag
+// registers the sig under the right package key without loading the
+// stdlib `.ry` file.
 // ============================================================
 
 TEST_F(CodeGenTest, MathPowIntNegativeExponentAborts) {
     EXPECT_EXIT(
         runSource(
-            "@native\n"
+            "@native(\"math\")\n"
             "fn pow(x: int, y: int) -> int\n"
             "print(pow(2, -1))\n"),
         ::testing::ExitedWithCode(1),
@@ -351,7 +352,7 @@ TEST_F(CodeGenTest, MathPowIntNegativeExponentAborts) {
 TEST_F(CodeGenTest, DigitsNegativeNAborts) {
     EXPECT_EXIT(
         runSource(
-            "@native\n"
+            "@native(\"math\")\n"
             "fn digits(n: int, base: int) -> List<int>\n"
             "print(digits(-1, 10))\n"),
         ::testing::ExitedWithCode(1),
@@ -361,7 +362,7 @@ TEST_F(CodeGenTest, DigitsNegativeNAborts) {
 TEST_F(CodeGenTest, DigitsBaseLessThan2Aborts) {
     EXPECT_EXIT(
         runSource(
-            "@native\n"
+            "@native(\"math\")\n"
             "fn digits(n: int, base: int) -> List<int>\n"
             "print(digits(10, 1))\n"),
         ::testing::ExitedWithCode(1),
@@ -371,7 +372,7 @@ TEST_F(CodeGenTest, DigitsBaseLessThan2Aborts) {
 TEST_F(CodeGenTest, DigitsBaseZeroAborts) {
     EXPECT_EXIT(
         runSource(
-            "@native\n"
+            "@native(\"math\")\n"
             "fn digits(n: int, base: int) -> List<int>\n"
             "print(digits(10, 0))\n"),
         ::testing::ExitedWithCode(1),
@@ -1512,14 +1513,19 @@ TEST_F(CodeGenTest, ReservedBuiltinAllowsFallthroughAdd) {
     ));
 }
 
-TEST_F(CodeGenTest, ReservedBuiltinAllowsFallthroughAbs) {
-    EXPECT_NO_THROW(runSource(
+// `abs` was added to the reserved set in #2340 alongside the math A2
+// carve-out, so attempting a user `fn abs` declaration is rejected at
+// parse-time with the standard reserved-name diagnostic. The companion
+// fall-through test for `add` above pins that other historically
+// allowed names remain unreserved.
+TEST_F(CodeGenTest, ReservedBuiltinRejectsUserAbs) {
+    expectCompileError(
         "fn abs(x: int) -> int:\n"
         "    if x < 0:\n"
         "        return -x\n"
         "    return x\n"
-        "print(abs(-7))\n"
-    ));
+        "print(abs(-7))\n",
+        "cannot declare function 'abs': name is reserved for a built-in function");
 }
 
 // `@native` declarations are exempt by design — the stdlib itself

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -132,14 +132,14 @@ TEST_F(CodeGenTest, FnBasicDefinitions) {
         "fn isPositive(x: int) -> bool:\n"
         "    return x > 0\n"
         "print(isPositive(5))"), "true\n");
-    // FnWithIf
+    // FnWithIf — `abs` is reserved (#2340), use a fresh name.
     EXPECT_EQ(runSource(
-        "fn abs(x: int) -> int:\n"
+        "fn myAbs(x: int) -> int:\n"
         "    if x < 0:\n"
         "        return -x\n"
         "    return x\n"
-        "print(abs(-5))\n"
-        "print(abs(3))"), "5\n3\n");
+        "print(myAbs(-5))\n"
+        "print(myAbs(3))"), "5\n3\n");
     // FnCallAsStatement
     EXPECT_EQ(runSource(
         "fn greet() -> int:\n"


### PR DESCRIPTION
## Summary

- Carve the eleven type-driven A2 `@native` customEmitter entries into Pattern B compiler builtins: `math::abs/log/pow/floor/ceil/round/digits` → `emitBuiltinMath`, `json::stringify` / `stringifySafe` + `json5` mirrors → `emitBuiltinJson` / `emitBuiltinJson5`, `thread::threadSpawn` / `threadJoin` → `emitBuiltinThread`. The eleven names join `kReservedBuiltinFunctionNames`; user `fn` definitions for them now raise the standard reserved-name diagnostic at parse time.
- Retire the three hand-written `used_native_libraries_.insert(...)` lines inside `emitTableDrivenNativeCall` (variadic / customEmitter / normal paths) in favour of a single descriptor-driven auto-register at function entry. `dispatchThread` gains a dispatcher-level `libry_thread` insert to mirror the guarantee `dispatchJson` / `dispatchJson5` already provided for the remaining table-driven customEmitters.
- Generalise `emitNativeCustomEmitterMockDispatch` to accept a `CodeGenCustomEmitterFn` and add an `emitBuiltinNativeOrMock` wrapper so Pattern B carve-outs preserve #1682 mock/spy semantics (`mock("pow(int, int)", ...)` still intercepts).

Closes #2340

## Test plan

- [x] `./build-rust/ry_tests` (2986 / 2986 pass; `GetRequiredLibrariesOnlyIncludesCalledFunctions` still expects only `{"base64"}`)
- [x] `./build-rust/ry test -p` (219 / 219 spec files pass)
- [x] ASan + UBSan via `./.claude/skills/pre-commit-checklist/run-asan.sh` (219 / 219, exit 0)
- [x] `./.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh`
- [x] Reserved-name blast radius checked: `grep -rnE '\bfn (abs|log|pow|floor|ceil|round|digits|stringify|stringifySafe|threadSpawn|threadJoin)\b' share/ examples/ docs/` returns only `@native`-prefixed lines after the documentation updates in this PR.