### PR TITLE
docs(examples): define canonical examples taxonomy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ cmake --build <build-dir>
 - tree-sitter: `editor/tree-sitter/README.md` + `.claude/rules/tree-sitter-grammar-editing.md`; rebuild `ry.so`.
 - CI images: `/ci-image-workflow`.
 - Test classification: `docs/reference/test-taxonomy.md`.
+- Examples classification: `docs/reference/examples-taxonomy.md`.
 
 ## Completion
 

--- a/changelog.d/2327-examples-taxonomy.md
+++ b/changelog.d/2327-examples-taxonomy.md
@@ -1,0 +1,4 @@
+### Internal
+
+- `docs/reference/examples-taxonomy.md` を追加。`examples/` 配下の `.ry` ファイルを **canonical** / **regression** / **scratch** の 3 カテゴリに分類するポリシー文書で、canonical の品質ルール (runnable / canonical import / 明示型注釈 / `any` を dynamic boundary 限定 / 意図的失敗禁止 / stdlib のみ依存)、`any` の使用ポリシー (`docs/reference/strict-any.md` と `docs/architecture/implicit-any-paths.md` を canonical examples に適用)、および LoRA training data セレクションルール (canonical のみ採用) を定義する。後続 issue (#2326 canonical 拡張 / #2328 realistic small programs / #2329 verification / #2330 spec-derived examples / #2324 stdlib-docs migration) が参照する policy 基盤。(#2327)
+- `AGENTS.md` Path-Specific Entry Points に `Examples classification: docs/reference/examples-taxonomy.md.` を 1 行追加し、agent routing から policy を発見可能にした。(#2327)

--- a/docs/reference/examples-taxonomy.md
+++ b/docs/reference/examples-taxonomy.md
@@ -1,0 +1,65 @@
+# Examples Taxonomy
+
+`examples/` 配下の `.ry` ファイルを「何のためにあるか」で 3 カテゴリに分類する。LoRA training の positive data として使うものと、含めてはならないものをルールで区別可能にすることが目的。`tests/` 側の `docs/reference/test-taxonomy.md` と同じ三段構成 (定義 → 制約 → 具体例) を踏襲する。
+
+## カテゴリ
+
+### canonical
+
+LoRA training の positive data として使う「公式の Ry の書き方」を示す例。`examples/` 直下の現存ファイルは provisionally このカテゴリに置かれている。要件は次節の「品質ルール」を満たすこと。
+
+例: `examples/fibonacci.ry`, `examples/closures_higher_order.ry`, `examples/json_record_loading.ry`。
+
+### regression
+
+過去のバグ・review 指摘を再現または防御する例。LoRA training には**含めない**。
+
+- 冒頭コメントに `# regression #NNNN` を 1 行付け、ファイル単位で識別可能にする。`docs/reference/test-taxonomy.md` の regression カテゴリと同じ `#NNNN` 規約。
+- 意図的に compiler error / runtime panic を発火させてよい。
+- 現状ゼロ。
+
+### scratch
+
+review・探索・実験用の一時コード。LoRA training には**含めない**。
+
+- 冒頭コメントに `# scratch` を 1 行付け、ファイル単位で識別可能にする。
+- 動作不完全な断片や polish 前の探索コードを含んでよい。
+- 現状ゼロ。
+
+## canonical の品質ルール
+
+canonical カテゴリのファイルは以下をすべて満たす:
+
+1. ビルドした `<build-dir>/ry <file>` がゼロ exit code で完結する (`<build-dir>` は preset により `build/` または `build-rust/`、`AGENTS.md` の "Build And Test" 表を参照)。
+2. `fn` の引数は明示型注釈を持つ。戻り値および lambda 引数の注釈省略は許容する (`docs/architecture/implicit-any-paths.md` の Path 1/2/3 の keep / deprecate 区分に従う)。LoRA training data としては戻り値の明示注釈を**推奨**する。
+3. import は canonical 形式のみ — `from ry.<module> import …` または `import ry.<module>` (`changelog.d/2351-reject-legacy-stdlib-imports.md` で legacy 形式が hard error 化済み)。
+4. `--strict-any` を付けてもエラーなくビルドできる。`any` の使用は dynamic boundary に限定する (次節)。
+5. 意図的な panic / abort / 未網羅 `case` 起因のフォールスルー失敗を含まない。
+6. ライブラリ外部依存なし — `from ry.*` の stdlib のみで完結する。
+
+ルール 1 と 6 は LoRA training 入力として安定 reproducible であるため。ルール 2 から 5 は Ry の "stronger typing direction" の品質指針を反映する。
+
+## `any` の使用ポリシー (dynamic boundary 限定)
+
+詳細な classification は `docs/architecture/implicit-any-paths.md`、mode semantics は `docs/reference/strict-any.md` を source of truth とする。canonical examples の範囲では以下のみ判断材料となる:
+
+**許可される (dynamic boundary)**: JSON / JSON5 parse 結果、`@native` heterogeneous-return プレースホルダ (`.claude/rules/docs-reference-conventions.md` の規約)、FFI / `@extern` 戻り値、plugin / diagnostics 境界。
+
+**避けるべき**: `fn` 引数の implicit any (型注釈省略)、`v: any = …` から具体型への implicit unwrap、`any` 値への直接演算。同等比較 `==` / `!=` は許容。`Map<str, any>` の値を具体型として扱う場面では `case asType[T](v)` 等のチェック付き narrowing を使う。
+
+## LoRA training data のセレクション
+
+`canonical` カテゴリのみを training data に含める。除外条件:
+
+- 冒頭コメントに `# regression #NNNN` または `# scratch` を含むファイル。
+- `<build-dir>/ry <file>` が非ゼロ exit で完結するファイル。
+- 「canonical の品質ルール」のいずれかを満たさないファイル。
+
+自動化 (manifest 出力 / CI ガード) と全数検証は別 issue のスコープで、本ドキュメントはルールの定義のみを担う。training pipeline 本体 (別リポジトリ) との接続点は `docs/architecture/jsonl-run-logs.md` を参照。
+
+## 関連
+
+- `docs/reference/test-taxonomy.md` — `tests/` 側の対応分類。本文書の regression 規約はこれと整合する。
+- `docs/reference/strict-any.md` — `any` ポリシーの mode semantics、診断 id、default flip 計画。
+- `docs/architecture/implicit-any-paths.md` — implicit any 経路の網羅目録と keep / deprecate 区分。
+- `docs/architecture/jsonl-run-logs.md` — `scripts/export-run-logs.sh` 経由の training pipeline 接続点。


### PR DESCRIPTION
## Summary
- `docs/reference/examples-taxonomy.md` を追加。`examples/` 配下を canonical / regression / scratch に分類し、品質ルール (runnable / 明示型注釈 / canonical import / dynamic boundary 限定 any / 意図的失敗禁止 / stdlib 依存のみ)、`any` 使用ポリシー、LoRA training data セレクション基準を定義する policy 文書。
- `AGENTS.md` の Path-Specific Entry Points に `Examples classification:` の 1 行を追加し、agent routing から発見可能にした。
- `changelog.d/2327-examples-taxonomy.md` を追加。

Closes #2327

## Test plan
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` が clean
- [x] exemplar 5本 (`fibonacci.ry`, `closures_higher_order.ry`, `json_record_loading.ry`, `read_json.ry`, `write_json.ry`) が canonical policy に整合することを目視確認
- [x] `docs/reference/test-taxonomy.md` の三段構成 (定義 → 制約 → 具体例) と並行する章立て