### PR TITLE
test(examples): verify canonical examples still run cleanly (#2329)

### DIFF
--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -24,6 +24,7 @@ Also evaluate when relevant:
 - Rust lint when `crates/` changed.
 - Prompt-reference lint when `.claude/`, `AGENTS.md`, or `CLAUDE.md` changed.
 - Export-run-logs JSONL schema test when `scripts/export-run-logs.sh`, `tests/scripts/`, or the `__ry_test_summary` output format in `src/test_runtime.cpp` changed.
+- Examples check when `examples/` or `scripts/check-examples.sh` changed.
 - tree-sitter check when grammar, scanner, query, or EBNF changed.
 - Label cleanup policy.
 
@@ -49,6 +50,7 @@ Update a rule or skill when work reveals a reusable constraint, a new rejection-
 ./.claude/skills/pre-commit-checklist/run-rust-lint.sh
 ./.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh
 ./.claude/skills/pre-commit-checklist/run-export-run-logs-tests.sh
+./.claude/skills/pre-commit-checklist/run-examples-check.sh
 ./.claude/skills/pre-commit-checklist/run-fuzz.sh
 ./.claude/skills/pre-commit-checklist/run-tree-sitter.sh
 ```

--- a/.claude/skills/pre-commit-checklist/run-examples-check.sh
+++ b/.claude/skills/pre-commit-checklist/run-examples-check.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Canonical examples verification (#2329) — runs scripts/check-examples.sh
+# against every examples/*.ry file (non-recursive). Run before pushing any
+# change under examples/ or scripts/check-examples.sh.
+#
+# Requires: a built ry binary in build-rust/ or build/ (or $RY_BUILD_DIR).
+# No --clean flag: no build dir owned by this wrapper.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+
+echo "==> scripts/check-examples.sh" >&2
+bash scripts/check-examples.sh
+
+echo "==> canonical examples OK" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,12 @@ jobs:
         run: ./build/ry_tests
       - name: Test (Ry self-tests)
         run: ./build/ry test
+      - name: 'Test (canonical examples, #2329)'
+        # Run every examples/*.ry (non-recursive — future negative/review
+        # subdirs are excluded by construction; see examples/README.md).
+        # Exit-code only, no golden output matching. Catches drift between
+        # the LoRA-source examples and current language semantics.
+        run: bash scripts/check-examples.sh
       - name: 'Test (export-run-logs JSONL schema, #2300)'
         # `jq` is not in `ry-ci:llvm-21` (gcc:14-trixie base); install a
         # prebuilt binary inline, verified against the project's published

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ cmake --build <build-dir>
 ./<build-dir>/ry_tests
 ./<build-dir>/ry test -p
 ./<build-dir>/ry test tests/spec/<file>.test.ry
+bash scripts/check-examples.sh
 ```
 
 - Requires Rust 1.83+ and shared libLLVM. If corrosion misses Rust, configure with `-DRust_COMPILER=$(rustup which rustc)`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,12 +1,10 @@
 # Examples
 
-Canonical, runnable examples that demonstrate Ry language features. Used as
+Runnable Ry programs that demonstrate language features. Used as
 documentation samples and as source material for LoRA fine-tuning in the
 external `t0k0sh1/ry-code` project.
 
-- The positive set is every `*.ry` file directly under `examples/` (non-recursive).
-- Examples that intentionally demonstrate failures, or are under review, belong
-  in `examples/negative/` or `examples/review/`; the verification script's
-  non-recursive glob excludes them by construction.
-- Verify the positive set locally with `bash scripts/check-examples.sh`
-  (requires a built `ry` binary in `build-rust/` or `build/`).
+Classification (canonical / regression / scratch) is defined in
+`docs/reference/examples-taxonomy.md`. Verify the canonical set locally
+with `bash scripts/check-examples.sh` (requires a built `ry` binary in
+`build-rust/` or `build/`).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,12 @@
+# Examples
+
+Canonical, runnable examples that demonstrate Ry language features. Used as
+documentation samples and as source material for LoRA fine-tuning in the
+external `t0k0sh1/ry-code` project.
+
+- The positive set is every `*.ry` file directly under `examples/` (non-recursive).
+- Examples that intentionally demonstrate failures, or are under review, belong
+  in `examples/negative/` or `examples/review/`; the verification script's
+  non-recursive glob excludes them by construction.
+- Verify the positive set locally with `bash scripts/check-examples.sh`
+  (requires a built `ry` binary in `build-rust/` or `build/`).

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Verify that canonical examples/*.ry programs still run cleanly (#2329).
+#
+# Runs `ry run` on every *.ry file directly under examples/ (non-recursive)
+# and reports failures by file name. Exit code only — no golden-output
+# matching. The non-recursive glob is the exclusion mechanism: future
+# negative / review / intentional-failure examples live in subdirectories
+# such as examples/negative/ or examples/review/ (see examples/README.md)
+# and are skipped automatically.
+#
+# Usage:
+#   scripts/check-examples.sh
+# Env:
+#   RY_BUILD_DIR — override build dir (default: build-rust/ if present,
+#                  else build/). Must be a repo-relative path.
+# Exit codes:
+#   0  every example exited 0
+#   1  one or more examples failed, or the ry binary was not located
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [[ -n "${RY_BUILD_DIR:-}" ]]; then
+  RY_BUILD_DIR="${RY_BUILD_DIR%/}"
+  if [[ ! -x "$RY_BUILD_DIR/ry" ]]; then
+    echo "error: ry binary not found at $RY_BUILD_DIR/ry" >&2
+    exit 1
+  fi
+elif [[ -x "build-rust/ry" ]]; then
+  RY_BUILD_DIR="build-rust"
+elif [[ -x "build/ry" ]]; then
+  RY_BUILD_DIR="build"
+else
+  echo "error: ry binary not found in build-rust/ or build/; set RY_BUILD_DIR" >&2
+  exit 1
+fi
+
+RY_BIN="$RY_BUILD_DIR/ry"
+
+shopt -s nullglob
+EXAMPLES=(examples/*.ry)
+shopt -u nullglob
+
+(( ${#EXAMPLES[@]} > 0 )) || { echo "error: no examples/*.ry files found" >&2; exit 1; }
+
+TOTAL=${#EXAMPLES[@]}
+PASS=0
+FAIL=0
+
+for f in "${EXAMPLES[@]}"; do
+  if out="$("$RY_BIN" run "$f" 2>&1)"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s\n' "$f" >&2
+    printf '%s\n' "$out" >&2
+    echo "::error::canonical example failed: $f" >&2
+  fi
+done
+
+echo "$PASS/$TOTAL examples passed" >&2
+(( FAIL == 0 )) || exit 1

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Verify that canonical examples/*.ry programs still run cleanly (#2329).
 #
-# Runs `ry run` on every *.ry file directly under examples/ (non-recursive)
-# and reports failures by file name. Exit code only — no golden-output
-# matching. The non-recursive glob is the exclusion mechanism: future
-# negative / review / intentional-failure examples live in subdirectories
-# such as examples/negative/ or examples/review/ (see examples/README.md)
-# and are skipped automatically.
+# Runs `ry run` on every *.ry file under examples/ that the taxonomy
+# (docs/reference/examples-taxonomy.md) classifies as canonical, and
+# reports failures by file name. Exit code only — no golden-output
+# matching. Files whose first line is `# regression #NNNN` or `# scratch`
+# are non-canonical and skipped (intentional compile-error or
+# runtime-panic demos, or pre-polish exploratory code).
 #
 # Usage:
 #   scripts/check-examples.sh
@@ -37,10 +37,22 @@ fi
 RY_BIN="$RY_BUILD_DIR/ry"
 
 shopt -s nullglob
-EXAMPLES=(examples/*.ry)
+ALL=(examples/*.ry)
 shopt -u nullglob
 
-(( ${#EXAMPLES[@]} > 0 )) || { echo "error: no examples/*.ry files found" >&2; exit 1; }
+(( ${#ALL[@]} > 0 )) || { echo "error: no examples/*.ry files found" >&2; exit 1; }
+
+EXAMPLES=()
+SKIPPED=()
+for f in "${ALL[@]}"; do
+  first_line=""
+  IFS= read -r first_line < "$f" || true
+  if [[ "$first_line" =~ ^#[[:space:]](regression|scratch)([[:space:]]|$) ]]; then
+    SKIPPED+=("$f")
+  else
+    EXAMPLES+=("$f")
+  fi
+done
 
 TOTAL=${#EXAMPLES[@]}
 PASS=0
@@ -57,5 +69,9 @@ for f in "${EXAMPLES[@]}"; do
   fi
 done
 
-echo "$PASS/$TOTAL examples passed" >&2
+if (( ${#SKIPPED[@]} > 0 )); then
+  echo "$PASS/$TOTAL canonical examples passed (${#SKIPPED[@]} non-canonical skipped)" >&2
+else
+  echo "$PASS/$TOTAL canonical examples passed" >&2
+fi
 (( FAIL == 0 )) || exit 1


### PR DESCRIPTION
## Summary

- Add `scripts/check-examples.sh`: runs `ry run` on every canonical `examples/*.ry` and reports failures by file name; exit code only, no golden-output matching.
- Honor `docs/reference/examples-taxonomy.md` (PR #2366): files whose first line is `# regression #NNNN` or `# scratch` are non-canonical and skipped.
- Wire the check into the CI `test` job (after `Test (Ry self-tests)`), the `/pre-commit-checklist` skill, and AGENTS.md's Build And Test block. Add a short `examples/README.md` that points at the taxonomy doc.

Closes #2329

## Test plan

- [x] `bash scripts/check-examples.sh` → `33/33 canonical examples passed`, exit 0
- [x] Corrupt one example → `FAIL examples/<name>.ry` + `::error::` annotation + exit 1; restore → exit 0
- [x] Verified `# regression #NNNN` and `# scratch` markers are skipped (temporary fixtures, since removed)
- [x] `RY_BUILD_DIR=build-rust` env override works; `RY_BUILD_DIR=nonexistent` errors out with exit 1
- [x] `bash .claude/skills/pre-commit-checklist/run-examples-check.sh` end-to-end OK
- [x] `bash scripts/check-prompt-refs.sh` clean (AGENTS.md / SKILL.md inline paths resolve)
- [x] `ci.yml` YAML syntax validated