### PR TITLE
chore(examples): derive curated canonical examples from spec tests (#2330)

### DIFF
--- a/examples/block_strings.ry
+++ b/examples/block_strings.ry
@@ -1,0 +1,39 @@
+# triple-quoted block strings: indentation stripping and multi-line content
+
+# The leading and trailing newlines are dropped, and the common indentation
+# of the content lines is removed.
+poem = """
+  roses are red
+    violets are blue
+  this is multi-line
+  """
+
+print(poem)
+
+# Blank lines inside the block are preserved verbatim
+withBlank = """
+  alpha
+
+  beta
+  """
+
+print(withBlank)
+
+# Raw tabs and other whitespace are kept verbatim
+escaped = """tab	here"""
+print(escaped)
+
+# Block strings happily contain quotes without escaping
+quoted = """she said "hi" and left"""
+print(quoted)
+
+# Useful for embedded documentation or templates
+fn helpText() -> str:
+  return """
+    Usage: greet [--upper] <name>
+
+    Options:
+      --upper   shout the greeting
+    """
+
+print(helpText())

--- a/examples/filesystem_basics.ry
+++ b/examples/filesystem_basics.ry
@@ -1,0 +1,26 @@
+# filesystem stdlib: create a directory, write files, inspect, then clean up
+from ry.filesystem import mkdirAll, removeAll, listDir, isFile, isDir, fileSize
+from ry.io import writeText
+from ry.path import join
+
+dir = "/tmp/ry_examples_fs"
+
+# Idempotent setup: clear any leftover state, then recreate the directory.
+# Re-running this example must not fail because a directory already exists.
+removeAll(dir)
+case mkdirAll(dir):
+  Ok(_):
+
+    # `?` propagates an Err out of each call, so the filesystem chain stays flat.
+    helloPath = join(dir, "hello.txt")?
+    writeText(helloPath, "hello from ry\n")?
+    writeText(join(dir, "data.txt")?, "12345")?
+    entries = listDir(dir)?
+    print("entries:", len(entries))
+    print("hello.txt isFile:", isFile(helloPath)?)
+    print("hello.txt size:", fileSize(helloPath)?)
+    print("dir isDir:", isDir(dir)?)
+  Err(e):
+    print("mkdirAll failed:", e.message)
+
+removeAll(dir)

--- a/examples/generic_bounds.ry
+++ b/examples/generic_bounds.ry
@@ -1,0 +1,34 @@
+# bounded generics with record subtyping
+record Animal:
+  name: str
+  legs: int
+
+# Dog is a subtype of Animal: it inherits Animal's fields and adds one
+record Dog < Animal:
+  breed: str
+
+# GuideDog is a subtype of Dog, transitively a subtype of Animal
+record GuideDog < Dog:
+  handler: str
+
+# A bounded generic accepts Animal and any of its subtypes
+fn describe<T: Animal>(a: T) -> str:
+  return a.name + " has " + str(a.legs) + " legs"
+
+cat = Animal("Cat", 4)
+rex = Dog("Rex", 4, "Labrador")
+guide = GuideDog("Lily", 4, "Poodle", "Anna")
+
+print(describe(cat))
+print(describe(rex))
+print(describe(guide))
+
+# Bounds compose with extra unbounded parameters
+fn pairLabel<T: Animal, U>(a: T, extra: U) -> str:
+  return a.name + " (" + str(extra) + ")"
+
+print(pairLabel(rex, 42))
+print(pairLabel(guide, "trained"))
+
+# Explicit type argument selects the bound used for checking
+print(describe[Dog](rex))

--- a/examples/nested_functions.ry
+++ b/examples/nested_functions.ry
@@ -1,0 +1,50 @@
+# nested fn definitions: scoping, sibling calls, mutual recursion
+
+# A helper defined inside its enclosing function
+fn computeArea(width: int, height: int) -> int:
+  fn rectArea(w: int, h: int) -> int:
+    return w * h
+  return rectArea(width, height)
+
+print("area:", computeArea(3, 4))
+
+# Same name in sibling scopes does not collide
+fn foo() -> int:
+  fn helper() -> int:
+    return 1
+  return helper()
+
+fn bar() -> int:
+  fn helper() -> int:
+    return 2
+  return helper()
+
+print("foo + bar =", foo() + bar())
+
+# Mutual recursion between nested functions
+fn parityOf(n: int) -> str:
+  fn isEven(k: int) -> bool:
+    if k == 0:
+      return true
+    return isOdd(k - 1)
+  fn isOdd(k: int) -> bool:
+    if k == 0:
+      return false
+    return isEven(k - 1)
+  if isEven(n):
+    return "even"
+  return "odd"
+
+print("4 is", parityOf(4))
+print("7 is", parityOf(7))
+
+# Passing a nested function to a higher-order function
+fn apply(f: fn(int) -> int, x: int) -> int:
+  return f(x)
+
+fn runDoubler(x: int) -> int:
+  fn doubleIt(n: int) -> int:
+    return n * 2
+  return apply(doubleIt, x)
+
+print("doubled:", runDoubler(5))

--- a/examples/numeric_literal_suffixes.ry
+++ b/examples/numeric_literal_suffixes.ry
@@ -1,0 +1,27 @@
+# numeric literal type suffixes and matching type annotations
+
+# Signed integer suffixes — i8, i16, i32, i64 are all available; i8 and i64 shown
+a: i8 = 127i8
+d: i64 = 1000i64
+print("signed:", a as int, d)
+
+# Unsigned integer suffixes — u8, u16, u32, u64 are all available; u8 and u64 shown
+u: u8 = 255u8
+x: u64 = 1000u64
+print("unsigned:", u as int, x as int)
+
+# Float suffixes — f32 and f64
+f: f32 = 3.14f32
+g: f64 = 2.5f64
+print("f32 value:", f as float)
+print("f64 value:", g)
+
+# Arithmetic on suffixed literals stays in that type
+sumI32 = 10i32 + 20i32
+sumU8 = 100u8 + 50u8
+sumF32 = 1.5f32 + 2.5f32
+print("sums:", sumI32 as int, sumU8 as int, sumF32 as float)
+
+# Negative suffixed literals
+neg: i8 = -128i8
+print("min i8:", neg as int)

--- a/examples/record_patterns.ry
+++ b/examples/record_patterns.ry
@@ -1,0 +1,41 @@
+# positional record destructuring in case, with guards and nesting
+record Point:
+  x: int
+  y: int
+
+record Segment:
+  start: Point
+  endPt: Point
+
+# Bind fields positionally
+p = Point(3, 4)
+case p:
+  Point(a, b):
+    print("point", a, b)
+
+# Mix a literal with a binding to filter on a field
+case Point(0, 5):
+  Point(0, y):
+    print("on y-axis, y =", y)
+  _:
+    print("off-axis")
+
+# Add a guard on the destructured fields
+case Point(10, 3):
+  Point(a, b) if a > b:
+    print("x bigger")
+  Point(_, _):
+    print("y bigger or equal")
+
+# Patterns nest: a record inside a record
+seg = Segment(Point(1, 2), Point(3, 4))
+case seg:
+  Segment(Point(x1, _), Point(x2, _)):
+    print("x range:", x1, "to", x2)
+
+# case as an expression
+labelStr = case Point(0, 0):
+  Point(0, 0) : "origin"
+  _ : "other"
+
+print(labelStr)

--- a/examples/tuple_destructuring.ry
+++ b/examples/tuple_destructuring.ry
@@ -1,0 +1,36 @@
+# tuple destructuring with case patterns, guards, and Option nesting
+
+# Bind both components from a 2-tuple
+case (10, 20):
+  (x, y):
+    print(x, y)
+
+# Mix a literal with a binding to filter and capture
+case (1, 99):
+  (1, n):
+    print("matched 1, n =", n)
+  _:
+    print("no match")
+
+# Add a guard on a tuple binding
+case (10, 3):
+  (a, b) if a > b:
+    print("first bigger")
+  (a, b):
+    print("other")
+
+# Patterns nest: an Option inside a tuple
+opt: Option<int> = Some(7)
+t = (opt, 42)
+case t:
+  (Some(v), _):
+    print("found", v)
+  _:
+    print("not found")
+
+# case can return a value (expression form)
+total = case (3, 4):
+  (a, b) : a + b
+  _ : -1
+
+print("total =", total)


### PR DESCRIPTION
## Summary

- Adds 7 canonical examples derived from `tests/spec/` that fill underrepresented feature families: pattern/destructure (tuple, record), advanced functions (nested fns, bounded generics with record subtyping), types/numerics (literal suffixes, block strings), and stdlib (filesystem).
- Strips the `ry.testing` DSL so each file reads as an ordinary runnable Ry program — the goal taxonomy laid out in #2327.
- Comments are in English (per LoRA-batch direction); all files satisfy the canonical rules from `docs/reference/examples-taxonomy.md` (explicit `fn` arg types, canonical `ry.*` imports, no `--strict-any` violations).

## Test plan

- [x] `bash scripts/check-examples.sh` → 40/40 passed
- [x] Each new file passes `./build-rust/ry --strict-any run examples/<file>.ry`
- [x] `./build-rust/ry fmt --check examples/` clean
- [x] `filesystem_basics.ry` is idempotent: re-running back-to-back stays exit 0
- [x] `scripts/check-prompt-refs.sh` clean

Closes #2330