### PR TITLE
chore: migrate stdlib docs and examples away from broad any usage (#2324)

### DIFF
--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -8,7 +8,7 @@ fn functionName(paramName: type, ...) -> returnType:
     return value
 ```
 
-- Parameter types are optional. When omitted, the parameter is treated as `any` type.
+- Parameter types are optional; when omitted, the parameter defaults to `any` ([deprecated](#type-omission-and-any) — prefer an explicit type).
 - A trailing comma after the last parameter is allowed: `fn f(a: int, b: int,) -> int:`.
 - Return type is optional. When omitted, the return type is **inferred from the body** (both named functions and lambdas). If the function has no `return` statement, the return type is inferred as `Unit`. Use `-> any` explicitly for functions that should accept any return type.
 - The body is an indented block.
@@ -31,7 +31,7 @@ fn greet(name: str) -> Unit:
 
 | Item | Description |
 |---|---|
-| Parameter type | Optional. Defaults to `any` when the `: type` annotation is omitted |
+| Parameter type | Optional. Defaults to `any` when the `: type` annotation is omitted ([deprecated](#type-omission-and-any)) |
 | Return type | Optional. Inferred from the body when omitted (inferred as `Unit` if no `return` statement) |
 | `Unit` | Return type for functions that return no value |
 
@@ -44,16 +44,18 @@ fn noReturn(x: int) -> Unit:  # Return type Unit (explicit)
 fn getValue() -> int:     # Return type int
     return 42
 
-fn identity(x) -> any:    # Parameter type any (omitted)
+fn identity(x: any) -> any:    # Parameter type any (explicit)
     return x
 ```
 
 ### Type Omission and `any`
 
-When a parameter type annotation is omitted, the parameter is treated as `any` — a dynamic type that accepts any primitive value at runtime. This is similar to Python's untyped parameters.
+When a parameter type annotation is omitted, the parameter is treated as `any` — a dynamic type that accepts any primitive value at runtime.
+
+> **Deprecated (#2317, #2323)**: Omitting a parameter type annotation emits a compile-time warning. Write `: any` explicitly to suppress it, or prefer a concrete type. See [Untyped Parameters (Deprecated)](types.md#untyped-parameters-deprecated) for migration guidance.
 
 ```ry
-# All parameters default to any
+# Deprecated: implicit any from omitted annotation
 fn add(a, b):
     return a + b
 
@@ -62,7 +64,7 @@ add("hello", " world") # "hello world" (str + str)
 add(1, 2.0)            # 3.0 (int + float)
 ```
 
-You can also use `any` explicitly in type annotations:
+You can also use `any` explicitly in type annotations (no warning):
 
 ```ry
 fn identity(x: any) -> any:
@@ -282,7 +284,7 @@ Low-level numeric types (`i8`, `i16`, `i32`, `i64`, `u8`–`u64`, `f32`) do **no
 fn process(x: int) -> str:
     return "int"
 
-fn process(x) -> str:          # x: any
+fn process(x: any) -> str:     # any fallback (lowest-priority overload)
     return "any"
 
 process(42)       # "int" — exact match (int) beats any

--- a/examples/read_json.ry
+++ b/examples/read_json.ry
@@ -6,6 +6,13 @@ raw = "{\"name\": \"Alice\", \"age\": 30, \"items\": [1, 2, 3]}"
 case load[Map<str,any>](raw):
   Ok(v):
     print(f"parsed (map): {v}")
+    # 取り出した値は asType[T] で型安全に narrowing する
+    case asType[str](v["name"]):
+      Ok(name): print(f"name: {name}")
+      Err(e):   print(f"name err: {e.message}")
+    case asType[int](v["age"]):
+      Ok(age): print(f"age: {age}")
+      Err(e):  print(f"age err: {e.message}")
   Err(e):
     print(f"parse err: {e.message}")
 

--- a/examples/write_json.ry
+++ b/examples/write_json.ry
@@ -1,9 +1,7 @@
 # JSON 書き出し (stdlib の json モジュール)
 from ry.json import stringify
 
-# Map<str, any> リテラル: 各値を明示的に any 化する必要がある
-v1: any = 1
-v2: any = "hello"
-m: Map<str, any> = {"x": v1, "y": v2}
+# Map<str, any> リテラル: 値はリテラル位置で any に自動ラップされる
+m: Map<str, any> = {"x": 1, "y": "hello"}
 s = stringify(m)
 print(f"stringified: {s}")


### PR DESCRIPTION
## Summary

Source-material cleanup ahead of #2322 (flip `--strict-any` to compiler default). Compiler enforcement already landed via #2367 / #2369; this PR migrates the docs and canonical examples to match the new norms.

- `examples/write_json.ry`: drop the explicit `v1: any = 1` / `v2: any = "hello"` boxing pattern in favor of the `Map<str, any>` literal auto-wrap form documented at `docs/reference/types.md` (line 936).
- `examples/read_json.ry`: add an `asType[T]` narrowing demo inside the `Ok(v):` branch, mirroring the canonical recovery pattern documented at `types.md` (lines 1117-1129).
- `docs/reference/functions.md`: add a Deprecated (#2317, #2323) callout to the "Type Omission and `any`" section, link the top-level bullet and "Parameter and Return Types" table row to that callout, and swap implicit-`any` side examples (lines 47, 285) to the explicit `(x: any)` form for internal consistency.

`share/std/` source intentionally left unchanged — every `any` use there is a real dynamic boundary (JSON, `asType` builtin, `thread.ry` generic-T placeholder per `.claude/rules/docs-reference-conventions.md`, `testing.ry` directive infra).

Closes #2324

## Test plan

- [x] `./build-rust/ry run examples/write_json.ry` — exit 0, prints `stringified: {"x":1,"y":"hello"}`
- [x] `./build-rust/ry --strict-any run examples/write_json.ry` — same
- [x] `./build-rust/ry run examples/read_json.ry` — exit 0, prints parsed map plus `name: Alice` / `age: 30` from the new asType blocks
- [x] `./build-rust/ry --strict-any run examples/read_json.ry` — same
- [x] `bash scripts/check-examples.sh` — 33/33 canonical examples pass
- [x] `./build-rust/ry_tests` — 3015/3015 unit tests pass
- [x] `./build-rust/ry test -p` — 218 spec files, 0 failures
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` — clean