### PR TITLE
chore(examples): expand canonical examples for core language features and stdlib (#2326)

### DIFF
--- a/examples/base64_bytes.ry
+++ b/examples/base64_bytes.ry
@@ -1,0 +1,19 @@
+# バイナリデータ (List<u8>) を base64 でラウンドトリップする
+# URL-safeアルファベットそのものの比較は examples/base64_url_safe.ry を参照
+from ry.base64 import encodeBytes, decodeBytes
+
+# JPEGファイルのマジックバイト 0xFF 0xD8 0xFF 0xE0
+jpegMagic: List<u8> = [255u8, 216u8, 255u8, 224u8]
+encoded = encodeBytes(jpegMagic)
+print(encoded)
+
+# encodeBytes → decodeBytes でラウンドトリップ
+case decodeBytes(encoded):
+  Ok(bytes):
+    print(bytes == jpegMagic)
+  Err(e):
+    print(e.message)
+
+# 0x00 を含むバイト列もそのまま扱える (str-baseのencode/decodeはNUL前で切れる)
+withNul: List<u8> = [0u8, 255u8, 0u8]
+print(encodeBytes(withNul))

--- a/examples/base64_url_safe.ry
+++ b/examples/base64_url_safe.ry
@@ -1,0 +1,26 @@
+# URL-safe base64 (encode/decodeUrlSafe) と標準base64との違いを示す
+from ry.base64 import encode, encodeUrlSafe, decode, decodeUrlSafe
+
+# 標準base64は + と / を使うが、URL-safe版は - と _ を使う
+text = "?>>"
+std = encode(text)
+urlSafe = encodeUrlSafe(text)
+print(std)
+print(urlSafe)
+
+# URL-safe版は = padding も省略する
+print(encodeUrlSafe("Hello, World!"))
+
+# 復号は対応する関数で行う (標準は decode、URL-safeは decodeUrlSafe)
+case decodeUrlSafe(urlSafe):
+  Ok(decoded):
+    print(decoded)
+  Err(e):
+    print(e.message)
+
+# 不正な文字列はErrを返す
+case decodeUrlSafe("!!!"):
+  Ok(_):
+    print("unexpected ok")
+  Err(e):
+    print(e.message)

--- a/examples/builtins_dynamic_dispatch.ry
+++ b/examples/builtins_dynamic_dispatch.ry
@@ -1,0 +1,48 @@
+# asType[T] / isType[T] による any 値の安全な絞り込みを示す
+# JSON の load[Map<str, any>] 等から得た any 値を具体型に narrow する標準パターン
+
+# isType[T] は any が型 T を保持していれば true
+v: any = 42
+print(isType[int](v))
+print(isType[str](v))
+print(isType[bool](v))
+
+# asType[T] はチェック付きのcast。型が合えば Ok、合わなければ Err
+case asType[int](v):
+  Ok(n):
+    print(n)
+  Err(e):
+    print(e.message)
+
+w: any = "hello"
+case asType[int](w):
+  Ok(_):
+    print("unexpected ok")
+  Err(e):
+    print(e.message)
+
+# 異なる any 値に対して順にcastを試みるディスパッチ
+fn describe(value: any) -> str:
+  case asType[int](value):
+    Ok(n):
+      return "int: " + str(n)
+    Err(_):
+      0
+  case asType[str](value):
+    Ok(s):
+      return "str: " + s
+    Err(_):
+      0
+  case asType[bool](value):
+    Ok(b):
+      return "bool: " + str(b)
+    Err(_):
+      0
+  return "unknown"
+
+asInt: any = 7
+asStr: any = "ry"
+asBool: any = true
+print(describe(asInt))
+print(describe(asStr))
+print(describe(asBool))

--- a/examples/builtins_enumerate_zip.ry
+++ b/examples/builtins_enumerate_zip.ry
@@ -1,0 +1,22 @@
+# enumerate と zip でindexペアや要素ペアを得る
+xs = [10, 20, 30]
+
+# enumerate(xs) は (index, value) のtuple Listを返す
+pairs = enumerate(xs)
+print(pairs)
+
+# 通常のforループでdestructuringして使う
+for i, x in enumerate(xs):
+  print(i, x)
+
+# zip(a, b) は同じindexの要素をペアにする
+ys = ["a", "b", "c"]
+combined = zip(xs, ys)
+print(combined)
+
+for n, label in zip(xs, ys):
+  print(label, n)
+
+# 長さが違う場合、短い方に合わせて切り詰められる
+print(zip([1, 2, 3], [10, 20]))
+print(zip([1, 2], [10, 20, 30, 40]))

--- a/examples/builtins_env_args.ry
+++ b/examples/builtins_env_args.ry
@@ -1,0 +1,22 @@
+# プロセス環境変数とCLI引数の取得を示す
+
+# env(key) は環境変数を Option<str> で返す。未設定ならNone
+case env("PATH"):
+  Some(path):
+
+    # 値が長いので先頭1要素だけ表示
+    parts = split(path, ":")
+    print(parts[0])
+  None:
+    print("PATH not set")
+
+# 未設定の変数はNone
+print(env("RY_EXAMPLES_NONEXISTENT_XYZ"))
+
+# 2引数版 env(key, default) は未設定時にdefaultを直接返す
+print(env("RY_EXAMPLES_NONEXISTENT_XYZ", "fallback"))
+
+# args() はコマンドライン引数のList<str>を返す
+# `ry run examples/builtins_env_args.ry` のように追加引数なしで実行すると空Listになる
+for arg in args():
+  print(arg)

--- a/examples/case_expression.ry
+++ b/examples/case_expression.ry
@@ -1,0 +1,48 @@
+# caseを値を返す式として使う、OR-pattern、文字列リテラルマッチ、ガード節を示す
+
+# 整数リテラルとwildcardによる式形式
+x = 2
+label = case x:
+  1 : "one"
+  2 : "two"
+  _ : "other"
+
+print(label)
+
+# OR-pattern: 1 | 2 | 3 などをまとめて分岐
+fn bucket(n: int) -> str:
+  return case n:
+    1 | 2 | 3 : "small"
+    4 | 5 | 6 : "medium"
+    _ : "large"
+
+print(bucket(3))
+print(bucket(5))
+
+# ガード付き分岐 — 評価順に一致する最初のアームが採用される
+score = 85
+grade = case score:
+  n if n >= 90 : "A"
+  n if n >= 80 : "B"
+  n if n >= 70 : "C"
+  _ : "F"
+
+print(grade)
+
+# 文字列リテラルにマッチ
+s = "hello"
+kind = case s:
+  "hello" : "greeting"
+  "bye" : "farewell"
+  _ : "unknown"
+
+print(kind)
+
+# 負の整数リテラルもマッチ可能
+y = -1
+sign = case y:
+  -1 : "minus one"
+  0 : "zero"
+  _ : "other"
+
+print(sign)

--- a/examples/closure_stateful.ry
+++ b/examples/closure_stateful.ry
@@ -1,0 +1,31 @@
+# パラメータをキャプチャするclosure、関数合成、カリー化を示す
+# 兄弟スコープと相互再帰は examples/nested_functions.ry を参照
+
+# 2つのパラメータをキャプチャするclosure: a*x + b
+fn makeLinear(a: int, b: int) -> fn(int) -> int:
+  return (x: int) => a * x + b
+
+threeXPlusTen = makeLinear(3, 10)
+print(threeXPlusTen(5))
+
+# 関数合成: 2つの fn(int) -> int を1つの新しいclosureに
+fn compose(f: fn(int) -> int, g: fn(int) -> int) -> fn(int) -> int:
+  return (x: int) => f(g(x))
+
+double = (x: int) => x * 2
+inc = (x: int) => x + 1
+doubleThenInc = compose(inc, double)
+print(doubleThenInc(5))
+
+# closureを返すclosureを返す: 各レベルでパラメータをcaptureする
+fn outer(a: int) -> fn(int) -> fn(int) -> int:
+  fn middle(b: int) -> fn(int) -> int:
+    fn inner(c: int) -> int:
+      return a + b + c
+    return inner
+  return middle
+
+# 1段ずつ呼び出すことで各レベルのcaptureが解決される
+f = outer(10)
+g = f(20)
+print(g(30))

--- a/examples/contracts_advanced.ry
+++ b/examples/contracts_advanced.ry
@@ -1,0 +1,43 @@
+# require複数節、ensure後置条件、record invariantの継承を示す
+# 基本的な単一節は examples/contracts.ry を参照
+
+# 複数のrequire節は全てtrueでなければならない
+fn deposit(amount: int, balance: int) -> int:
+  require:
+    amount > 0
+    balance >= 0
+  return balance + amount
+
+print(deposit(100, 50))
+
+# ensure v: は戻り値 v を参照する後置条件
+fn absVal(x: int) -> int:
+  ensure v:
+    v >= 0
+  if x < 0:
+    return -x
+  return x
+
+print(absVal(-5))
+print(absVal(3))
+
+# ensureで引数も参照できる
+fn increment(x: int) -> int:
+  ensure v:
+    v == x + 1
+  return x + 1
+
+print(increment(10))
+
+# 親recordの invariant は子recordにも継承される
+record Positive:
+  value: int
+  invariant:
+    value > 0
+
+record NamedPositive < Positive:
+  name: str
+
+np = NamedPositive(42, "good")
+print(np.value)
+print(np.name)

--- a/examples/directive_inline.ry
+++ b/examples/directive_inline.ry
@@ -1,0 +1,34 @@
+# @inlineディレクティブで関数のinlining方針を指示する
+
+# 引数なしの@inlineは既定 (always相当)
+@inline
+fn add(a: int, b: int) -> int:
+  return a + b
+
+# mode="always" は呼び出し箇所すべてでinlineする
+@inline(mode="always")
+fn mul(a: int, b: int) -> int:
+  return a * b
+
+# mode="hint" はinline候補だが最終判断はコンパイラに委ねる
+@inline(mode="hint")
+fn sub(a: int, b: int) -> int:
+  return a - b
+
+# mode="never" はinlineしないことを明示する
+@inline(mode="never")
+fn negate(a: int) -> int:
+  return -a
+
+# 再帰関数にも適用できる (展開深度は実装依存)
+@inline
+fn factorial(n: int) -> int:
+  if n <= 1:
+    return 1
+  return n * factorial(n - 1)
+
+print(add(3, 4))
+print(mul(5, 6))
+print(sub(10, 3))
+print(negate(-5))
+print(factorial(5))

--- a/examples/enum_generic.ry
+++ b/examples/enum_generic.ry
@@ -1,0 +1,19 @@
+# 型パラメータを持つジェネリックenumと、そのパターンマッチを示す
+enum MyOption<T>:
+  MySome(T)
+  MyNone
+
+fn unwrapOrDefault(opt: MyOption<int>, fallback: int) -> int:
+  return case opt:
+    MyOption::MySome(v) : v
+    MyOption::MyNone : fallback
+
+a = MyOption<int>::MySome(42)
+b = MyOption<int>::MyNone
+
+print(unwrapOrDefault(a, -1))
+print(unwrapOrDefault(b, -1))
+
+# 同じバリアントで同じpayloadなら等しい
+print(MyOption<int>::MySome(42) == MyOption<int>::MySome(42))
+print(MyOption<int>::MySome(1) == MyOption<int>::MyNone)

--- a/examples/enum_simple.ry
+++ b/examples/enum_simple.ry
@@ -1,0 +1,22 @@
+# 関連データを持たないenumのバリアント、等値性、caseマッチを示す
+enum Color:
+  Red
+  Green
+  Blue
+
+# 同じバリアントは等しく、異なるバリアントは等しくない
+print(Color::Red == Color::Red)
+print(Color::Red != Color::Green)
+
+# str()はバリアント名を返す
+print(str(Color::Red))
+print(str(Color::Blue))
+
+# caseでバリアントを分岐する
+fn name(c: Color) -> str:
+  return case c:
+    Color::Red : "red"
+    Color::Green : "green"
+    Color::Blue : "blue"
+
+print(name(Color::Blue))

--- a/examples/f_strings.ry
+++ b/examples/f_strings.ry
@@ -1,0 +1,25 @@
+# f-stringによる値式の埋め込みとrecord表示を示す
+record Point:
+  x: int
+  y: int
+
+n = 42
+pi = 3.14
+flag = true
+p = Point(3, 4)
+
+# 各プリミティブを {} で埋め込み
+print(f"value: {n}")
+print(f"pi: {pi}")
+print(f"flag: {flag}")
+
+# 中括弧内に式
+a = 1
+b = 2
+print(f"{a} + {b} = {a + b}")
+
+# recordも自動でstr変換
+print(f"point = {p}")
+
+# エスケープではなく文字列リテラルの中括弧
+print("{braces}")

--- a/examples/filesystem_copy_move.ry
+++ b/examples/filesystem_copy_move.ry
@@ -1,0 +1,33 @@
+# filesystem の copy / move によるファイル操作を示す
+from ry.filesystem import mkdirAll, copy, move, removeAll, isFile
+from ry.io import readText, writeText
+from ry.path import join
+
+# 全工程をResult-valuedな関数にまとめ、? でフラットに書き下す
+fn demo(root: str) -> Result<Unit, Error>:
+  removeAll(root)
+  mkdirAll(root)
+  src = join(root, "source.txt")?
+  writeText(src, "original content")?
+
+  # copy は内容を複製し、元ファイルは残る
+  copyDst = join(root, "copy.txt")?
+  copy(src, copyDst)?
+  print(readText(copyDst)?)
+  print(isFile(src)?)
+
+  # move は元ファイルを別名に移動。元ファイルは消える
+  moveDst = join(root, "moved.txt")?
+  move(src, moveDst)?
+  print(isFile(moveDst)?)
+  print(isFile(src)?)
+  return Ok(0 as u8)
+
+root = "/tmp/ry_examples_copy_move"
+case demo(root):
+  Ok(_):
+    0
+  Err(e):
+    print(e.message)
+
+removeAll(root)

--- a/examples/filesystem_walk_glob.ry
+++ b/examples/filesystem_walk_glob.ry
@@ -1,0 +1,46 @@
+# walk による再帰的なディレクトリ走査と glob によるパターンマッチを示す
+from ry.filesystem import mkdirAll, walk, glob, removeAll
+from ry.io import writeText
+from ry.path import join
+
+# fixture: 入れ子のディレクトリと数個のファイルを準備
+fn setup(root: str) -> Result<Unit, Error>:
+  removeAll(root)
+  mkdirAll(join(root, "sub", "deep")?)
+  writeText(join(root, "a.log")?, "alpha")
+  writeText(join(root, "sub", "b.log")?, "beta")
+  writeText(join(root, "sub", "deep", "c.txt")?, "gamma")
+  return Ok(0 as u8)
+
+root = "/tmp/ry_examples_walk"
+case setup(root):
+  Ok(_):
+
+    # walk は配下のすべてのエントリ (ファイル・ディレクトリ) を Result で返す
+    case walk(root):
+      Ok(entries):
+        print(len(entries) >= 5)
+      Err(e):
+        print(e.message)
+
+    # glob は1ディレクトリ内でパターンに合うpathをListで返す
+    case join(root, "*.log"):
+      Ok(pattern):
+        case glob(pattern):
+          Ok(matches):
+            print(len(matches))
+          Err(e):
+            print(e.message)
+      Err(e):
+        print(e.message)
+
+    # 該当なしなら空List
+    case glob("/tmp/ry_examples_no_match_*.zzz"):
+      Ok(matches):
+        print(len(matches))
+      Err(e):
+        print(e.message)
+  Err(e):
+    print(e.message)
+
+removeAll(root)

--- a/examples/for_loop_patterns.ry
+++ b/examples/for_loop_patterns.ry
@@ -1,0 +1,34 @@
+# forループのさまざまな反復対象とdestructuringを示す
+# enumerate / zip による反復は examples/builtins_enumerate_zip.ry を参照
+
+# List<int> を反復
+for x in [10, 20, 30]:
+  print(x)
+
+# range(N)、range(start, end, step)、負のstep
+for i in range(5):
+  print(i)
+
+for i in range(0, 10, 3):
+  print(i)
+
+for i in range(10, 0, -3):
+  print(i)
+
+# `1..3` 範囲シンタックス (両端含む)
+for i in 1..3:
+  print(i)
+
+# Mapを key, value のペアで反復
+scores = {"alice": 90, "bob": 80}
+for k, v in scores:
+  print(k, v)
+
+# tupleのListをそのままdestructureできる
+triples = [(1, 2, 3), (4, 5, 6)]
+for a, b, c in triples:
+  print(a, b, c)
+
+# 不要要素は `_` で受ける
+for a, _, c in triples:
+  print(a + c)

--- a/examples/generic_collections.ry
+++ b/examples/generic_collections.ry
@@ -1,0 +1,25 @@
+# List/Map/Setを引数に取るジェネリック関数と、型推論および明示型引数を示す
+# 単一型引数の基本形は examples/generic_functions.ry を参照
+fn lastOf<T>(items: List<T>) -> T:
+  return items[len(items) - 1]
+
+fn mapHas<K, V>(m: Map<K, V>, key: K) -> bool:
+  return contains(m, key)
+
+fn setSize<T>(s: Set<T>) -> int:
+  return len(s)
+
+# 型推論: 引数からTを推論する
+print(lastOf([10, 20, 30]))
+print(lastOf(["alpha", "beta"]))
+
+# 明示的に[T]を指定する形式
+print(lastOf[int]([10, 20, 30]))
+
+# 複数の型引数を持つジェネリック
+print(mapHas({"a": 1, "b": 2}, "a"))
+print(mapHas[str,int]({"a": 1, "b": 2}, "z"))
+
+# Set<T>も同様
+print(setSize({1, 2, 3}))
+print(setSize[int]({4, 5, 6, 4}))

--- a/examples/higher_order_aggregates.ry
+++ b/examples/higher_order_aggregates.ry
@@ -1,0 +1,44 @@
+# sum/min/maxとany/all、sequenceによるList<Result>の集約を示す
+
+# List全体に対する集約
+print(sum([1, 2, 3, 4, 5]))
+print(min([3, 1, 4, 1, 5]))
+print(max([3, 1, 4, 1, 5]))
+
+# floatのListも同じ関数で集約できる
+print(sum([1.0, 2.0, 3.0]))
+print(min([3.0, 1.0, 2.0]))
+
+# variadic形式: 同じ関数名でスカラーをそのまま並べる
+print(sum(1, 2, 3))
+print(min(3, 5, 1))
+print(max(3, 1, 5))
+
+# 述語ベースの判定
+print(any([1, 2, 3, 4, 5], (n: int) => n > 4))
+print(all([2, 4, 6], (n: int) => n > 0))
+print(all([2, 4, 6], (n: int) => n > 3))
+
+# sequence: List<Result<int, Error>>を1つのResult<List<int>, Error>に畳む
+fn parsePositive(n: int) -> Result<int, Error>:
+  if n > 0:
+    return Ok(n)
+  return Err(Error("non-positive: " + str(n)))
+
+allOk = [parsePositive(1), parsePositive(2), parsePositive(3)]
+print(sequence(allOk))
+
+withErr = [parsePositive(1), parsePositive(-2), parsePositive(3)]
+print(sequence(withErr))
+
+# Optionについても同じくsequenceできる
+fn maybe(n: int, isNone: bool) -> Option<int>:
+  if isNone:
+    return None
+  return Some(n)
+
+allSome = [maybe(10, false), maybe(20, false)]
+print(sequence(allSome))
+
+withNone = [maybe(10, false), maybe(0, true), maybe(30, false)]
+print(sequence(withNone))

--- a/examples/higher_order_pipeline.ry
+++ b/examples/higher_order_pipeline.ry
@@ -1,0 +1,17 @@
+# filter → map → fold/reduceの連鎖で数値Listを集約する
+# 単体のmapによるcaptureは examples/closures_higher_order.ry を参照
+values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+# 偶数だけ残し、それぞれを2乗してから合計する
+evens = filter(values, (n: int) => n % 2 == 0)
+squared = map(evens, (n: int) => n * n)
+total = fold(squared, 0, (acc: int, n: int) => acc + n)
+print(total)
+
+# reduceは初期値なしの集約。要素ゼロなら None
+print(reduce([3, 1, 4, 1, 5, 9, 2, 6], (a: int, b: int) => a + b))
+empty: List<int> = []
+print(reduce(empty, (a: int, b: int) => a + b))
+
+# 1段で書き下した形 — 中間Listを変数に置かなくてもよい
+print(fold(map(filter(values, (n: int) => n > 5), (n: int) => n * 10), 0, (acc: int, n: int) => acc + n))

--- a/examples/import_patterns.ry
+++ b/examples/import_patterns.ry
@@ -1,0 +1,23 @@
+# selective import (from ry.<module> import <name>) のcanonical形式を示す
+# preludeの暗黙利用と明示importの両方を扱う
+
+# モジュールから特定の名前だけを取り込む
+from ry.math import PI, sqrt
+from ry.base64 import encode
+
+print(sqrt(2.0))
+print(PI)
+print(encode("hi"))
+
+# 同じモジュールの別のシンボルを別行のimportで取り込んでもよい
+from ry.math import abs, round
+
+print(abs(-3))
+print(round(3.7))
+
+# prelude (ry.lang) はimport不要で利用可能。明示的にimportもできる
+from ry.lang import map, filter
+
+nums: List<int> = [1, 2, 3, 4, 5]
+print(map(nums, (n: int) => n * 10))
+print(filter(nums, (n: int) => n % 2 == 0))

--- a/examples/io_binary.ry
+++ b/examples/io_binary.ry
@@ -1,0 +1,39 @@
+# バイナリI/O — readBytes / writeBytes / toBytes / bytesToStr / appendText を示す
+from ry.io import readBytes, writeBytes, toBytes, bytesToStr, writeText, readText, appendText, deleteFile
+
+path = "/tmp/ry_examples_binary.bin"
+
+# writeBytes は List<u8> をそのままファイルへ書き出す
+bytes: List<u8> = [72u8, 105u8, 0u8, 33u8]
+case writeBytes(path, bytes):
+  Ok(_):
+    0
+  Err(e):
+    print(e.message)
+
+# readBytes は List<u8> を返す
+case readBytes(path):
+  Ok(b):
+    print(b)
+  Err(e):
+    print(e.message)
+
+# toBytes / bytesToStr で str ↔ List<u8> 変換
+encoded = toBytes("hello")
+print(encoded)
+
+decoded = bytesToStr([104u8, 105u8])
+print(decoded)
+
+# appendText は writeText (上書き) と違い既存内容の末尾に追記する
+textPath = "/tmp/ry_examples_text_append.txt"
+writeText(textPath, "first\n")
+appendText(textPath, "second\n")
+case readText(textPath):
+  Ok(content):
+    print(content)
+  Err(e):
+    print(e.message)
+
+deleteFile(path)
+deleteFile(textPath)

--- a/examples/io_file_handle.ry
+++ b/examples/io_file_handle.ry
@@ -1,0 +1,51 @@
+# open / readAll / readLine / lines によるファイルハンドルAPIを示す
+from ry.io import open, readAll, readLine, writeText, close, deleteFile, lines
+
+path = "/tmp/ry_examples_file_handle.txt"
+
+# 書き出し: writeText は path 直接呼び出しで一発書き
+case writeText(path, "alpha\nbeta\ngamma\n"):
+  Ok(_):
+    0
+  Err(e):
+    print(e.message)
+
+# 一括読み込み: open でハンドルを得て readAll
+case open(path, "r"):
+  Ok(f):
+    case readAll(f):
+      Ok(content):
+        print(content)
+      Err(e):
+        print(e.message)
+    close(f)
+  Err(e):
+    print(e.message)
+
+# 1行ずつ読む: readLine は Result<Option<str>, Error> を返す
+# EOF では Ok(None)、まだ行があれば Ok(Some(line))
+case open(path, "r"):
+  Ok(f):
+    case readLine(f):
+      Ok(opt):
+        case opt:
+          Some(line):
+            print(line)
+          None:
+            print("EOF")
+      Err(e):
+        print(e.message)
+    close(f)
+  Err(e):
+    print(e.message)
+
+# lines() は行のイテレータを返し、for ... in でそのまま回せる
+case open(path, "r"):
+  Ok(f):
+    for line in lines(f):
+      print(line)
+    close(f)
+  Err(e):
+    print(e.message)
+
+deleteFile(path)

--- a/examples/json5_config_load.ry
+++ b/examples/json5_config_load.ry
@@ -1,0 +1,22 @@
+# json5.loadはJSONを超える設定ファイル向け拡張を受け付ける
+from ry.json5 import load, stringify
+
+# JSON5は次のように strict JSON が拒否する入力を受け付ける:
+# - // と /* */ コメント
+# - unquoted な keyや単一引用符
+# - 末尾カンマ、16進整数、リーディング小数点
+src = "{\n  // tool config\n  name: 'ry',\n  port: 0xFF,\n  ratio: .5,\n}"
+
+case load[Map<str,any>](src):
+  Ok(config):
+    print(stringify(config, sortKeys=true))
+  Err(e):
+    print(e.message)
+
+# strict JSONに変換しても元の意味は保たれる (round trip)
+src2 = "{ a: 1, b: [1, 2, 3,], }"
+case load[Map<str,any>](src2):
+  Ok(v):
+    print(stringify(v, sortKeys=true))
+  Err(e):
+    print(e.message)

--- a/examples/json5_special_floats.ry
+++ b/examples/json5_special_floats.ry
@@ -1,0 +1,39 @@
+# json5は strict JSON が拒否する Infinity / NaN を読み書きできる
+from ry.json5 import load, stringify, stringifySafe
+from ry.math import INF, NAN, isInf, isNan
+
+# strict JSONがErrを返す特殊な float も json5 は受け付ける
+case load[float]("Infinity"):
+  Ok(v):
+    print(isInf(v))
+  Err(e):
+    print(e.message)
+
+case load[float]("-Infinity"):
+  Ok(v):
+    print(v < 0.0)
+  Err(e):
+    print(e.message)
+
+case load[float]("NaN"):
+  Ok(v):
+    print(isNan(v))
+  Err(e):
+    print(e.message)
+
+# stringify はそのまま "Infinity" / "-Infinity" / "NaN" を出力する
+posInf: any = INF
+print(stringify(posInf))
+
+negInf: any = -INF
+print(stringify(negInf))
+
+nan: any = NAN
+print(stringify(nan))
+
+# stringifySafe も非有限値を許容する (strict json との違い)
+case stringifySafe(posInf):
+  Ok(s):
+    print(s)
+  Err(e):
+    print(e.message)

--- a/examples/lambda_styles.ry
+++ b/examples/lambda_styles.ry
@@ -1,0 +1,29 @@
+# =>形式とブロック本体形式の2つのlambdaスタイル、fn型注釈を示す
+
+# =>形式: 1式のlambda
+double = (x: int) => x * 2
+print(double(7))
+
+# ブロック本体形式: 複数の式や文を含められる
+classify = (x: int) -> str:
+  if x < 0:
+    return "negative"
+  if x == 0:
+    return "zero"
+  return "positive"
+print(classify(-3))
+print(classify(0))
+print(classify(5))
+
+# fn型を関数の引数にする
+fn apply(f: fn(int) -> int, value: int) -> int:
+  return f(value)
+
+print(apply(double, 10))
+print(apply((x: int) => x + 100, 5))
+
+# fn() -> int の0引数版もそのまま渡せる
+fn invoke(f: fn() -> int) -> int:
+  return f()
+
+print(invoke(() => 42))

--- a/examples/list_mutation.ry
+++ b/examples/list_mutation.ry
@@ -1,0 +1,38 @@
+# Listの挿入・削除・取得系の操作を示す
+xs = [1, 2, 3]
+
+# insert(list, index, value) で指定位置に挿入
+insert(xs, 1, 99)
+print(xs)
+
+# removeAt(list, index) でindex位置の要素を取り除いて返す
+v = removeAt(xs, 1)
+print(v)
+print(xs)
+
+# pop はOption<T>を返す。空Listに対してNone
+stack = [10, 20, 30]
+print(pop(stack))
+print(stack)
+
+empty: List<int> = []
+print(pop(empty))
+
+# first / last はOptionで安全に取得
+print(first([100, 200, 300]))
+print(last([100, 200, 300]))
+print(first(empty))
+
+# isEmpty で空判定
+print(isEmpty(empty))
+print(isEmpty([0]))
+
+# tap は元のListを返しつつ、副作用関数を要素に適用
+nums = [1, 2, 3]
+echoed = tap(nums, (x: int) => x * 10)
+print(echoed)
+
+# reverse! はin-placeで反転
+ys = [1, 2, 3]
+reverse!(ys)
+print(ys)

--- a/examples/list_sorting.ry
+++ b/examples/list_sorting.ry
@@ -1,0 +1,26 @@
+# Listの並び替え、スライス、distinct、flatを示す
+xs = [5, 3, 1, 4, 2]
+
+# 既定の昇順ソート (非破壊的にコピーを返す)
+print(sort(xs))
+
+# カスタム比較関数で降順
+print(sort(xs, (a: int, b: int) => a > b))
+
+# in-place版のsort!は元のListを書き換える
+mutable = [3, 1, 2]
+sort!(mutable)
+print(mutable)
+
+# slice(start, end) で部分List
+print(slice([10, 20, 30, 40, 50], 1, 4))
+
+# take(n) で先頭から最大n個
+print(take([1, 2, 3, 4, 5], 3))
+print(take([1, 2, 3], 10))
+
+# distinct で重複を除去 (順序は最初の出現順を保つ)
+print(distinct([1, 2, 3, 2, 1, 4]))
+
+# flat で1段の入れ子を平らに
+print(flat([[1, 2], [3, 4], [5]]))

--- a/examples/map_keys_values.ry
+++ b/examples/map_keys_values.ry
@@ -1,0 +1,23 @@
+# Mapのkeys/values/hasKey/merge/removeを示す
+scores = {"alice": 90, "bob": 80, "carol": 75}
+
+# keysはkey一覧、valuesはvalue一覧をListで返す
+print(keys(scores))
+print(values(scores))
+
+# hasKey で存在判定
+print(hasKey(scores, "alice"))
+print(hasKey(scores, "dave"))
+
+# merge: 第2Mapで第1Mapの同keyを上書きしながら統合
+defaults = {"alice": 0, "dave": 50}
+updated = merge(defaults, scores)
+print(updated)
+
+# remove はin-placeでkeyを削除
+remove(scores, "bob")
+print(scores)
+
+# 存在しないkeyのremoveは何もしない
+remove(scores, "nonexistent")
+print(len(scores))

--- a/examples/map_path_access.ry
+++ b/examples/map_path_access.ry
@@ -1,0 +1,29 @@
+# getPath/setPathでネストしたMap<str, any>をjq風のドットパスで操作する
+# json.load[Map<str, any>] で取得したJSONデータの操作に有用
+
+# 入れ子のMap<str, any>を準備
+inner: Map<str, any> = {"host": "localhost", "port": 8080}
+config: Map<str, any> = {"server": inner, "debug": true}
+
+# getPathはdot区切りで深い値をたどり、Option<any>を返す
+# any値を具体型に絞り込むには asType[T] でチェック付きcastする
+case getPath(config, "server.host"):
+  Some(v):
+    case asType[str](v):
+      Ok(host):
+        print(host)
+      Err(e):
+        print(e.message)
+  None:
+    print("missing")
+
+# 中間/leaf keyが欠けていれば None。Option<any>のままで判定可能
+print(getPath(config, "missing.host"))
+print(getPath(config, "server.unknown"))
+
+# setPathで既存leafを更新、または新しいleaf keyを追加 (any値に自動昇格)
+setPath(config, "server.port", 9090)
+setPath(config, "server.tls", true)
+
+print(getPath(config, "server.port"))
+print(getPath(config, "server.tls"))

--- a/examples/math_advanced.ry
+++ b/examples/math_advanced.ry
@@ -1,0 +1,30 @@
+# mathモジュールの三角関数、log/exp/pow、特殊値判定を示す
+from ry.math import PI, E, INF, NAN, sin, cos, tan, atan2, hypot, log, log2, log10, exp, pow, isNan, isInf
+
+# 三角関数 — 引数はラジアン
+print(sin(0.0))
+print(cos(0.0))
+print(tan(0.0))
+
+# 2次元の角度と斜辺
+print(atan2(0.0, 1.0))
+print(hypot(3.0, 4.0))
+
+# 自然対数、底2対数、底10対数
+print(log(1.0))
+print(log2(8.0))
+print(log10(100.0))
+
+# 任意の底を取る log
+print(log(81.0, 3.0))
+
+# 指数関数 e^x、整数版 pow
+print(exp(0.0))
+print(pow(2, 10))
+print(pow(-2, 3))
+
+# 特殊値判定: NAN は自身とも等しくない
+print(isNan(NAN))
+print(NAN == NAN)
+print(isInf(INF))
+print(isNan(log(-1.0)))

--- a/examples/math_digits.ry
+++ b/examples/math_digits.ry
@@ -1,0 +1,17 @@
+# digitsで整数を桁のList<int>に分解する (リトルエンディアン順)
+from ry.math import digits
+
+# 10進: 1234 -> [4, 3, 2, 1] (最下位桁が先頭)
+d = digits(1234)
+print(d)
+print(sum(d))
+print(digits(0))
+print(digits(1))
+
+# 2進数: 8 -> [0, 0, 0, 1]
+print(digits(8, 2))
+print(digits(13, 2))
+
+# 16進数: 255 -> [15, 15]
+print(digits(255, 16))
+print(digits(4095, 16))

--- a/examples/option_default.ry
+++ b/examples/option_default.ry
@@ -1,0 +1,22 @@
+# ??演算子でOptionから値またはデフォルト値を取り出す
+
+# Mapのindexは存在しないキーに対しNoneを返す。?でOptionに、?? でデフォルト値に
+prices: Map<str, int> = {"apple": 100, "banana": 80}
+print(prices["apple"]? ?? -1)
+print(prices["pear"]? ?? -1)
+
+# Listのindexも同様。負のindexは末尾からの参照に
+nums = [10, 20, 30]
+print(nums[1]? ?? 0)
+print(nums[100]? ?? 0)
+print(nums[-1]? ?? 0)
+
+# Optionを返す関数の戻り値にもそのまま使える
+fn firstPositive(values: List<int>) -> Option<int>:
+  for n in values:
+    if n > 0:
+      return Some(n)
+  return None
+
+print(firstPositive([-1, -2, 3, 4]) ?? -999)
+print(firstPositive([-1, -2]) ?? -999)

--- a/examples/option_map_chain.ry
+++ b/examples/option_map_chain.ry
@@ -1,0 +1,22 @@
+# Option上のmapで値を変換し、Noneは自動で伝播することを示す
+# `?` による短絡形式は examples/option_safe_access.ry を参照
+
+# SomeにmapするとSomeのまま値が変換される
+some: int? = Some(42)
+doubled = map(some, (x: int) => x * 2)
+print(doubled)
+
+# Noneにmapしても結果はNone (関数は呼ばれない)
+empty: int? = None
+print(map(empty, (x: int) => x * 2))
+
+# 連続するmapは前段の結果に対して順番に適用される
+chained = map(map(some, (x: int) => x + 5), (x: int) => x * 2)
+print(chained)
+
+# mapで型を変えられる: int? を bool? に
+predicate = map(some, (x: int) => x > 40)
+print(predicate)
+
+# Noneは長いチェーンでも保持される
+print(map(map(empty, (x: int) => x + 5), (x: int) => x * 2))

--- a/examples/path_resolve.ry
+++ b/examples/path_resolve.ry
@@ -1,0 +1,22 @@
+# path モジュールの resolve と isAbsolute を示す
+# 結合や basename/dirname/ext は examples/path_components.ry を参照
+from ry.path import resolve, isAbsolute
+
+# isAbsolute は path が絶対pathかどうかを判定する
+print(isAbsolute("/tmp"))
+print(isAbsolute("tmp/file"))
+print(isAbsolute(""))
+
+# resolve は path を絶対pathに解決する (実体が存在する場合)
+case resolve("/tmp"):
+  Ok(absolute):
+    print(isAbsolute(absolute))
+  Err(e):
+    print(e.message)
+
+# 存在しないpathはErrを返す
+case resolve("/nonexistent_path_xyz_12345_ry_example"):
+  Ok(_):
+    print("unexpected ok")
+  Err(e):
+    print(e.message)

--- a/examples/record_optional_fields.ry
+++ b/examples/record_optional_fields.ry
@@ -1,0 +1,28 @@
+# recordのフィールド型としてOptionを使い、欠損値を表現する
+record UserWithAvatar:
+  name: str
+  avatar: Option<str>
+
+record MixOptInt:
+  id: int
+  opt: Option<str>
+
+# Some(...) で値あり、None() または none で値なし
+withFace = UserWithAvatar("bob", Some("face.png"))
+withoutFace = UserWithAvatar("alice", None())
+shorthand = UserWithAvatar("carol", none)
+
+# caseで値の有無に応じて分岐
+fn describeAvatar(u: UserWithAvatar) -> str:
+  return case u.avatar:
+    Some(path) : u.name + " -> " + path
+    None : u.name + " (no avatar)"
+
+print(describeAvatar(withFace))
+print(describeAvatar(withoutFace))
+print(describeAvatar(shorthand))
+
+# 非先頭位置のフィールドにもOptionが使える
+m = MixOptInt(42, None())
+print(m.id)
+print(m.opt)

--- a/examples/regex_advanced.ry
+++ b/examples/regex_advanced.ry
@@ -1,0 +1,24 @@
+# 正規表現の (?i) ケースフラグ、\b 単語境界、{n,m} 量指定子、lazy修飾子を示す
+
+# (?i) でパターン全体を大文字小文字を区別しない判定にする
+print(regexMatch("HELLO", "(?i)hello"))
+print(regexMatch("HELLO", "hello"))
+
+# \b は単語境界。単語の途中ではマッチしない
+print(regexMatch("hello world", "\\bworld\\b"))
+print(regexMatch("helloworld", "\\bworld\\b"))
+
+# (?i) と \b を組み合わせると単語境界つきの大小無視マッチ
+print(regexFindAll("Hello HELLO hello", "(?i)\\bhello\\b"))
+
+# {n} は厳密にn回、{n,m} はn〜m回、{n,} はn回以上の繰り返し
+print(regexMatch("aaa", "a{3}"))
+print(regexMatch("aa", "a{3}"))
+print(regexMatch("aaa", "a{2,4}"))
+print(regexMatch("aaaaa", "a{2,4}"))
+print(regexMatch("aa", "a{2,}"))
+print(regexMatch("a", "a{2,}"))
+
+# lazy修飾子 *? / +? は最短マッチ
+print(regexReplace("\"a\" and \"b\"", "\".*?\"", "X"))
+print(regexReplace("aaa", "a+?", "X"))

--- a/examples/regex_string_api.ry
+++ b/examples/regex_string_api.ry
@@ -1,0 +1,15 @@
+# 正規表現を文字列パターンとして渡すregex* 系の関数を示す
+# Regexリテラル `/.../` は examples/regex_literals.ry を参照
+
+# regexMatchはパターンが部分マッチするかを返す
+print(regexMatch("hello", "[a-z]+"))
+print(regexMatch("HELLO", "[a-z]+"))
+
+# regexReplaceはマッチした全箇所を置換する
+print(regexReplace("abc123def456", "[0-9]+", "X"))
+
+# regexSplitはパターンで分割する
+print(regexSplit("a1b2c3", "[0-9]"))
+
+# regexFindAllはマッチした全部分文字列をListで返す
+print(regexFindAll("a1b2c3", "[0-9]"))

--- a/examples/result_chain.ry
+++ b/examples/result_chain.ry
@@ -1,0 +1,20 @@
+# ResultをandThenとmapで連結し、Errで短絡することを示す
+# `?` による短絡形式は examples/result_propagation.ry を参照
+fn safeDivide(a: int, b: int) -> Result<int, Error>:
+  if b == 0:
+    return Err(Error("division by zero"))
+  return Ok(a // b)
+
+# andThenはOkなら次の呼び出しに進み、Errならそのまま伝播する
+print(andThen(safeDivide(100, 2), (v: int) => safeDivide(v, 5)))
+print(andThen(safeDivide(10, 0), (v: int) => safeDivide(v, 1)))
+
+# 複数のandThenを連結できる
+print(andThen(andThen(safeDivide(100, 2), (v: int) => safeDivide(v, 5)), (v: int) => safeDivide(v, 2)))
+
+# mapは中身を変換するだけでErrは保持される
+print(map(safeDivide(10, 2), (v: int) => v * 10))
+print(map(safeDivide(10, 0), (v: int) => v * 10))
+
+# andThen → map の混在チェーンも自然に書ける
+print(map(andThen(safeDivide(100, 10), (v: int) => safeDivide(v, 2)), (v: int) => v + 100))

--- a/examples/set_predicates.ry
+++ b/examples/set_predicates.ry
@@ -1,0 +1,25 @@
+# Setの対称差、部分集合判定、in-placeの追加と削除を示す
+a = {1, 2, 3}
+b = {2, 3, 4}
+
+# symmetricDifferenceは両側の片方だけにある要素
+print(symmetricDifference(a, b))
+
+# isSubset / isSuperset で集合関係を判定
+small = {1, 2}
+big = {1, 2, 3}
+print(isSubset(small, big))
+print(isSubset(big, small))
+print(isSuperset(big, small))
+
+# add でin-placeで要素追加。既存要素の追加はno-op
+s = {1, 2, 3}
+add(s, 4)
+add(s, 1)
+print(s)
+print(len(s))
+
+# remove でin-placeで要素削除。存在しない要素のremoveはno-op
+remove(s, 2)
+remove(s, 999)
+print(s)

--- a/examples/string_escapes.ry
+++ b/examples/string_escapes.ry
@@ -1,0 +1,24 @@
+# 文字列リテラルでの主要なエスケープシーケンスを示す
+# 表示文字数 (Unicode code point数) は examples/string_unicode.ry を参照
+
+# 改行・タブ・バックスラッシュ・引用符
+print("line1\nline2")
+print("col1\tcol2")
+print("path: C:\\Users\\name")
+print("quote: \"hello\"")
+
+# Unicode文字はそのままUTF-8でリテラルに書ける
+print("あいう")
+print("こんにちは")
+
+# raw NUL は文字列内に保持され、Ry の str は byte-safe
+withNul = "a\0b"
+print(byteLen(withNul))
+
+# blockstring (3連引用符) はエスケープ不要で複数行を保持
+multi = """
+  line A
+  line B
+  """
+
+print(multi)

--- a/examples/string_manipulation.ry
+++ b/examples/string_manipulation.ry
@@ -1,0 +1,24 @@
+# 文字列のcase変換、trim、split/join、replace、prefix/suffix判定を示す
+text = "  Hello, Ry World  "
+
+# 前後の空白を除去 / 一方の端のみtrim
+print(trim(text))
+print(trimStart(text))
+print(trimEnd(text))
+
+# 大小変換
+print(toUpper("hello"))
+print(toLower("HELLO"))
+
+# 部分文字列の置換 (target → replacement)
+print(replace("aaabbb", "a", "X"))
+
+# 区切り文字でsplit、結合はjoin
+parts = split("one,two,three", ",")
+print(parts)
+print(join(parts, " | "))
+
+# 接頭辞・接尾辞判定 (ignoreCase付きversion)
+print(startsWith("hello world", "hello"))
+print(endsWith("hello world", "world"))
+print(startsWith("Hello", "hello", true))

--- a/examples/string_search_format.ry
+++ b/examples/string_search_format.ry
@@ -1,0 +1,21 @@
+# 文字列の検索、文字単位アクセス、出現回数、繰り返し、反転、部分抽出を示す
+text = "the quick brown fox"
+
+# find: 部分文字列の最初の位置をOption<int>で返す
+print(find(text, "quick"))
+print(find(text, "missing"))
+
+# charAt は指定位置の1文字をstrで返す (Unicode code point単位)
+print(charAt("abc", 1))
+print(charAt("日本語", 1))
+
+# count: 出現回数 (ignoreCase付きversion)
+print(count("banana", "a"))
+print(count("Banana", "a", true))
+
+# repeat と reverse
+print(repeat("ab", 4))
+print(reverse("hello"))
+
+# substr(start, end) で部分文字列 (Unicode code point単位)
+print(substr("greeting", 0, 5))

--- a/examples/thread_mutex.ry
+++ b/examples/thread_mutex.ry
@@ -1,0 +1,41 @@
+# Lock (mutex) と RWLock による排他制御を示す
+from ry.thread import threadSpawn, threadJoin, lockNew, lockAcquire, lockRelease, rwlockNew, rwlockReadLock, rwlockWriteLock, rwlockUnlock, atomicIntNew, atomicIntLoad, atomicIntAdd
+
+# Mutex: 1つのthreadだけがcritical sectionに入れる
+lock = lockNew()
+counter = atomicIntNew(0)
+
+t1 = threadSpawn(():
+  for i in range(5):
+    lockAcquire(lock)
+    atomicIntAdd(counter, 1)
+    lockRelease(lock)
+)
+t2 = threadSpawn(():
+  for i in range(5):
+    lockAcquire(lock)
+    atomicIntAdd(counter, 1)
+    lockRelease(lock)
+)
+
+threadJoin(t1)
+threadJoin(t2)
+print(atomicIntLoad(counter))
+
+# RWLock: 複数reader同時、writerは排他
+rw = rwlockNew()
+readCount = atomicIntNew(0)
+
+r1 = threadSpawn(():
+  rwlockReadLock(rw)
+  atomicIntAdd(readCount, 1)
+  rwlockUnlock(rw)
+)
+r2 = threadSpawn(():
+  rwlockReadLock(rw)
+  atomicIntAdd(readCount, 1)
+  rwlockUnlock(rw)
+)
+threadJoin(r1)
+threadJoin(r2)
+print(atomicIntLoad(readCount))

--- a/examples/thread_semaphore_barrier.ry
+++ b/examples/thread_semaphore_barrier.ry
@@ -1,0 +1,46 @@
+# Semaphoreで同時実行数を制限、Barrierでthreadを同期させる
+from ry.thread import threadSpawn, threadJoin, semaphoreNew, semaphoreAcquire, semaphoreRelease, barrierNew, barrierWait, atomicIntNew, atomicIntLoad, atomicIntAdd
+
+# Semaphore(N): 同時にN個のthreadだけがcritical sectionへ入れる
+# ここではN=2で、2つの thread が permit を取得して進める
+case semaphoreNew(2):
+  Ok(sem):
+    counter = atomicIntNew(0)
+
+    t1 = threadSpawn(():
+      semaphoreAcquire(sem)
+      atomicIntAdd(counter, 1)
+      semaphoreRelease(sem)
+    )
+    t2 = threadSpawn(():
+      semaphoreAcquire(sem)
+      atomicIntAdd(counter, 1)
+      semaphoreRelease(sem)
+    )
+
+    threadJoin(t1)
+    threadJoin(t2)
+    print(atomicIntLoad(counter))
+  Err(e):
+    print(e.message)
+
+# Barrier(N): N個の thread が barrierWait に到達するまで全員待つ
+# 厳密にN個のthreadを起動・joinしなければdeadlockする
+case barrierNew(2):
+  Ok(barrier):
+    reached = atomicIntNew(0)
+
+    b1 = threadSpawn(():
+      atomicIntAdd(reached, 1)
+      barrierWait(barrier)
+    )
+    b2 = threadSpawn(():
+      atomicIntAdd(reached, 1)
+      barrierWait(barrier)
+    )
+
+    threadJoin(b1)
+    threadJoin(b2)
+    print(atomicIntLoad(reached))
+  Err(e):
+    print(e.message)

--- a/examples/thread_spawn_join.ry
+++ b/examples/thread_spawn_join.ry
@@ -1,0 +1,18 @@
+# threadSpawn/threadJoinとAtomicIntによる並列処理を示す
+from ry.thread import threadSpawn, threadJoin, atomicIntNew, atomicIntLoad, atomicIntAdd
+
+# 並列処理の本体は内側のlambdaにできる
+# AtomicIntへの加算はrace-freeなので、joinを取れば合計値は決定的
+fn runParallelSum() -> int:
+  counter = atomicIntNew(0)
+  t1 = threadSpawn(():
+    atomicIntAdd(counter, 10)
+  )
+  t2 = threadSpawn(():
+    atomicIntAdd(counter, 20)
+  )
+  threadJoin(t1)
+  threadJoin(t2)
+  return atomicIntLoad(counter)
+
+print(runParallelSum())

--- a/examples/top_level_bindings.ry
+++ b/examples/top_level_bindings.ry
@@ -1,0 +1,49 @@
+# モジュールレベル@constと、それを関数から参照する例 (issue #817)
+@const
+PI: float = 3.14
+
+@const
+MAX_RETRIES: int = 5
+
+@const
+GREETING: str = "hello"
+
+@const
+PRIMES: List<int> = [2, 3, 5, 7, 11]
+
+@const
+SCORES: Map<str, int> = {"alice": 90, "bob": 80}
+
+record Point:
+  x: int
+  y: int
+
+@const
+ORIGIN: Point = Point(0, 0)
+
+# 関数からはこれらの定数を直接参照できる
+fn circleArea(radius: float) -> float:
+  return PI * radius * radius
+
+fn isValidRetry(attempt: int) -> bool:
+  return attempt > 0 and attempt <= MAX_RETRIES
+
+fn greetName(name: str) -> str:
+  return GREETING + ", " + name
+
+fn primeCount() -> int:
+  return len(PRIMES)
+
+fn aliceScore() -> int:
+  return SCORES["alice"]
+
+fn distanceFromOrigin(p: Point) -> int:
+  return p.x - ORIGIN.x + (p.y - ORIGIN.y)
+
+print(circleArea(2.0))
+print(isValidRetry(3))
+print(isValidRetry(10))
+print(greetName("Ry"))
+print(primeCount())
+print(aliceScore())
+print(distanceFromOrigin(Point(3, 4)))

--- a/examples/type_aliases.ry
+++ b/examples/type_aliases.ry
@@ -1,0 +1,41 @@
+# type aliasで型に意味のある名前を与え、union aliasや入れ子aliasも示す
+
+# 基本: プリミティブのエイリアス
+type Meters = float
+
+distance: Meters = 3.14
+print(distance)
+
+# 2つのプリミティブのunion alias
+type Pair = int | str
+
+a: Pair = 42
+b: Pair = "hello"
+print(str(a))
+print(str(b))
+
+# 入れ子aliasは平坦化される
+type Inner = int | str
+
+type Outer = Inner | bool
+
+v1: Outer = 7
+v2: Outer = "ok"
+v3: Outer = true
+print(str(v1), str(v2), str(v3))
+
+# union aliasを関数の引数と戻り値で使う
+type Tagged = int | str
+
+fn show(v: Tagged) -> str:
+  return str(v)
+
+fn choose(b: bool) -> Tagged:
+  if b:
+    return 42
+  return "zero"
+
+print(show(7))
+print(show("abc"))
+print(show(choose(true)))
+print(show(choose(false)))

--- a/examples/type_cast_as.ry
+++ b/examples/type_cast_as.ry
@@ -1,0 +1,23 @@
+# asキーワードによる明示的な型変換 (int/float/bool/str/u8)
+# call形式の変換 (int("42")など) は examples/type_conversions.ry を参照
+
+# 数値同士
+print(42 as float)
+print(3.14 as int)
+print(-3.7 as int)
+print(-0.5 as int)
+
+# bool との往復
+print(1 as bool)
+print(0 as bool)
+print(true as int)
+print(false as int)
+
+# str への変換
+print(42 as str)
+
+# u8 との往復
+b: u8 = 200u8
+print(b as int)
+roundTrip: u8 = 255 as u8
+print(roundTrip as int)

--- a/examples/type_conversions.ry
+++ b/examples/type_conversions.ry
@@ -1,0 +1,26 @@
+# int(str)/float(str)/str(v) のcall形式の変換と ?? 既定値を示す
+# `as` キーワードによるキャストは examples/type_cast_as.ry を参照
+
+# 文字列をパース: 成功はOk、失敗はErr
+case int("42"):
+  Ok(v):
+    print(v)
+  Err(e):
+    print(e.message)
+
+case float("3.14"):
+  Ok(v):
+    print(v)
+  Err(e):
+    print(e.message)
+
+# ?? でデフォルト値にフォールバック
+print(int("abc") ?? -1)
+
+# 値の文字列表示 (int/float/boolなどに対応)
+print(str(42))
+print(str(true))
+
+# 第1級関数として扱える: List<str>に対してintを map で適用
+texts: List<str> = ["1", "2", "3"]
+print(map(texts, int))

--- a/examples/union_types.ry
+++ b/examples/union_types.ry
@@ -1,0 +1,27 @@
+# 匿名union型を関数の引数と戻り値で扱い、str()でディスパッチする
+# numeric_type_constraints.ryが型注釈側を扱うのに対し、本例はディスパッチを示す
+fn show(x: int | str) -> str:
+  return str(x)
+
+fn showWithFloat(x: int | float) -> str:
+  return str(x)
+
+fn pickByFlag(b: bool) -> int | str:
+  if b:
+    return 42
+  return "zero"
+
+print(show(42))
+print(show("hello"))
+print(showWithFloat(100))
+print(showWithFloat(2.5))
+
+# 戻り値もunion型として扱える
+print(show(pickByFlag(true)))
+print(show(pickByFlag(false)))
+
+# CollectionをunionのバリアントにできるためListやMapも保持できる
+listOrInt: int | List<int> = [1, 2, 3]
+mapOrStr: str | Map<str, int> = {"a": 1}
+print(str(listOrInt))
+print(str(mapOrStr))

--- a/examples/using_resource.ry
+++ b/examples/using_resource.ry
@@ -1,0 +1,57 @@
+# using ブロックでファイルハンドル等のリソースを確実に解放する
+from ry.io import open, writeText, readAll, close, deleteFile
+
+path = "/tmp/ry_examples_using.txt"
+
+# using f = open(...)?: の形でハンドルをbind、blockを抜けるとcloseが自動実行
+fn writeViaUsing(p: str, content: str) -> Result<Unit, Error>:
+  using f = open(p, "w")?:
+    case writeText(f, content):
+      Ok(_):
+        0
+      Err(e):
+        return Err(e)
+  return Ok(0 as u8)
+
+case writeViaUsing(path, "hello via using\n"):
+  Ok(_):
+    print("written")
+  Err(e):
+    print(e.message)
+
+# usingブロックの内側で ? による早期 return も close を確実に呼ぶ
+fn readViaUsing(p: str) -> Result<str, Error>:
+  using f = open(p, "r")?:
+    case readAll(f):
+      Ok(s):
+        return Ok(s)
+      Err(e):
+        return Err(e)
+  return Err(Error("unreachable"))
+
+case readViaUsing(path):
+  Ok(s):
+    print(s)
+  Err(e):
+    print(e.message)
+
+# nestedな using は内側から外側の順で close される
+# 内側のwriteText(...)? は失敗時に自動でErrを伝播しつつ外側のusingも閉じる
+fn writeTwo(a: str, b: str) -> Result<Unit, Error>:
+  using fa = open(a, "w")?:
+    using fb = open(b, "w")?:
+      writeText(fa, "A")?
+      writeText(fb, "B")?
+  return Ok(0 as u8)
+
+pathA = "/tmp/ry_examples_using_a.txt"
+pathB = "/tmp/ry_examples_using_b.txt"
+case writeTwo(pathA, pathB):
+  Ok(_):
+    print("both written")
+  Err(e):
+    print(e.message)
+
+deleteFile(path)
+deleteFile(pathA)
+deleteFile(pathB)


### PR DESCRIPTION
## Summary

- Adds **50 new canonical examples** under `examples/`, taking the directory from 40 to 90 files (~2,200 lines total).
- Each file is derived from an existing `tests/spec/*.test.ry` (or `share/std/<module>/*.ry` declaration) with the `ry.testing` DSL stripped, so it reads as an ordinary Ry program demonstrating one clear concept (per `docs/reference/examples-taxonomy.md`).
- Coverage spans the 8 issue-scope areas: type system & syntax (8), pattern matching & Option/Result (4), functions/closures/generics (5), collections (9), math/regex/base64 (6), json5/io/filesystem/path (8), concurrency (3), contracts/directives/modules/dynamic (7).

## Test plan

- [x] `bash scripts/check-examples.sh` — **90/90 canonical examples passed**
- [x] `build-rust/ry --strict-any run examples/<f>.ry` — exit 0 on all 50 new files
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` — clean
- [x] `/simplify` review: 4 cleanup agents (reuse / simplification / efficiency / altitude), 20 findings applied (dedup, header accuracy, `?`-propagation flattening, stub fix in `generic_collections.ry`, etc.)
- [x] `build-rust/ry fmt --check examples/` — 47 clean, 3 thread files trigger a pre-existing fmt round-trip bug (also affects `tests/spec/thread.test.ry`, see notes below)

Closes #2326

---

## Notes on known-fmt issues encountered (out of scope for this PR)

While building these examples, several `ry fmt` behaviours were observed. Calling them out for future triage:

- **fmt rewrites `import ry.math as m` → `import math as m`**, which `#2351` made a hard runtime error. Workaround in this PR: `import_patterns.ry` uses selective imports only.
- **fmt strips explicit enum integer values** (`Ok = 200` → `Ok`). The planned `enum_explicit_values.ry` was replaced with `record_optional_fields.ry`.
- **fmt cannot round-trip multi-line inline lambdas** (`threadSpawn(():\n …\n)`). Affects all 3 thread examples and `tests/spec/thread.test.ry`; `ry run` still works.
- **fmt breaks `f(...)[T]("arg")` chained calls** by inserting a newline. Workaround: assign intermediate result.
- **fmt rejects `\u{HHHH}` escape sequences**. `string_escapes.ry` uses literal Unicode characters instead.
- **fmt normalises UFCS `.method()` → prefix `method(self, ...)`**. Accepted as policy; comments adjusted accordingly.

`scripts/check-examples.sh` (the canonical gate) only runs `ry run`, so these fmt issues do not block the LoRA data pipeline. They are tracked separately as side findings.