### PR TITLE
chore(examples): add stock_ledger realistic small-program example

### DIFF
--- a/examples/stock_ledger.ry
+++ b/examples/stock_ledger.ry
@@ -1,0 +1,146 @@
+# 在庫台帳 — SKU ごとの在庫移動を List<StockMovement> で記録し Result で不正操作を拒否する
+
+enum MovementKind:
+  Receive(int)
+  Issue(int)
+  Adjust(int)
+
+record StockItem:
+  sku: str
+  name: str
+  onHand: int
+  reorderAt: int
+  invariant:
+    onHand >= 0
+
+record StockMovement:
+  sku: str
+  kind: MovementKind
+  resultOnHand: int
+
+record MovementOrder:
+  sku: str
+  kind: MovementKind
+
+fn movementLabel(k: MovementKind) -> str:
+  return case k:
+    MovementKind::Receive(n) : f"receive {n}"
+    MovementKind::Issue(n) : f"issue {n}"
+    MovementKind::Adjust(delta) : f"adjust {delta}"
+
+fn findIndex(items: List<StockItem>, sku: str) -> Option<int>:
+  for i, it in enumerate(items):
+    if it.sku == sku:
+      return Some(i)
+  return None
+
+fn requireSku(items: List<StockItem>, sku: str) -> Result<int, Error>:
+  case findIndex(items, sku):
+    Some(i):
+      return Ok(i)
+    None:
+      return Err(Error(f"unknown SKU '{sku}'"))
+
+fn applyMovement(item: StockItem, kind: MovementKind) -> Result<StockItem, Error>:
+  case kind:
+    MovementKind::Receive(n):
+      if n <= 0:
+        return Err(Error(f"receive amount {n} must be positive for {item.sku}"))
+      return Ok(StockItem(item.sku, item.name, item.onHand + n, item.reorderAt))
+    MovementKind::Issue(n):
+      if n <= 0:
+        return Err(Error(f"issue amount {n} must be positive for {item.sku}"))
+      if n > item.onHand:
+        return Err(Error(f"issue {n} exceeds onHand {item.onHand} for {item.sku}"))
+      return Ok(StockItem(item.sku, item.name, item.onHand - n, item.reorderAt))
+    MovementKind::Adjust(delta):
+      next = item.onHand + delta
+      if next < 0:
+        return Err(Error(f"adjust {delta} would make {item.sku} negative ({next})"))
+      return Ok(StockItem(item.sku, item.name, next, item.reorderAt))
+
+fn applyToLedger(items: List<StockItem>, sku: str, kind: MovementKind, journal: List<StockMovement>) -> Result<List<StockItem>, Error>:
+  i = requireSku(items, sku)?
+  updated = applyMovement(items[i], kind)?
+  next: List<StockItem> = []
+  for j, t in enumerate(items):
+    if j == i:
+      append!(next, updated)
+    else:
+      append!(next, t)
+  append!(journal, StockMovement(sku, kind, updated.onHand))
+  return Ok(next)
+
+fn runMovements(items: List<StockItem>, moves: List<MovementOrder>, journal: List<StockMovement>) -> Result<List<StockItem>, Error>:
+  current = items
+  for mv in moves:
+    case applyToLedger(current, mv.sku, mv.kind, journal):
+      Ok(updated):
+        current = updated
+      Err(e):
+        return Err(e)
+  return Ok(current)
+
+fn isLowStock(item: StockItem) -> bool:
+  return item.onHand <= item.reorderAt
+
+fn lowStockItems(items: List<StockItem>) -> List<StockItem>:
+  return filter(items, isLowStock)
+
+fn printItems(items: List<StockItem>):
+  for it in items:
+    print(f"  {it.sku} {it.name}: onHand={it.onHand} (reorderAt={it.reorderAt})")
+
+fn printLedger(journal: List<StockMovement>):
+  for e in journal:
+    print(f"  {e.sku}: {movementLabel(e.kind)} -> onHand={e.resultOnHand}")
+
+# --- demo: initial stock ---
+
+initial: List<StockItem> = [
+  StockItem("BOOK-01", "Hitchhiker's Guide", 12, 5),
+  StockItem("MUG-01", "Coffee mug", 8, 10),
+  StockItem("PEN-01", "Ballpoint pen", 50, 20),
+  StockItem("LAMP-01", "Desk lamp", 3, 5)
+]
+
+print("initial stock:")
+printItems(initial)
+
+# --- demo: successful movement sequence ---
+
+moves: List<MovementOrder> = [
+  MovementOrder("BOOK-01", MovementKind::Issue(4)),
+  MovementOrder("MUG-01", MovementKind::Receive(1)),
+  MovementOrder("PEN-01", MovementKind::Issue(15)),
+  MovementOrder("LAMP-01", MovementKind::Adjust(2))
+]
+
+journal: List<StockMovement> = []
+case runMovements(initial, moves, journal):
+  Ok(finalItems):
+    print("\njournal:")
+    printLedger(journal)
+    print("\nstock after movements:")
+    printItems(finalItems)
+    print("\nlow-stock items (onHand <= reorderAt):")
+    printItems(lowStockItems(finalItems))
+  Err(e):
+    print(f"unexpected error: {e.message}")
+
+# --- demo: error paths (each guard exercised independently) ---
+
+errCases: List<MovementOrder> = [
+  MovementOrder("BOOK-01", MovementKind::Issue(99)),
+  MovementOrder("GHOST-99", MovementKind::Receive(5)),
+  MovementOrder("LAMP-01", MovementKind::Adjust(-99))
+]
+
+print("\nerror paths:")
+errJournal: List<StockMovement> = []
+for mv in errCases:
+  case applyToLedger(initial, mv.sku, mv.kind, errJournal):
+    Ok(_):
+      print(f"  unexpected: {mv.sku} {movementLabel(mv.kind)} succeeded")
+    Err(e):
+      print(f"  rejected: {e.message}")


### PR DESCRIPTION
## Summary

- Adds `examples/stock_ledger.ry` (146 lines), the inventory-domain realistic small-program example missing after PR #2372 dropped two CI-failing files.
- Brings the canonical "realistic small-program" count from 9 to **10**, meeting the #2328 acceptance criterion `at least 10 realistic small-program examples`.
- Structurally avoids the `Map<str, V>` dynamic-insertion + iteration LLVM/default-emit SIGSEGV pattern that drove the original two drops (now tracked as #2375; restoration of temperature_aggregate as #2376).

Design mirrors `examples/todo_tasks.ry` (findIndex / immutable List rebuild) and `examples/bank_ledger_invariant.ry` (record `invariant`, pre-`Err` guard, `runAll` + journal accumulator). Three guard paths (over-issue, unknown SKU, negative Adjust) are exercised by a unified err-cases loop.

## Test plan

- [x] `./build-rust/ry run examples/stock_ledger.ry` exits 0; all 5 demo sections produce expected output (initial stock → success journal + low-stock filter → 3 err rejections).
- [x] `bash scripts/check-examples.sh` reports `50/50 canonical examples passed` (was 49/49 before this change).
- [ ] CI runs `scripts/check-examples.sh` on Linux/default-emit (relies on the new file's Map-free design to pass).

Closes #2328.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new stock ledger example that tracks inventory changes in memory.
  * Supports receiving, issuing, and adjusting stock, with invalid actions safely rejected.
  * Includes a running journal of stock movements, low-stock detection, and demo output for both successful and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->