### PR TITLE
fix(codegen): align Map<str, V> retain to StringHeader offset (#2375)

### DIFF
--- a/changelog.d/2375-map-str-dynamic-insert-arc-offset.md
+++ b/changelog.d/2375-map-str-dynamic-insert-arc-offset.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `Map<str, V>` への動的キー挿入後の retain/release が ArcHeader (-16) で行われ、StringHeader (-24) と offset が食い違う bug を修正。`for k in keys: m[k] = v` / `k = keys[i]; m[k] = v` / `m[rec.strField] = v` の三経路すべてに影響し、Linux/default-emit (release build) では JIT optimiser が固定アドレスへの UB store を残すため、3 件目あたりの挿入で `private constant` global の weak_count に書き込んで SIGSEGV していた。macOS/rust-emit では同じ UB が malloc 配置や Mach-O の rodata 扱いで偶発的に許容されていただけで、`RY_NO_OPT=1` でも観測可能。`retainArcValue` 経路を str 認識ベースで分岐させ、`for` ループ束縛・暗黙束縛・record field の三経路すべてが StringHeader (-24) へ正しく合流する。(#2375)

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -823,13 +823,20 @@ bool CodeGen::tryRetainArcSource(llvm::Value *val) {
         return true;
     // Case 3: ExtractValueInst — record/tuple field access (CreateExtractValue).
     // Guard on collection metadata so closures, weak refs, and other non-ARC
-    // ptrTy_ values are not incorrectly retained (#999).
+    // ptrTy_ values are not incorrectly retained (#999). str fields dispatch
+    // through StringHeader (-24) like Case 4 below (#2375).
     if (llvm::isa<llvm::ExtractValueInst>(val)) {
         auto *meta = getMeta(val);
-        if (meta && (meta->list_elem || meta->map_key || meta->set_elem)) {
-            auto *hdr = emitArcGetHeaderFromData(val);
-            emitArcRetain(hdr, /*atomic=*/false);
-            return true;
+        if (meta) {
+            const bool isArcContainerElem =
+                meta->list_elem || meta->map_key || meta->set_elem;
+            const bool isStrElem = meta->str_elem;
+            if (isArcContainerElem || isStrElem) {
+                auto *hdr = isStrElem ? emitStrGetHeaderFromData(val)
+                                      : emitArcGetHeaderFromData(val);
+                emitArcRetain(hdr, /*atomic=*/false);
+                return true;
+            }
         }
     }
     // Case 4: GEP-loaded container element borrowed from a long-lived

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -337,8 +337,18 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e)
             if (deprecated_fields_.count(qualifiedField))
                 emitDeprecationWarning(qualifiedField);
             llvm::Value *fieldVal = builder_.CreateExtractValue(obj, i, e->field);
-            if (info.fields[i].type)
-                propagateTypeMeta(info.fields[i].type->toString(), fieldVal);
+            if (info.fields[i].type) {
+                const std::string fieldTypeStr = info.fields[i].type->toString();
+                propagateTypeMeta(fieldTypeStr, fieldVal);
+                // Stamp str_elem so tryRetainArcSource Case 3 retains via
+                // StringHeader (-24) rather than ArcHeader (-16). Without
+                // this, `m[rec.strField] = v` corrupts weak_count on the
+                // literal/heap str (#2375). propagateTypeMeta intentionally
+                // does NOT set this for "str" — the str→str_elem mapping is
+                // an opt-in per-call-site discriminant (#1266, #1576).
+                if (fieldTypeStr == "str")
+                    getOrCreateMeta(fieldVal).str_elem = true;
+            }
             return fieldVal;
         }
     }

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -346,7 +346,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e)
                 // literal/heap str (#2375). propagateTypeMeta intentionally
                 // does NOT set this for "str" — the str→str_elem mapping is
                 // an opt-in per-call-site discriminant (#1266, #1576).
-                if (fieldTypeStr == "str")
+                // resolveTypeAlias so `type Key = str; record R { k: Key }`
+                // also stamps (CodeRabbit, PR #2386).
+                if (resolveTypeAlias(fieldTypeStr) == "str")
                     getOrCreateMeta(fieldVal).str_elem = true;
             }
             return fieldVal;

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -1080,6 +1080,14 @@ void CodeGen::emitVarDecl(const std::string &name,
         if (isRetainedArc) {
             if (arc_str_owned_values_.count(val) > 0) {
                 isRetainedArcStr = true;
+            } else if (auto *meta = getMeta(val); meta && meta->str_elem) {
+                // List<str>[i] / Map<*,str>[k] / record.strField — any val
+                // tryRetainArcSource handled via StringHeader (-24) must
+                // match in the alloca cleanup. Without this, implicit
+                // bindings like `k = keys[i]` or `k = rec.strField` enter
+                // arc_backed_vars_ and release at -16, corrupting str
+                // refcounts (#2375).
+                isRetainedArcStr = true;
             } else if (auto *ld = llvm::dyn_cast<llvm::LoadInst>(val)) {
                 auto *src = llvm::dyn_cast<llvm::AllocaInst>(ld->getPointerOperand());
                 if (src && arc_str_managed_vars_.count(src) > 0)

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -398,12 +398,14 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
     // pointer invalidation from unordered_map rehash inside propagateTypeMeta/getOrCreateMeta.
     std::string elemTypeName;
     std::optional<FnTypeInfo> elemFnTypeInfo;
+    bool listElemIsStr = false;
     if (auto *iterMeta = getMeta(iterable)) {
         if (headerTy == setHeaderTy_ && !iterMeta->set_elem_type_name.empty())
             elemTypeName = iterMeta->set_elem_type_name;
         else
             elemTypeName = iterMeta->list_elem_type_name;
         elemFnTypeInfo  = iterMeta->list_elem_fn_type_info;
+        listElemIsStr   = iterMeta->list_elem_is_str;
     }
     emitIndexedForLoop(length, s->body, [&](llvm::Value *iCur) {
         llvm::Value *dataPtr;
@@ -418,6 +420,12 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
         }
         llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {iCur}, "for_elem_ptr");
         llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "for_elem");
+        // Stamp str_elem on the loaded element so the binding can route
+        // through the StringHeader (-24) retain/release path. Mirrors the
+        // IndexExpr stamp at codegen_expr_literal.cpp:1226 used by the
+        // `k = list[i]` form (#2375).
+        if (listElemIsStr && elemTy == ptrTy_)
+            getOrCreateMeta(elem).str_elem = true;
         emitForBindingPattern(s->binding, elem, elemTy, elemTypeName);
         if (elemFnTypeInfo) {
             std::string loopVarName;
@@ -440,6 +448,22 @@ void CodeGen::emitForBindingPattern(const Pattern &pattern, llvm::Value *value,
         builder_.CreateStore(value, loopVar);
         if (!valueTypeName.empty())
             propagateTypeMeta(valueTypeName, loopVar);
+        // ARC tracking for a str loop variable. Without this, `for k in
+        // list<str>: m[k] = v` retains/releases at ArcHeader (-16) instead
+        // of StringHeader (-24), corrupting weak_count and (in optimised
+        // builds) faulting on a UB write into the literal constant in
+        // .rodata that the optimiser left dynamic (#2375). Mirrors the
+        // destructure path at codegen_stmt_misc.cpp:757-763 — the retain
+        // emitted by tryRetainArcSource Case 4 is balanced by the release
+        // popScope() will emit for arc_str_managed_vars_ at loop-body exit.
+        if (valueTy == ptrTy_) {
+            if (auto *meta = getMeta(value); meta && meta->str_elem) {
+                if (tryRetainArcSource(value)) {
+                    arc_str_managed_vars_.insert(loopVar);
+                    markArcManaged(loopVar);
+                }
+            }
+        }
         return;
     }
 

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -456,12 +456,23 @@ void CodeGen::emitForBindingPattern(const Pattern &pattern, llvm::Value *value,
         // destructure path at codegen_stmt_misc.cpp:757-763 — the retain
         // emitted by tryRetainArcSource Case 4 is balanced by the release
         // popScope() will emit for arc_str_managed_vars_ at loop-body exit.
+        // Also treat `valueTypeName == "str"` paths (Map `for k, v in m:`
+        // ExtractValue, Set<str> iteration, str-aliased element types) as
+        // str-managed even without a pre-existing str_elem stamp — the
+        // emitForListLoop site only stamps List<str> elements (CodeRabbit,
+        // PR #2386).
         if (valueTy == ptrTy_) {
-            if (auto *meta = getMeta(value); meta && meta->str_elem) {
-                if (tryRetainArcSource(value)) {
-                    arc_str_managed_vars_.insert(loopVar);
-                    markArcManaged(loopVar);
-                }
+            bool isStrElem = false;
+            if (auto *meta = getMeta(value))
+                isStrElem = meta->str_elem;
+            if (!isStrElem && !valueTypeName.empty() &&
+                resolveTypeAlias(valueTypeName) == "str") {
+                getOrCreateMeta(value).str_elem = true;
+                isStrElem = true;
+            }
+            if (isStrElem && tryRetainArcSource(value)) {
+                arc_str_managed_vars_.insert(loopVar);
+                markArcManaged(loopVar);
             }
         }
         return;

--- a/tests/spec/map_str_dynamic_insert_2375.test.ry
+++ b/tests/spec/map_str_dynamic_insert_2375.test.ry
@@ -184,3 +184,51 @@ fn mapStrDynamicInsertViaLoopVariable2375Tests():
     expect(len(m)).toEq(3)
     expect(m.contains("heap_21")).toEq(true)
     expect(m.contains("heap_23")).toEq(true)
+
+  @it("should accept str-aliased record field as Map key")
+  fn shouldAcceptStrAliasedRecordFieldAsMapKey():
+    # `type Alias = str` is sugar over str; the field's toString() returns
+    # "Alias", so codegen_expr_literal.cpp must resolve the alias before
+    # deciding whether to stamp str_elem. Without the resolveTypeAlias()
+    # call, the alias path skipped the stamp and the wrong-offset retain
+    # corrupted weak_count again (CodeRabbit, PR #2386 review).
+    type StrAlias = str
+    record AliasRec:
+      tag: StrAlias
+    items: List<AliasRec> = [AliasRec(heapKey(31)), AliasRec(heapKey(32)), AliasRec(heapKey(33))]
+    m: Map<str, int> = {}
+    for it in items:
+      m[it.tag] = 1
+    expect(len(m)).toEq(3)
+    expect(m.contains("heap_31")).toEq(true)
+    expect(m.contains("heap_33")).toEq(true)
+
+  @it("should accept Map<str, int> tuple-destructure iteration with dynamic re-insert")
+  fn shouldAcceptMapStrIntTupleDestructureIterationWithDynamicReInsert():
+    # `for k, v in m:` reaches emitForBindingPattern via TuplePattern; the
+    # recursive call binds `k` from an ExtractValueInst with
+    # valueTypeName="str" but no pre-existing str_elem stamp (since the
+    # iter elem is a tuple, not the str itself). The loop binding must
+    # still register `k` as str-managed (CodeRabbit, PR #2386 review).
+    src: Map<str, int> = {}
+    keys: List<str> = [heapKey(41), heapKey(42), heapKey(43)]
+    for k in keys:
+      src[k] = 1
+    dst: Map<str, int> = {}
+    for k, v in src:
+      dst[k] = v
+    expect(len(dst)).toEq(3)
+    expect(dst.contains("heap_41")).toEq(true)
+    expect(dst.contains("heap_43")).toEq(true)
+
+  @it("should accept Set<str> iteration variable as Map key")
+  fn shouldAcceptSetStrIterationVariableAsMapKey():
+    # Set<str> iteration: emitForListLoop fetches set_elem_type_name="str"
+    # but the elem load has no str_elem stamp (the IndexExpr stamp targets
+    # List<str>). The loop binding falls back to valueTypeName == "str"
+    # detection (CodeRabbit, PR #2386 review).
+    s: Set<str> = {heapKey(51), heapKey(52), heapKey(53)}
+    m: Map<str, int> = {}
+    for item in s:
+      m[item] = 1
+    expect(len(m)).toEq(3)

--- a/tests/spec/map_str_dynamic_insert_2375.test.ry
+++ b/tests/spec/map_str_dynamic_insert_2375.test.ry
@@ -1,0 +1,186 @@
+from ry.testing import it, describe, expect
+
+# Force makeString (heap-allocated str, NOT ARC_IMMORTAL literal). With
+# literal-only keys the offset bug is invisible to ARC balance checks —
+# the retain immortal-gate makes the wrong-offset retain a no-op either
+# way. Heap strs exercise the actual strong-count delta path that the
+# release walks in the Map destructor; under ASan a mismatched retain
+# turns into UAF when the map is read after the str's last source ref
+# drops. Asserting `contains` / index-read after dynamic insert is the
+# behavioural probe ASan needs. (#2375, .claude/rules/tests-arc-leak-pattern.md)
+fn heapKey(i: int) -> str:
+  return "heap_" + str(i)
+
+@describe("Map<str, V> dynamic key insertion via loop variable (#2375)")
+fn mapStrDynamicInsertViaLoopVariable2375Tests():
+  @it("should accept str keys from a for-in loop variable across 3+ inserts")
+  fn shouldAcceptStrKeysFromAForInLoopVariableAcross3PlusInserts():
+    # SIGSEGV without #2375 fix on Linux/default-emit. The for-loop's
+    # `k` alloca is not tagged as str-managed, so the map.store retain
+    # uses ArcHeader offset (-16) instead of StringHeader (-24). The
+    # corrupt write into a `constant` global's weak_count is folded
+    # away by the JIT optimiser for the inline-literal forms (#L,#M)
+    # but kept for the loop-loaded ptr form, faulting on .rodata.
+    m: Map<str, int> = {}
+    keys: List<str> = ["alpha", "beta", "gamma"]
+    for k in keys:
+      m[k] = 1
+    expect(len(m)).toEq(3)
+    expect(m.contains("alpha")).toEq(true)
+    expect(m.contains("beta")).toEq(true)
+    expect(m.contains("gamma")).toEq(true)
+
+  @it("should accept str keys from a while-loop binding across 3+ inserts")
+  fn shouldAcceptStrKeysFromAWhileLoopBindingAcross3PlusInserts():
+    # while-loop variant — `k = keys[i]` is a plain assignment, so it
+    # goes through codegen_stmt.cpp's AssignStmt path, not
+    # emitForBindingPattern. Both forms must reach the same fix.
+    m: Map<str, int> = {}
+    keys: List<str> = ["x", "y", "z"]
+    i: int = 0
+    while i < 3:
+      k: str = keys[i]
+      m[k] = 1
+      i = i + 1
+    expect(len(m)).toEq(3)
+    expect(m.contains("x")).toEq(true)
+    expect(m.contains("z")).toEq(true)
+
+  @it("should iterate inserted str-keyed Map without crash")
+  fn shouldIterateInsertedStrKeyedMapWithoutCrash():
+    # The original issue's surface symptom — `for k,v in m:` after
+    # dynamic insertion. Once the insert retain uses the right offset
+    # (-24), the iteration body has nothing to crash on.
+    m: Map<str, int> = {}
+    src: List<str> = ["a", "b", "c", "d"]
+    for x in src:
+      m[x] = 1
+    total: int = 0
+    for k, v in m:
+      total = total + v
+    expect(total).toEq(4)
+
+  @it("should accept str values from a for-in loop variable in Map<int, str>")
+  fn shouldAcceptStrValuesFromAForInLoopVariableInMapIntStr():
+    # Inverse: int key + str value, value coming from List<str> loop.
+    # Same retain-offset bug applies to the value path.
+    m: Map<int, str> = {}
+    vals: List<str> = ["a", "b", "c"]
+    i: int = 0
+    for v in vals:
+      m[i] = v
+      i = i + 1
+    expect(len(m)).toEq(3)
+    expect(m[0]).toEq("a")
+    expect(m[2]).toEq("c")
+
+  @it("should aggregate counts with dynamic str keys")
+  fn shouldAggregateCountsWithDynamicStrKeys():
+    # Realistic word-frequency-style aggregation: the canonical use
+    # case that motivated dropping inventory_ledger.ry /
+    # temperature_aggregate.ry. (Issue #2375 acceptance criterion 4.)
+    counts: Map<str, int> = {}
+    words: List<str> = ["apple", "banana", "apple", "cherry", "banana", "apple"]
+    for w in words:
+      prev: int = case get(counts, w):
+        Some(n): n
+        None: 0
+      counts[w] = prev + 1
+    expect(counts["apple"]).toEq(3)
+    expect(counts["banana"]).toEq(2)
+    expect(counts["cherry"]).toEq(1)
+
+  @it("should accept str keys from a record field across 3+ inserts")
+  fn shouldAcceptStrKeysFromARecordFieldAcross3PlusInserts():
+    # FieldAccessExpr returns an ExtractValueInst; tryRetainArcSource's
+    # Case 3 previously checked only collection-elem metadata and missed
+    # str fields, dispatching through ArcHeader (-16) and corrupting
+    # weak_count on the source str. (#2375)
+    record Tag:
+      name: str
+    tags: List<Tag> = [Tag("alpha"), Tag("beta"), Tag("gamma")]
+    m: Map<str, int> = {}
+    for t in tags:
+      m[t.name] = 1
+    expect(len(m)).toEq(3)
+    expect(m.contains("alpha")).toEq(true)
+    expect(m.contains("gamma")).toEq(true)
+
+  @it("should aggregate by record field with conditional insert")
+  fn shouldAggregateByRecordFieldWithConditionalInsert():
+    # Mirrors the temperature_aggregate.ry pattern: read record str
+    # field, use it as Map key, insert if absent / update if present.
+    # This is exactly what the dropped example tried to do.
+    record Reading:
+      location: str
+      v: int
+    readings: List<Reading> = [
+      Reading("tokyo", 23),
+      Reading("osaka", 25),
+      Reading("tokyo", 22),
+      Reading("sapporo", 17),
+    ]
+    counts: Map<str, int> = {}
+    for r in readings:
+      prev: int = case get(counts, r.location):
+        Some(n): n
+        None: 0
+      counts[r.location] = prev + 1
+    expect(counts["tokyo"]).toEq(2)
+    expect(counts["osaka"]).toEq(1)
+    expect(counts["sapporo"]).toEq(1)
+
+  @it("should accept heap-str keys from for-loop variable (ASan probe)")
+  fn shouldAcceptHeapStrKeysFromForLoopVariableAsanProbe():
+    # Heap-allocated keys (concat forces makeString) — the only form that
+    # exercises strong_count balance. Pre-fix on Linux/default-emit: retain
+    # at -16 bumped weak, release at -24 decremented strong 1→0 → premature
+    # free. The post-insert reads below give ASan a buffer to catch the
+    # UAF; without the read, the freed memory might never be accessed.
+    m: Map<str, int> = {}
+    keys: List<str> = [heapKey(1), heapKey(2), heapKey(3), heapKey(4)]
+    for k in keys:
+      m[k] = 1
+    # Read after insert — ASan dependency: if a key was prematurely freed,
+    # this contains() reads through a dangling pointer.
+    expect(m.contains("heap_1")).toEq(true)
+    expect(m.contains("heap_4")).toEq(true)
+    expect(len(m)).toEq(4)
+    total: int = 0
+    for k, v in m:
+      total = total + len(k)
+    expect(total).toBeGreaterThan(0)
+
+  @it("should accept unannotated implicit-binding heap-str (codegen_stmt.cpp path)")
+  fn shouldAcceptUnannotatedImplicitBindingHeapStr():
+    # Targets the codegen_stmt.cpp `str_elem`→`isRetainedArcStr` branch
+    # specifically: `k = keys[i]` (no `: str` annotation) is the only form
+    # that reaches the new metadata-based detection. An annotated
+    # `k: str = ...` would pass via the pre-existing `strByAnnot` path even
+    # if this branch were reverted.
+    m: Map<str, int> = {}
+    keys: List<str> = [heapKey(11), heapKey(12), heapKey(13)]
+    i: int = 0
+    while i < 3:
+      k = keys[i]
+      m[k] = i
+      i = i + 1
+    expect(len(m)).toEq(3)
+    expect(m.contains("heap_11")).toEq(true)
+    expect(m["heap_13"]).toEq(2)
+
+  @it("should accept record-field heap-str key (codegen_arc.cpp Case 3 path)")
+  fn shouldAcceptRecordFieldHeapStrKey():
+    # Targets codegen_arc.cpp Case 3 + codegen_expr_literal.cpp str_elem
+    # stamp specifically. The Record + heap str path crashes hardest under
+    # the old code because the wrong-offset retain on the str field
+    # corrupts weak_count while the strong path is freed on map drop.
+    record HK:
+      name: str
+    tags: List<HK> = [HK(heapKey(21)), HK(heapKey(22)), HK(heapKey(23))]
+    m: Map<str, int> = {}
+    for t in tags:
+      m[t.name] = 1
+    expect(len(m)).toEq(3)
+    expect(m.contains("heap_21")).toEq(true)
+    expect(m.contains("heap_23")).toEq(true)


### PR DESCRIPTION
## Summary

- `Map<str, V>` の動的キー挿入で `retainArcValue` が ArcHeader offset (-16) を使い、dtor の StringHeader offset (-24) と食い違って weak_count を破壊。Linux/default-emit (Release) では JIT optimiser が固定アドレスへの UB store を残すため SIGSEGV (macOS rust-emit / `RY_NO_OPT=1` では symptom が偶発的に隠れる)
- 修正は str 認識を 3 経路で揃える: `tryRetainArcSource` Case 3 が ExtractValueInst の str_elem を検出、`FieldAccessExpr` が str field 結果に str_elem を stamp、`AssignStmt` が val の str_elem を `isRetainedArcStr` に反映、`emitForBindingPattern` が List<str> ループ変数を str-managed に登録
- for / while / record-field の三経路すべてが StringHeader (-24) へ合流

Closes #2375

## Test plan

- [x] 検出 spec test 10 ケース追加 (`tests/spec/map_str_dynamic_insert_2375.test.ry`) — literal/heap × for-loop/while/record-field
- [x] macOS rust-emit: 219 spec test files 0 failures
- [x] Linux Docker default-emit: 219 spec test files 0 failures
- [x] Docker ASan: 219 spec test files 0 failures, UAF なし
- [x] cppcheck on touched files: clean
- [x] canonical examples: 99/99 pass
- [x] 元 crash 7 ケース (`bisect_h/j/p/q/s/t/z`) すべて pass
- [x] drop された `inventory_ledger.ry` / `temperature_aggregate.ry` を Linux で実行確認 (実復元は別 issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic `Map<str, V>` insertions so string keys and values are handled correctly across loops, indexing, and record-field assignments.
  * Improved string handling in iteration and variable binding to prevent crashes during repeated inserts.
* **Tests**
  * Added coverage for dynamic string-key map inserts, lookups, iteration, and record-field updates.
  * Added safety checks for cases that previously could fail after insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->