### PR TITLE
fix(tree-sitter): align directive_def_declaration and qualified_import grammar with stdlib usage

### DIFF
--- a/changelog.d/2382-tree-sitter-directive-and-qualified-import.md
+++ b/changelog.d/2382-tree-sitter-directive-and-qualified-import.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- tree-sitter grammar (`editor/tree-sitter/grammar.js`) で以下 2 件の不整合を解消し、対応する corpus entry を追加して editor (Neovim 等) の syntax highlight / indent 体験を修正:
+  - `directive_def_declaration` ルールが body 必須に書かれていたため、`share/std/core/directive.ry` 等の body-less な `@directive(target=[...])\nfn name(...)` 形が ERROR ノードを発生させていた問題を修正。`@directive(...)` 末尾の NEWLINE を rule に明示し、後続 `function_declaration` の body-less 形 (既存 `choice(function_body, _newline)`) を再利用する。`test/corpus/decorators.txt` に 3 ケース (single target / multi-target / `@public` 前置) を追加して shape を lock。
+  - `qualified_import_statement` ルールの `module` field が単発 `IDENT` 想定だったため、`import ry.math` / `import ry.math as m` の dotted module path 形が ERROR ノードを発生させていた問題を修正。`field('module', $.module_path)` に変更し dotted form を許容。既存 corpus 3 entry および `queries/highlights.scm` の `@module` キャプチャを追従更新。
+- あわせて `editor/tree-sitter/expected-fail.txt` の housekeeping:
+  - `#1618` 由来 3 entry (`arc_set_map_tuple_2226.test.ry` / `tuple_nested_generic_2264.test.ry` / `nested_fn_loop_capture.test.ry`) の triage を完了し、各 bucket の既存 grammar gap (tuple member access `.0`/`.1` / top-level `@const NAME: T = value`) と一致する旨を comment で明示。
+  - 既に clean parse する `tests/spec/implicit_widening.test.ry` を expected-fail から削除。
+- `./editor/tree-sitter/check.sh --verbose` で smoke `pass=169 skip=49 warn=0 fail=0` / `tree-sitter test` で corpus 119/119 pass を確認。 (#2382)

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -154,7 +154,8 @@ entry, or is explicitly marked as covered by the smoke fixture only.
 | `lambda_expression` | `lambdas.txt` |
 | literals (`integer_literal`, `float_literal`, `string_literal`, `block_string_literal`, `boolean_literal`, `none_literal`, `list_literal`, `map_literal`, `set_literal`, `tuple_literal`) | `literals.txt` |
 | `binary_expression`, `unary_expression`, `call_expression`, `index_expression`, `field_access` | `expressions.txt` |
-| **smoke-only** (corpus 化不能 / 既知 grammar gap) | `directive_def_declaration` (※1), `tuple_destructure_statement`, top-level `@<decorator> NAME: T = ...` (`expected-fail.txt` 該当) |
+| `directive_def_declaration` | `decorators.txt` (※1) |
+| **smoke-only** (corpus 化不能 / 既知 grammar gap) | `tuple_destructure_statement`, top-level `@<decorator> NAME: T = ...` (`expected-fail.txt` 該当) |
 
 Scope of the matrix is the rules that can appear as a direct child of
 `source_file` (declarations, top-level statements, imports). The
@@ -176,7 +177,7 @@ Adding dedicated corpus entries for the interior rules above is a
 worthwhile follow-up, but they are not within the Acceptance #2 scope
 ("each *top-level* rule").
 
-※1 `directive_def_declaration` は grammar.js 側で body 必須に書かれているのに対し、`share/std/core/directive.ry` の実例は body-less で内部 `(ERROR ...)` を残すため AST shape が安定せず corpus ロック不可。grammar 側 rule 整合は別 issue 候補。
+※1 `directive_def_declaration` は #2382 で grammar 整合済み。`@directive(...)` 行末の NEWLINE を rule に明示し、後続 `function_declaration` の body-less 形 (`function_declaration` 既存の `choice(function_body, _newline)` を再利用) を許容するよう更新した。実例 (`share/std/core/directive.ry` ほか) の AST shape が安定したため `decorators.txt` に 3 ケースを追加して corpus 対象化済み。
 
 ## Smoke-check (corpus regression test)
 

--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -15,7 +15,7 @@
 #     存在しないため file path 登録は無し。spec が追加されたら追記する。
 
 # === Tuple member access (`.0`, `.1`, ..., `.N`) ===
-tests/spec/arc_set_map_tuple_2226.test.ry  # pre-existing, registered in #1618
+tests/spec/arc_set_map_tuple_2226.test.ry  # triage(#2382): persistent — shares the tuple member-access (`.0`, `.1`) gap with the rest of this bucket
 tests/spec/collections.test.ry
 tests/spec/combinatorial/collection_element_tuple_access.test.ry
 tests/spec/combinatorial/collection_element_tuple_iterate.test.ry
@@ -26,7 +26,7 @@ tests/spec/combinatorial/nested_types.test.ry
 tests/spec/combinatorial/syntax_combinations.test.ry
 tests/spec/generic_infer_container.test.ry
 tests/spec/tuple_destructure_assign_parens.test.ry
-tests/spec/tuple_nested_generic_2264.test.ry  # pre-existing, registered in #1618
+tests/spec/tuple_nested_generic_2264.test.ry  # triage(#2382): persistent — shares the tuple member-access (`.0`, `.1`) gap with the rest of this bucket
 tests/spec/tuple_single_element.test.ry
 tests/spec/types.test.ry
 
@@ -51,9 +51,8 @@ tests/spec/concurrency.test.ry
 tests/spec/concurrency_stress.test.ry
 tests/spec/functions.test.ry
 tests/spec/http.test.ry
-tests/spec/implicit_widening.test.ry
 tests/spec/list_destructure_assign.test.ry
-tests/spec/nested_fn_loop_capture.test.ry  # pre-existing (@const top-level), registered in #1618
+tests/spec/nested_fn_loop_capture.test.ry  # triage(#2382): persistent — top-level `@const NAME: T = value` form not yet covered (same gap as `top_level_bindings.test.ry`)
 tests/spec/net.test.ry
 tests/spec/top_level_bindings.test.ry
 

--- a/editor/tree-sitter/grammar.js
+++ b/editor/tree-sitter/grammar.js
@@ -132,9 +132,13 @@ export default grammar({
     // The `as` alias form registers the alias as the effective name
     // (Python-style: `import math as m` makes `m.sqrt(...)` valid and
     // bare `math` undefined). Same-effective-name collisions are rejected.
+    // The module accepts a dotted path (`import ry.math`, `import ry.math as m`)
+    // to match the C++ parser; the canonical EBNF lists `IDENT` only but the
+    // tree-sitter grammar is intentionally more permissive (see README §
+    // "Live-editing tolerance" and the `_top_level_statement` rule comment).
     qualified_import_statement: $ => seq(
       'import',
-      field('module', $.identifier),
+      field('module', $.module_path),
       optional(seq('as', field('alias', $.identifier))),
       $._newline,
     ),
@@ -354,11 +358,19 @@ export default grammar({
     ),
 
     /* ------- @directive definition (#708) ------- */
+    // The body-less `fn` form (no `:` body, terminated by NEWLINE) is the only
+    // shape in actual stdlib usage (`share/std/core/directive.ry`,
+    // `share/std/testing/testing.ry`). `function_declaration` already supports
+    // both body-ful and body-less forms via its trailing
+    // `choice(function_body, _newline)`. The NEWLINE between `@directive(...)`
+    // and the `fn` keyword is required so the parser can absorb the line
+    // terminator at the end of the directive header line.
     directive_def_declaration: $ => seq(
       '@directive',
       '(',
       $.decorator_arguments,
       ')',
+      $._newline,
       $.function_declaration,
     ),
 

--- a/editor/tree-sitter/queries/highlights.scm
+++ b/editor/tree-sitter/queries/highlights.scm
@@ -25,9 +25,12 @@
   "from"
 ] @keyword.import
 
-; Qualified import: `import math` — module identifier is a namespace.
+; Qualified import: `import math` / `import ry.math` — module identifier is a
+; namespace. The `module_path` wrapper covers both single-segment and dotted
+; forms; tagging each `(identifier)` inside it gives every segment the
+; `@module` highlight.
 (qualified_import_statement
-  module: (identifier) @module)
+  module: (module_path (identifier) @module))
 
 (qualified_import_statement
   alias: (identifier) @module)

--- a/editor/tree-sitter/test/corpus/decorators.txt
+++ b/editor/tree-sitter/test/corpus/decorators.txt
@@ -288,3 +288,81 @@ fn abs(x: int) -> int:
       (return_statement
         value: (qualified_identifier
           (identifier))))))
+
+==================
+@directive definition with single target (body-less)
+==================
+
+@directive(target=["function"])
+fn inline(mode: str = "always")
+
+---
+
+(source_file
+  (directive_def_declaration
+    (decorator_arguments
+      (decorator_argument
+        name: (identifier)
+        value: (list_literal
+          (string_literal))))
+    (function_declaration
+      name: (function_name
+        (identifier))
+      parameters: (parameter_list
+        (parameter
+          name: (identifier)
+          type: (union_type
+            (primitive_type))
+          default: (string_literal))))))
+
+==================
+@directive definition with multi-target list and no parameters
+==================
+
+@directive(target=["function", "record", "field", "statement"])
+fn deprecated(reason: str = "")
+
+---
+
+(source_file
+  (directive_def_declaration
+    (decorator_arguments
+      (decorator_argument
+        name: (identifier)
+        value: (list_literal
+          (string_literal)
+          (string_literal)
+          (string_literal)
+          (string_literal))))
+    (function_declaration
+      name: (function_name
+        (identifier))
+      parameters: (parameter_list
+        (parameter
+          name: (identifier)
+          type: (union_type
+            (primitive_type))
+          default: (string_literal))))))
+
+==================
+@public preceded @directive definition (body-less)
+==================
+
+@public
+@directive(target=["for"])
+fn parallel()
+
+---
+
+(source_file
+  (decorator
+    name: (identifier))
+  (directive_def_declaration
+    (decorator_arguments
+      (decorator_argument
+        name: (identifier)
+        value: (list_literal
+          (string_literal))))
+    (function_declaration
+      name: (function_name
+        (identifier)))))

--- a/editor/tree-sitter/test/corpus/imports.txt
+++ b/editor/tree-sitter/test/corpus/imports.txt
@@ -207,7 +207,8 @@ import math
 
 (source_file
   (qualified_import_statement
-    module: (identifier)))
+    module: (module_path
+      (identifier))))
 
 ==================
 qualified import with alias (#1724)
@@ -219,7 +220,8 @@ import math as m
 
 (source_file
   (qualified_import_statement
-    module: (identifier)
+    module: (module_path
+      (identifier))
     alias: (identifier)))
 
 ==================
@@ -233,7 +235,8 @@ from math import PI
 
 (source_file
   (qualified_import_statement
-    module: (identifier))
+    module: (module_path
+      (identifier)))
   (import_statement
     source: (module_path
       (identifier))


### PR DESCRIPTION
## Summary

- `directive_def_declaration` rule に `)` と `function_declaration` の間の NEWLINE を明示し、`share/std/core/directive.ry` 等の body-less な `@directive(target=[...])\nfn name(...)` 形が ERROR ノードを残す問題を解消。`test/corpus/decorators.txt` に 3 ケース (single target / multi-target / `@public` 前置) を追加して shape を lock。
- `qualified_import_statement` rule の `module` field を `$.identifier` から `$.module_path` に変更し、`import ry.math` / `import ry.math as m` の dotted module path を許容。既存 corpus 3 entry と `queries/highlights.scm` の `@module` キャプチャを追従更新。`./check.sh --verbose` 自己検証中に発見した pre-existing gap で、当初 expected-fail に登録する方針だったが「Out of scope」宣言が issue IMPORTANT block に抵触するため grammar 修正で対応 (#2382 scope に追加、issue 本文反映済み)。
- expected-fail housekeeping: #1618 由来 3 entry (`arc_set_map_tuple_2226` / `tuple_nested_generic_2264` / `nested_fn_loop_capture`) の triage 完了コメント追記、clean parse する `implicit_widening.test.ry` を削除。

## Test plan

- [x] `./editor/tree-sitter/build.sh` で `ry.so` 再ビルド
- [x] `tree-sitter test` で corpus 119/119 pass
- [x] `./editor/tree-sitter/check.sh --verbose` で `pass=169 skip=49 warn=0 fail=0`
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` clean

Closes #2382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing for body-less directive definitions and qualified imports with dotted module paths.
  * Updated highlighting so each part of a dotted module path is recognized correctly.

* **Tests**
  * Added new parser coverage for directive declarations and updated import parsing expectations.
  * Refined expected-fail tracking for several known grammar cases.

* **Documentation**
  * Updated the grammar coverage notes to reflect the latest test coverage and parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->