### PR TITLE
chore(fuzz): integrate fuzz_json5 into local run-fuzz.sh

### DIFF
--- a/.claude/skills/pre-commit-checklist/run-fuzz.sh
+++ b/.claude/skills/pre-commit-checklist/run-fuzz.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# §3.6 libFuzzer (fuzz_parser / fuzz_json / fuzz_utf8 / fuzz_io_open — 60s each, via Docker)
-# fuzz_json5 (#1855) is built and validated locally but not yet in the docker
-# allowlist — re-add the docker/run.sh call after the next /ci-image-workflow.
+# §3.6 libFuzzer (fuzz_parser / fuzz_json / fuzz_json5 / fuzz_utf8 / fuzz_io_open — 60s each, via Docker)
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
 
@@ -26,6 +24,9 @@ done
 
 ./docker/run.sh fuzz fuzz_json -max_total_time=60 -rss_limit_mb=2048 \
     -artifact_prefix=tests/fuzz/regressions/json/ tests/fuzz/corpus/json
+
+./docker/run.sh fuzz fuzz_json5 -max_total_time=60 -rss_limit_mb=2048 \
+    -artifact_prefix=tests/fuzz/regressions/json5/ tests/fuzz/corpus/json5
 
 ./docker/run.sh fuzz fuzz_utf8 -max_total_time=60 -rss_limit_mb=2048 \
     -artifact_prefix=tests/fuzz/regressions/utf8/ tests/fuzz/corpus/utf8

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ target/
 # Already-tracked named seeds (*.ry, *.json, *.txt, *.bin, crash-*) are unaffected.
 tests/fuzz/corpus/parser/*
 tests/fuzz/corpus/json/*
+tests/fuzz/corpus/json5/*
 tests/fuzz/corpus/utf8/*
 tests/fuzz/corpus/fuzz_io_open/*
 !tests/fuzz/corpus/**/*.ry
@@ -76,3 +77,4 @@ tests/fuzz/corpus/fuzz_io_open/*
 !tests/fuzz/corpus/**/*.txt
 !tests/fuzz/corpus/**/*.bin
 !tests/fuzz/corpus/**/crash-*
+!tests/fuzz/corpus/**/seed-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,8 +618,16 @@ if(ENABLE_FUZZER)
     add_ry_fuzz_target(fuzz_json tests/fuzz/fuzz_json.cpp src/runtime/native/json.cpp src/runtime/native/io.cpp)
     # fuzz_json5 mirrors fuzz_json (#1855). json5's parser embeds io references
     # via __ry_json5_load_file / __ry_json5_dump_file just like json, so the
-    # same source-embedding pattern is required.
+    # same source-embedding pattern is required. Additionally, json5.cpp's
+    # identifier-name predicates reference __ry_xid_start / __ry_xid_continue
+    # from libry_xid (#2314); since json5.cpp is compiled directly into the
+    # harness those become real undefined references at link time (unlike `ry`
+    # where the reference lives only in the dlopen'd libry_json5). Link the
+    # xid cdylib explicitly — only this harness needs it, so the shared
+    # add_ry_fuzz_target helper is left untouched.
     add_ry_fuzz_target(fuzz_json5 tests/fuzz/fuzz_json5.cpp src/runtime/native/json5.cpp src/runtime/native/io.cpp)
+    add_dependencies(fuzz_json5 ry_xid)
+    target_link_libraries(fuzz_json5 PRIVATE ${RY_XID_LINK})
     add_ry_fuzz_target(fuzz_utf8 tests/fuzz/fuzz_utf8.cpp)
     # fuzz_io_open compiles runtime_io.cpp directly (it lives in ry_io SHARED lib,
     # not ry_lib) so the File handle symbols are available without dlopen.

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,6 +23,7 @@ manually delete them.
 # libFuzzer (mirrors CI fuzz job)
 ./docker/run.sh fuzz fuzz_parser  -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/parser/       tests/fuzz/corpus/parser
 ./docker/run.sh fuzz fuzz_json    -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/json/         tests/fuzz/corpus/json
+./docker/run.sh fuzz fuzz_json5   -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/json5/        tests/fuzz/corpus/json5
 ./docker/run.sh fuzz fuzz_utf8    -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/utf8/         tests/fuzz/corpus/utf8
 ./docker/run.sh fuzz fuzz_io_open -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/fuzz_io_open/ tests/fuzz/corpus/fuzz_io_open
 

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -8,6 +8,7 @@ Coverage-guided fuzzing for the ry compiler and runtime using [LLVM libFuzzer](h
 |---|---|---|
 | `fuzz_parser` | `ry::Lexer` + `ry::Parser::parseProgram()` | Lexer + parser pipeline on arbitrary byte sequences |
 | `fuzz_json` | `__ry_json_parse` | JSON parser on arbitrary byte sequences |
+| `fuzz_json5` | `__ry_json5_parse` | JSON5 parser (comments, trailing commas, unquoted keys, hex/Inf/NaN) on arbitrary byte sequences |
 | `fuzz_utf8` | `__ry_utf8_len_n`, `__ry_utf8_char_at_checked`, `__ry_utf8_reverse`, `__ry_utf8_substring` | Bounded UTF-8 walker functions |
 | `fuzz_io_open` | `__ry_io_file_open` | I/O file-open path-string handling on arbitrary byte sequences across `"r"` / `"w"` / `"a"` / invalid modes |
 
@@ -53,7 +54,7 @@ UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
     -artifact_prefix=tests/fuzz/regressions/parser/ \
     tests/fuzz/corpus/parser
 
-# Same pattern for fuzz_json, fuzz_utf8, and fuzz_io_open
+# Same pattern for fuzz_json, fuzz_json5, fuzz_utf8, and fuzz_io_open
 ```
 
 `-rss_limit_mb=512` prevents OOM — compiler-input harnesses can peak high.
@@ -64,16 +65,19 @@ UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 tests/fuzz/
 ├── fuzz_parser.cpp          # Harness: lexer + parser
 ├── fuzz_json.cpp            # Harness: JSON parser
+├── fuzz_json5.cpp           # Harness: JSON5 parser
 ├── fuzz_utf8.cpp            # Harness: bounded UTF-8 walkers
 ├── fuzz_io_open.cpp         # Harness: __ry_io_file_open path-string handling
 ├── corpus/
 │   ├── parser/              # Seed inputs for fuzz_parser (*.ry snippets)
 │   ├── json/                # Seed inputs for fuzz_json
+│   ├── json5/               # Seed inputs for fuzz_json5 (seed-* covering each spec extension)
 │   ├── utf8/                # Seed inputs for fuzz_utf8 (text + binary)
 │   └── fuzz_io_open/        # Seed inputs for fuzz_io_open (arbitrary path bytes)
 └── regressions/
     ├── parser/              # Saved crash inputs for fuzz_parser
     ├── json/                # Saved crash inputs for fuzz_json
+    ├── json5/               # Saved crash inputs for fuzz_json5
     ├── utf8/                # Saved crash inputs for fuzz_utf8
     └── fuzz_io_open/        # Saved crash inputs for fuzz_io_open
 ```


### PR DESCRIPTION
## Summary

- Re-add the `fuzz_json5` docker invocation to `.claude/skills/pre-commit-checklist/run-fuzz.sh` after the `/ci-image-workflow` rebuild propagated `fuzz_json5` into `docker/entrypoint.sh`'s allowlist (#2289 deferral).
- Close two latent breaks surfaced by the smoke test: `fuzz_json5` was not linking `ry_xid` (undefined `__ry_xid_start` / `__ry_xid_continue` from `src/runtime/native/json5.cpp` being compiled directly into the harness), and `tests/fuzz/corpus/json5/*` was missing from `.gitignore` so libFuzzer's runtime-generated interesting inputs (1500+ extensionless SHA1-named files) leaked as untracked.
- Bring `docker/README.md` and `tests/fuzz/README.md` target enumeration up to 5 targets.

Closes #2384

## Test plan

- [x] Single-target smoke: `./docker/run.sh fuzz fuzz_json5 -max_total_time=60 -rss_limit_mb=2048 -artifact_prefix=tests/fuzz/regressions/json5/ tests/fuzz/corpus/json5` → 1,522,016 runs / 61s / 0 crashes.
- [x] Full `run-fuzz.sh` (5 targets × 60s) → all complete, 0 crashes, no new artifacts in `tests/fuzz/regressions/`.
- [x] `prompt-refs lint` clean.
- [x] After `.gitignore` fix, `git status` shows only the 6 intended files (1500+ libFuzzer-generated corpus entries correctly ignored; PR #2289's `seed-*` files unaffected as they are already tracked).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new JSON5 fuzzing target, expanding coverage for JSON5-specific syntax such as comments, trailing commas, unquoted keys, and special number values.
  * Updated build setup to include the new fuzzing target so it runs correctly.

* **Documentation**
  * Expanded fuzzing documentation and quick-start instructions to include the new JSON5 target.
  * Updated corpus and regression test layout examples to reflect the new JSON5 paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->