### PR TITLE
test: extend contract/internal/regression taxonomy to codegen, runtime, and ABI test files (#2383)

### DIFF
--- a/docs/reference/test-taxonomy.md
+++ b/docs/reference/test-taxonomy.md
@@ -47,6 +47,17 @@ C++ / Ry の test を「何を守っているか」で 3 カテゴリに分類�
 
 `tests/test_regression_<issue>_<desc>.cpp` を作る既存運用を継続する。
 
+### 単一スコープで section header が立たないファイルは whole-file tag
+
+ファイル全体が単一テーマで複数の section header に分かれない場合 (例: subprocess CLI で 1 つの bug を pin する `tests/test_codegen_call_json_reject.cpp`、`__ry_lock_acquire` / `__ry_lock_release` の contention 1 本だけを assert する `tests/test_runtime_lock_stress.cpp`)、ファイル冒頭の taxonomy index コメントに `Whole-file dominant tag: [contract] / [regression #NNNN] / [internal]` の 1 行を加える。section header の `// ===== [tag] Title =====` 行は追加しない (新たな見出し階層の捏造を避けるため)。
+
+```cpp
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file tag: [regression #1941] (subprocess-based emitJsonLoad type rejection).
+```
+
 ### Section 内で混在するときは inline tag
 
 Section の dominant category を採り、別カテゴリの個別テストの直上にコメントを 1 行追加する:
@@ -78,7 +89,25 @@ TEST(ParserTest, ParenTupleDestructRejectsSnakeCase) { ... }
 
 ## カテゴリ分布は層によって偏る
 
-3 カテゴリを抽象的に並べているが、テスト対象の層によって分布は自然に偏る。公開境界が単一の層 (例: parser の `parseProgram()`) では `[contract]` が支配的になり `[internal]` はほぼ立たない。ARC / IR / runtime layer のテストでは `[internal]` の比率が上がる。
+3 カテゴリを抽象的に並べているが、テスト対象の層によって分布は自然に偏る。
+`tests/test_parser.cpp` (#1831) / `tests/test_codegen*.cpp` / `tests/test_runtime*.cpp`
+への pilot 適用 (#2383) で観測した分布:
+
+| 層 | 主な観察手段 | section 数 (contract / regression / internal) |
+|---|---|---|
+| parser | `parseProgram()` → AST / 例外 (黒箱) | 47 / 4 / 0 |
+| codegen + ABI / native-descriptor | `runSource` / `runTestSource` → 標準出力 / 例外 (黒箱) が支配的。ARC ヘッダ・IR 形状・extern "C" emit ABI guard・native call descriptor 等の内部観察は局所的に発生 | 273 / 26 / 22 |
+| runtime | `__ry_*` runtime symbol を直接呼ぶ、layout struct を手で組み立てる (白箱) | 0 / 8 / 78 |
+
+`[internal]` が実際に立ったケース:
+
+- codegen 層: `tests/test_codegen_arc.cpp` (ARC ヘッダ layout / 構造的 IR 検証), `tests/test_codegen_directive.cpp` (`ry::util::deriveRuntimeFnName` / `NativeFnSignature` registry を直接呼ぶ helper test), `tests/test_codegen_net.cpp` (`__ry_tcp_send` / `__ry_send_all` / `__ry_tcp_receive` / `__ry_tcp_set_timeout` を直接呼ぶ unit test), `tests/test_codegen_gc_visit.cpp` (test-only flag で GC visitor IR 発行を強制し marker 形を assert)。
+- ABI / native-descriptor 層: `tests/test_header_layout.cpp` (C++ ↔ Rust collection / ARC header struct layout parity), `tests/test_emit_abi_guards.cpp` (extern "C" `ry_emit_*` ABI の NULL / range guard を直接呼ぶ), `tests/test_native_call_descriptor.cpp` (`inferLibraryName` / `CodeGen::getNativeCallDescriptors` の内部 descriptor 状態を assert)。
+- runtime 層: `tests/test_runtime_string.cpp` / `tests/test_runtime_any.cpp` / `tests/test_runtime_gc.cpp` / `tests/test_runtime_json.cpp` / `tests/test_runtime_json5.cpp` / `tests/test_runtime_http.cpp` / `tests/test_runtime_utf8.cpp` / `tests/test_regex_runtime.cpp` / `tests/test_abi_layout.cpp` ほぼ全件が `__ry_*` を直接呼ぶか layout struct を手で組み立てる。`tests/test_runtime_lock_stress.cpp` / `tests/test_runtime_rwlock_stress.cpp` / `tests/test_runtime_arc_contention_stress.cpp` / `tests/test_runtime_print.cpp` / `tests/test_runtime_io_file.cpp` / `tests/test_coverage_runtime.cpp` は section header が立たない単一スコープのファイルだが whole-file tag として `[internal]` を付している。
+
+scope 注: `tests/test_emit_llvm_ir.cpp` は CLI subprocess test (`ry emit-llvm-ir` の出力を assert する) で、codegen 内部状態ではなく CLI 観測の黒箱テストである。codegen 層の `tests/test_codegen_*.cpp` glob からも外れる位置付けのため、今回の taxonomy 適用範囲から外している。
+
+parser が `[contract]` 支配的、runtime が `[internal]` 支配的、codegen はその中間で `[contract]` を主軸に局所的に `[internal]` が立つ、という予測 (旧 doc) を観察で裏付けた形となった。
 
 ## "Contract" の語義衝突
 
@@ -88,4 +117,4 @@ TEST(ParserTest, ParenTupleDestructRejectsSnakeCase) { ... }
 
 - `.claude/skills/test-checklist/SKILL.md` — テスト作成時の perspective チェック
 - `.claude/rules/tests-cpp-conventions.md` — C++ テストの実装規約
-- 適用 pilot: `tests/test_parser.cpp` (#1831)
+- 適用済み: `tests/test_parser.cpp` (#1831), `tests/test_codegen*.cpp` + `tests/test_runtime*.cpp` + `tests/test_abi_layout.cpp` + `tests/test_coverage_runtime.cpp` + `tests/test_regex_runtime.cpp` + `tests/test_header_layout.cpp` + `tests/test_emit_abi_guards.cpp` + `tests/test_native_call_descriptor.cpp` (#2383)

--- a/tests/test_abi_layout.cpp
+++ b/tests/test_abi_layout.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — pure compile-time static_assert on
+// C++ struct sizeof/alignof/offset to pin the ABI contract with crates/emit.
+//
 // ABI struct-layout verification — C++ side (#1995).
 //
 // This translation unit is the C++ half of the C++ <-> Rust ABI layout
@@ -24,7 +30,7 @@
 
 #include <gtest/gtest.h>
 
-// === Descriptor structs: sizeof + alignof + every field offset ===
+// ===== [internal] Descriptor structs: sizeof + alignof + every field offset =====
 
 // RyCowEnsureUniqueDesc (12 fields) — api.h L429-465.
 static_assert(sizeof(RyCowEnsureUniqueDesc) == 64,
@@ -90,7 +96,7 @@ static_assert(offsetof(RyAnyTryUnwrapDesc, do_collection_retain) == 48, "RyAnyTr
 static_assert(offsetof(RyAnyTryUnwrapDesc, do_str_retain) == 52, "RyAnyTryUnwrapDesc.do_str_retain @ 52");
 static_assert(offsetof(RyAnyTryUnwrapDesc, err_msg_str_id) == 56, "RyAnyTryUnwrapDesc.err_msg_str_id @ 56");
 
-// === Opaque handle typedefs: sizeof + alignof only (no fields) ===
+// ===== [internal] Opaque handle typedefs: sizeof + alignof only (no fields) =====
 // All are pointers to incomplete structs -> 8 bytes / 8-byte aligned on
 // the 64-bit ABI. Per-field offset is N/A — handles carry no fields.
 static_assert(sizeof(RyModuleRef) == 8 && alignof(RyModuleRef) == 8, "RyModuleRef is an 8-byte pointer");
@@ -103,10 +109,10 @@ static_assert(sizeof(RyValueRef) == 8 && alignof(RyValueRef) == 8, "RyValueRef i
 static_assert(sizeof(RyBasicBlockRef) == 8 && alignof(RyBasicBlockRef) == 8, "RyBasicBlockRef is an 8-byte pointer");
 static_assert(sizeof(RySwitchRef) == 8 && alignof(RySwitchRef) == 8, "RySwitchRef is an 8-byte pointer");
 
-// === Scalar intern-handle typedefs (uint32_t) ===
+// ===== [internal] Scalar intern-handle typedefs (uint32_t) =====
 static_assert(sizeof(RyValueId) == 4 && alignof(RyValueId) == 4, "RyValueId is a 4-byte uint32_t");
 
-// === Enum selectors: underlying type is `int` (4 bytes) ===
+// ===== [internal] Enum selectors: underlying type is `int` (4 bytes) =====
 // The descriptor structs store these as plain `int` fields; locking the
 // enum width here documents that the function-argument enums match the
 // Rust side's `c_int` representation. (No descriptor field is enum-typed.)
@@ -114,7 +120,7 @@ static_assert(sizeof(RyBoundsKind) == sizeof(int), "RyBoundsKind underlying type
 static_assert(sizeof(RyArcAtomic) == sizeof(int), "RyArcAtomic underlying type is int");
 static_assert(sizeof(RyCowKind) == sizeof(int), "RyCowKind underlying type is int");
 
-// === RyICmpPred cross-language parity (#2143) ===
+// ===== [internal] RyICmpPred cross-language parity (#2143) =====
 // The C++ enumerator literals (api.h L985-996) and the Rust `RY_ICMP_*`
 // constants (crates/emit/src/abi.rs) were previously protected only by a
 // prose "MUST match" comment. Two layered guards now pin them mechanically:
@@ -159,7 +165,7 @@ TEST(AbiLayout, RyICmpPredRustMirrorMatchesCanonical) {
     EXPECT_EQ(rust.uge, static_cast<int>(RY_ICMP_UGE));
 }
 
-// === RyAtomicBinOp / RyAtomicOrdering / RyLinkage / RyListCopyKind cross-language parity (#2250) ===
+// ===== [internal] RyAtomicBinOp / RyAtomicOrdering / RyLinkage / RyListCopyKind cross-language parity (#2250) =====
 // Four enums whose `api.h` definitions and Rust-side `RY_*` constants in
 // `crates/emit/src/abi.rs` were previously protected only by a prose
 // "MUST match" comment. Two paired compile-time guards pin them mechanically:
@@ -182,7 +188,7 @@ static_assert(RY_LINKAGE_EXTERNAL == 0 && RY_LINKAGE_INTERNAL == 1 && RY_LINKAGE
 static_assert(RY_LISTCOPY_KEYS == 0 && RY_LISTCOPY_VALUES == 1 && RY_LISTCOPY_TAKE == 2,
               "RyListCopyKind literal mismatch (api.h reorder?)");
 
-// === IOListHeader / StringHeader prefix cross-language parity (#2282) ===
+// ===== [internal] IOListHeader / StringHeader prefix cross-language parity (#2282) =====
 // The Rust `native_base64` cdylib (crates/native_base64/src/ffi.rs) reads
 // `IOListHeader::{len,cap,data}` through a `#[repr(C)]` mirror and computes
 // `byte_len` for a Ry str handle by reading `handle - STRING_BYTELEN_OFFSET`.

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1,8 +1,12 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ===== Print literals =====
+// ===== [contract] Print literals =====
 
 TEST_F(CodeGenTest, PrintLiterals) {
     EXPECT_EQ(runSource("print(42)"), "42\n");
@@ -16,7 +20,7 @@ TEST_F(CodeGenTest, PrintLiterals) {
     EXPECT_EQ(runSource("print(\"\")"), "\n");
 }
 
-// ===== Print variadic =====
+// ===== [contract] Print variadic =====
 
 TEST_F(CodeGenTest, PrintVariadic) {
     // Multiple arguments (space-separated)
@@ -31,7 +35,7 @@ TEST_F(CodeGenTest, PrintVariadic) {
     EXPECT_EQ(runSource("print([1, 2], \"x\")"), "[1, 2] x\n");
 }
 
-// ===== Arithmetic (int) =====
+// ===== [contract] Arithmetic (int) =====
 
 TEST_F(CodeGenTest, ArithmeticInt) {
     EXPECT_EQ(runSource("x = 3 + 4\nprint(x)"), "7\n");
@@ -46,7 +50,7 @@ TEST_F(CodeGenTest, ArithmeticInt) {
     EXPECT_EQ(runSource("x = 2 ** 3 ** 2\nprint(x)"), "512.0\n");
 }
 
-// ===== Arithmetic (float) =====
+// ===== [contract] Arithmetic (float) =====
 
 TEST_F(CodeGenTest, ArithmeticFloat) {
     EXPECT_EQ(runSource("x = 7 / 2\nprint(x)"), "3.5\n");
@@ -55,7 +59,7 @@ TEST_F(CodeGenTest, ArithmeticFloat) {
     EXPECT_EQ(runSource("x = 5.5 % 2.0\nprint(x)"), "1.5\n");
 }
 
-// ===== Float shortest round-trip (#1031) =====
+// ===== [contract] Float shortest round-trip (#1031) =====
 
 TEST_F(CodeGenTest, FloatShortestRoundTrip) {
     // Imprecise arithmetic must show the actual stored value (#1031)
@@ -68,7 +72,7 @@ TEST_F(CodeGenTest, FloatShortestRoundTrip) {
     EXPECT_EQ(runSource("print(-2.0)"), "-2.0\n");
 }
 
-// ===== Comparison operators =====
+// ===== [contract] Comparison operators =====
 
 TEST_F(CodeGenTest, ComparisonOperators) {
     EXPECT_EQ(runSource("x = 1 == 1\nprint(x)"), "true\n");
@@ -84,7 +88,7 @@ TEST_F(CodeGenTest, ComparisonOperators) {
     EXPECT_EQ(runSource("x = 4 >= 5\nprint(x)"), "false\n");
 }
 
-// ===== Logical operators =====
+// ===== [contract] Logical operators =====
 
 TEST_F(CodeGenTest, LogicalOperators) {
     EXPECT_EQ(runSource("x = true and true\nprint(x)"), "true\n");
@@ -96,7 +100,7 @@ TEST_F(CodeGenTest, LogicalOperators) {
     EXPECT_EQ(runSource("x = not not true\nprint(x)"), "true\n");
 }
 
-// ===== Variables =====
+// ===== [contract] Variables =====
 
 TEST_F(CodeGenTest, VariableBasics) {
     EXPECT_EQ(runSource("print(1)\nprint(2)\nprint(3)"), "1\n2\n3\n");
@@ -110,7 +114,7 @@ TEST_F(CodeGenTest, VariableBindingBasics) {
     EXPECT_EQ(runSource("x: int = 42\nprint(x)"), "42\n");
 }
 
-// ===== Error handling (individual) =====
+// ===== [contract] Error handling (individual) =====
 
 TEST_F(CodeGenTest, UndefinedVariableThrows) {
     EXPECT_THROW(runSource("print(z)"), std::runtime_error);
@@ -120,7 +124,7 @@ TEST_F(CodeGenTest, UnknownFunctionThrows) {
     EXPECT_THROW(runSource("foo(42)"), std::runtime_error);
 }
 
-// ===== Operator return type constraint =====
+// ===== [contract] Operator return type constraint =====
 
 TEST_F(CodeGenTest, OperatorEqInferredNonBoolThrows) {
     EXPECT_THROW(runSource(
@@ -146,7 +150,7 @@ TEST_F(CodeGenTest, OperatorOrExplicitNonBoolThrows) {
         "    return 1\n"), std::runtime_error);
 }
 
-// ===== Bitwise operators =====
+// ===== [contract] Bitwise operators =====
 
 TEST_F(CodeGenTest, BitwiseOperators) {
     // 1100 & 1010 = 1000 = 8
@@ -180,7 +184,7 @@ TEST_F(CodeGenTest, BitwiseFloatThrows) {
     EXPECT_THROW(runSource("x = 1.0 & 2"), std::runtime_error);
 }
 
-// ===== String variables =====
+// ===== [contract] String variables =====
 
 TEST_F(CodeGenTest, StringVariables) {
     EXPECT_EQ(runSource("s = \"world\"\nprint(s)"), "world\n");
@@ -217,7 +221,7 @@ TEST_F(CodeGenTest, StringBinaryOpTypeMismatch) {
     EXPECT_EQ(runSource("print(\"ab\" < \"cd\")"), "true\n");
 }
 
-// ===== String auto-concatenation (#393) =====
+// ===== [contract] String auto-concatenation (#393) =====
 
 TEST_F(CodeGenTest, StringAutoConcat) {
     EXPECT_EQ(runSource("print(\"abc\" + 2)"), "abc2\n");
@@ -228,7 +232,7 @@ TEST_F(CodeGenTest, StringAutoConcat) {
     EXPECT_EQ(runSource("print(false + \" is false\")"), "false is false\n");
 }
 
-// ===== Non-string pointer types must not hit string paths (#397) =====
+// ===== [regression #397] Non-string pointer types must not hit string paths =====
 
 TEST_F(CodeGenTest, NonStrPointerNotTreatedAsStr) {
     // Collections share LLVM ptrTy_ with str but must not activate str-specific operator paths
@@ -239,7 +243,7 @@ TEST_F(CodeGenTest, NonStrPointerNotTreatedAsStr) {
     EXPECT_THROW(runSource("m = {\"a\": 1}\nprint(m + \"abc\")"), std::runtime_error);
 }
 
-// ===== Type change =====
+// ===== [contract] Type change =====
 
 TEST_F(CodeGenTest, TypeChangeThrows) {
     EXPECT_THROW(runSource("x = 1\nx = true\nprint(x)"), std::runtime_error);
@@ -253,7 +257,7 @@ TEST_F(CodeGenTest, IntFloatReassignCoerces) {
     EXPECT_EQ(runSource("x = 1.5\nx = 2\nprint(x)"), "2.0\n");
 }
 
-// ===== Type annotation =====
+// ===== [contract] Type annotation =====
 
 TEST_F(CodeGenTest, TypeAnnotationMatch) {
     EXPECT_EQ(runSource("a: int = 10\nprint(a)"), "10\n");
@@ -350,7 +354,7 @@ TEST_F(CodeGenTest, IntFloatCoercionReturnLowLevelStillRejected) {
         std::runtime_error);
 }
 
-// ===== u8 basics =====
+// ===== [contract] u8 basics =====
 
 TEST_F(CodeGenTest, U8Basics) {
     EXPECT_EQ(runSource("b: u8 = 42\nprint(b)"), "42\n");
@@ -383,7 +387,7 @@ TEST_F(CodeGenTest, U8OutOfRange) {
     EXPECT_THROW(runSource("b: u8 = 10\nb = 256"), std::runtime_error);
 }
 
-// ===== Hex / Binary literal tests =====
+// ===== [contract] Hex / Binary literal tests =====
 
 TEST_F(CodeGenTest, HexBinaryLiterals) {
     EXPECT_EQ(runSource("print(0xFF)"), "255\n");
@@ -395,7 +399,7 @@ TEST_F(CodeGenTest, HexBinaryLiterals) {
     EXPECT_EQ(runSource("print(-0xFF)"), "-255\n");
 }
 
-// ===== 論理右シフト >>> =====
+// ===== [contract] 論理右シフト >>> =====
 
 TEST_F(CodeGenTest, LogicalRightShift) {
     // 8 >>> 2 = 2
@@ -404,7 +408,7 @@ TEST_F(CodeGenTest, LogicalRightShift) {
     EXPECT_EQ(runSource("x = -1 >>> 1\nprint(x)"), "9223372036854775807\n");
 }
 
-// ===== 文字列繰り返し * =====
+// ===== [contract] 文字列繰り返し * =====
 
 TEST_F(CodeGenTest, StringRepeatOperator) {
     EXPECT_EQ(runSource("x = \"ab\" * 3\nprint(x)"), "ababab\n");
@@ -415,7 +419,7 @@ TEST_F(CodeGenTest, StringRepeatOperator) {
     EXPECT_EQ(runSource("x = \"a\" * 1\nprint(x)"), "a\n");
 }
 
-// ===== exit() tests (death tests - individual) =====
+// ===== [contract] exit() tests (death tests - individual) =====
 
 TEST_F(CodeGenTest, ExitZero) {
     EXPECT_EXIT(runSource("exit(0)"), ::testing::ExitedWithCode(0), "");
@@ -439,7 +443,7 @@ TEST_F(CodeGenTest, ExitArgumentErrors) {
     EXPECT_THROW(runSource("exit(1, 2)"), std::runtime_error);
 }
 
-// ===== Top-level `?` operator tests (#745) =====
+// ===== [contract] Top-level `?` operator tests (#745) =====
 // `?` at the top level desugars to "print error to stderr + exit(1)"
 // when the operand is Err/None; otherwise it unwraps the happy value.
 
@@ -485,7 +489,7 @@ TEST_F(CodeGenTest, TopLevelQuestionOnOptionNoneExits) {
         "unexpected None");
 }
 
-// ===== args() tests =====
+// ===== [contract] args() tests =====
 
 TEST_F(CodeGenTest, ArgumentsTests) {
     EXPECT_EQ(runSourceWithArgs("a = args()\nprint(len(a))", {}), "0\n");
@@ -497,7 +501,7 @@ TEST_F(CodeGenTest, ArgumentsTests) {
         {"foo", "bar"}), "foo\nbar\n");
 }
 
-// ===== @native fn missing dispatcher detection =====
+// ===== [contract] @native fn missing dispatcher detection =====
 
 TEST_F(CodeGenTest, NativeFunctionMissingDispatcher) {
     try {
@@ -515,7 +519,7 @@ TEST_F(CodeGenTest, NativeFunctionMissingDispatcher) {
     }
 }
 
-// ===== Zero division guard tests (death tests - individual) =====
+// ===== [contract] Zero division guard tests (death tests - individual) =====
 
 TEST_F(CodeGenTest, DivByZeroReturnsInf) {
     EXPECT_EQ(runSource("print(1 / 0)"),   "inf\n");
@@ -552,7 +556,7 @@ TEST_F(CodeGenTest, ModByZeroExits) {
                 "runtime error: modulo by zero");
 }
 
-// ===== Low-level integer zero division guard tests =====
+// ===== [contract] Low-level integer zero division guard tests =====
 
 TEST_F(CodeGenTest, LowLevelDivByZeroExits) {
     EXPECT_EXIT(runSource("a: i32 = 10\nb: i32 = 0\nc = a / b\nprint(c as int)"),
@@ -598,7 +602,7 @@ TEST_F(CodeGenTest, FloorDivModWorks) {
     EXPECT_EQ(runSource("print((7 // -3) * -3 + (7 % -3))"), "7\n");
 }
 
-// ===== Integer overflow guard tests (death tests) =====
+// ===== [contract] Integer overflow guard tests (death tests) =====
 
 TEST_F(CodeGenTest, IntAddOverflowExits) {
     EXPECT_EXIT(runSource("x = 9223372036854775807\nprint(x + 1)"),
@@ -675,7 +679,7 @@ TEST_F(CodeGenTest, LowLevelI64StillWraps) {
               "-9223372036854775808\n");
 }
 
-// ===== float → int conversion runtime check (#1232) =====
+// ===== [regression #1232] float → int conversion runtime check =====
 
 TEST_F(CodeGenTest, CastFloatInfToIntExits) {
     EXPECT_EXIT(runSource("print((1.0 / 0.0) as int)"),
@@ -757,7 +761,7 @@ TEST_F(CodeGenTest, CastFiniteFloatToIntStillWorks) {
     EXPECT_EQ(runSource("print(1e10 as int)"), "10000000000\n");
 }
 
-// ===== any type acceptance / rejection =====
+// ===== [contract] any type acceptance / rejection =====
 
 TEST_F(CodeGenTest, AnyTypeAcceptsCollections) {
     // #1697: `any` now holds List / Map / Set collections. Verify wrap and
@@ -869,7 +873,7 @@ TEST_F(CodeGenTest, CoerceResultOkNestedResultMismatchTrapsArcPayload) {
         "any enum type mismatch \\(expected Result<str, int>");
 }
 
-// ===== Low-level numeric types (i16, i32, f32) =====
+// ===== [contract] Low-level numeric types (i16, i32, f32) =====
 
 TEST_F(CodeGenTest, LowLevelI32Basics) {
     EXPECT_EQ(runSource("x: i32 = 42\nprint(x)"), "42\n");
@@ -991,7 +995,7 @@ TEST_F(CodeGenTest, LowLevelMixedTypeError) {
     EXPECT_THROW(runSource("c = 1 + -1i64"), std::runtime_error);
 }
 
-// ===== Numeric literal suffix =====
+// ===== [contract] Numeric literal suffix =====
 
 TEST_F(CodeGenTest, NumericLiteralSuffix_i32) {
     EXPECT_EQ(runSource("x = 42i32\nprint(x)"), "42\n");
@@ -1030,7 +1034,7 @@ TEST_F(CodeGenTest, NumericLiteralSuffix_OutOfRange) {
     EXPECT_THROW(runSource("x = -1u32"), std::runtime_error);
 }
 
-// ===== Unsigned variable negation error (#312) =====
+// ===== [contract] Unsigned variable negation error (#312) =====
 
 TEST_F(CodeGenTest, UnsignedVariableNegation_u8) {
     EXPECT_THROW(runSource("x: u8 = 5\ny = -x"), std::runtime_error);
@@ -1055,7 +1059,7 @@ TEST_F(CodeGenTest, UnsignedFunctionReturnNegation) {
         "y = -getU32()"), std::runtime_error);
 }
 
-// ===== Return type inference for named functions =====
+// ===== [contract] Return type inference for named functions =====
 
 TEST_F(CodeGenTest, ReturnTypeInference_Int) {
     // Omitted return type with return int → inferred as int
@@ -1125,9 +1129,7 @@ TEST_F(CodeGenTest, ReturnTypeInference_ExplicitAnyUnchanged) {
         "print(x)"), "42\n");
 }
 
-// ============================================================
-// Fixed-length array T[N]
-// ============================================================
+// ===== [contract] Fixed-length array T[N] =====
 
 TEST_F(CodeGenTest, ArrayBasicDecl) {
     EXPECT_EQ(runSource(
@@ -1214,7 +1216,7 @@ TEST_F(CodeGenTest, ArrayAssignRangeCheck) {
         "buf[0] = 256"), std::runtime_error);
 }
 
-// ===== Checked/Saturating/Wrapping Arithmetic =====
+// ===== [contract] Checked/Saturating/Wrapping Arithmetic =====
 
 TEST_F(CodeGenTest, CheckedAddOk) {
     EXPECT_EQ(runSource(
@@ -1325,7 +1327,7 @@ TEST_F(CodeGenTest, CheckedFloat) {
     EXPECT_THROW(runSource("checkedAdd(1.0f32, 2.0f32)"), std::runtime_error);
 }
 
-// ===== Top-level bindings accessible from top-level functions (#817) =====
+// ===== [regression #817] Top-level bindings accessible from top-level functions =====
 
 TEST_F(CodeGenTest, TopLevelConstFloatAccessibleFromFunction) {
     EXPECT_EQ(runSource(withStdlibDirectiveDecls(
@@ -1709,7 +1711,7 @@ TEST_F(CodeGenTest, TopLevelFixedArrayIndexedFromFunction) {
         "print(atTwo())"), "10\n30\n");
 }
 
-// ===== #807 u64 max literals =====
+// ===== [regression #807] u64 max literals =====
 
 TEST_F(CodeGenTest, U64MaxViaAnnotation) {
     EXPECT_EQ(runSource("h: u64 = 18446744073709551615\nprint(h)"),
@@ -1774,7 +1776,7 @@ TEST_F(CodeGenTest, U32OverflowRejected) {
                  std::runtime_error);
 }
 
-// ===== #819 scientific notation =====
+// ===== [regression #819] scientific notation =====
 
 TEST_F(CodeGenTest, ScientificBasic) {
     EXPECT_EQ(runSource("print(1e10)"), "1e+10\n");
@@ -1830,7 +1832,7 @@ TEST_F(CodeGenTest, U64AnnotationFormatterRoundtrip) {
         "18446744073709551615\n");
 }
 
-// ===== Option-returning index `m[k]?` / `xs[i]?` rejections (#1699) =====
+// ===== [contract] Option-returning index `m[k]?` / `xs[i]?` rejections (#1699) =====
 
 TEST_F(CodeGenTest, OptionIndexRejectsMapAssignmentTarget) {
     // Write-form `m[k]? = v` must be a compile error — `?` returns Option, not a slot.

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1,8 +1,12 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ===== Break / Continue =====
+// ===== [contract] Break / Continue =====
 
 TEST_F(CodeGenTest, BreakInWhile) {
     std::string src =
@@ -74,7 +78,7 @@ TEST_F(CodeGenTest, ParallelForContinueRejected) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== Struct field assignment =====
+// ===== [contract] Struct field assignment =====
 
 TEST_F(CodeGenTest, RecordFieldAssign) {
     std::string src =
@@ -112,7 +116,7 @@ TEST_F(CodeGenTest, RecordFieldAssignConstError) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== Escape sequences =====
+// ===== [contract] Escape sequences =====
 
 TEST_F(CodeGenTest, EscapeNewline) {
     std::string src = "print(\"hello\\nworld\")";
@@ -134,7 +138,7 @@ TEST_F(CodeGenTest, EscapeQuote) {
     EXPECT_EQ(runSource(src), "say \"hi\"\n");
 }
 
-// ===== range() as expression =====
+// ===== [contract] range() as expression =====
 
 TEST_F(CodeGenTest, RangeEmptyList) {
     std::string src =
@@ -153,7 +157,7 @@ TEST_F(CodeGenTest, RangeUsedAsList) {
     EXPECT_EQ(runSource(src), "0\n1\n2\n3\n");
 }
 
-// ===== Lambda (arrow function) tests =====
+// ===== [contract] Lambda (arrow function) tests =====
 
 TEST_F(CodeGenTest, LambdaBasicExpr) {
     std::string src =
@@ -253,7 +257,7 @@ TEST_F(CodeGenTest, LambdaArgTypeError) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== Effectively final capture tests =====
+// ===== [contract] Effectively final capture tests =====
 
 TEST_F(CodeGenTest, CapturedVarReassignError) {
     std::string src =
@@ -338,7 +342,7 @@ TEST_F(CodeGenTest, CapturedConstFieldAssignError) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== Set テスト =====
+// ===== [contract] Set テスト =====
 
 TEST_F(CodeGenTest, SetCreateAndIn) {
     std::string src =
@@ -429,7 +433,7 @@ TEST_F(CodeGenTest, SetForIn) {
     EXPECT_EQ(runSource(src), "60\n");
 }
 
-// ===== Enum テスト =====
+// ===== [contract] Enum テスト =====
 
 TEST_F(CodeGenTest, EnumBasic) {
     std::string src =
@@ -509,7 +513,7 @@ TEST_F(CodeGenTest, EnumMultiple) {
     EXPECT_EQ(runSource(src), "Green\nLarge\n");
 }
 
-// ===== Match statement tests =====
+// ===== [contract] Match statement tests =====
 
 TEST_F(CodeGenTest, MatchEnumAllVariants) {
     std::string src =
@@ -601,7 +605,7 @@ TEST_F(CodeGenTest, MatchNegativeLiteral) {
     EXPECT_EQ(runSource(src), "neg one\n");
 }
 
-// ===== Union 型テスト =====
+// ===== [contract] Union 型テスト =====
 
 TEST_F(CodeGenTest, UnionLetInt) {
     std::string src =
@@ -673,7 +677,7 @@ TEST_F(CodeGenTest, UnionThreeTypes) {
     EXPECT_EQ(runSource(src), "3.14\n");
 }
 
-// ===== not in テスト =====
+// ===== [contract] not in テスト =====
 
 TEST_F(CodeGenTest, NotInSetTrue) {
     std::string src =
@@ -709,7 +713,7 @@ TEST_F(CodeGenTest, NotExprRegression) {
     EXPECT_EQ(runSource("x = not true\nprint(x)"), "false\n");
 }
 
-// ===== f-string tests =====
+// ===== [contract] f-string tests =====
 
 TEST_F(CodeGenTest, FStringBasic) {
     EXPECT_EQ(runSource("name = \"world\"\nprint(f\"Hello {name}\")"), "Hello world\n");
@@ -739,7 +743,7 @@ TEST_F(CodeGenTest, FStringBoolValue) {
     EXPECT_EQ(runSource("print(f\"flag = {true}\")"), "flag = true\n");
 }
 
-// ===== as cast tests =====
+// ===== [contract] as cast tests =====
 
 TEST_F(CodeGenTest, AsCastIntToFloat) {
     EXPECT_EQ(runSource("x = 42 as float\nprint(x)"), "42.0\n");
@@ -778,7 +782,7 @@ TEST_F(CodeGenTest, AsCastU8ToInt) {
     EXPECT_EQ(runSource("b: u8 = 200\nx = b as int\nprint(x)"), "200\n");
 }
 
-// ===== Error type tests =====
+// ===== [contract] Error type tests =====
 
 TEST_F(CodeGenTest, ErrorConstructor1Arg) {
     std::string src = R"(
@@ -814,7 +818,7 @@ print(e)
     EXPECT_EQ(runSource(src), "Error: test error (code: 42)\n");
 }
 
-// ===== Result type tests =====
+// ===== [contract] Result type tests =====
 
 TEST_F(CodeGenTest, ResultOkMatch) {
     std::string src = R"(
@@ -882,7 +886,7 @@ case divide(10, 0):
     EXPECT_EQ(runSource(src), "division by zero\n");
 }
 
-// ===== when OR pattern =====
+// ===== [contract] when OR pattern =====
 
 TEST_F(CodeGenTest, MatchOrPatternInt) {
     std::string src =
@@ -914,7 +918,7 @@ TEST_F(CodeGenTest, MatchOrPatternVariableError) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== Tuple patterns in case (#834) =====
+// ===== [contract] Tuple patterns in case (#834) =====
 
 TEST_F(CodeGenTest, TuplePatternArityMismatch) {
     // (int, int) subject matched with a 3-element pattern -> codegen error
@@ -940,7 +944,7 @@ TEST_F(CodeGenTest, TuplePatternNonTupleSubject) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== Record Pattern =====
+// ===== [contract] Record Pattern =====
 
 TEST_F(CodeGenTest, RecordPatternArityMismatch) {
     // Point has 2 fields; pattern uses 3 -> codegen error
@@ -1036,7 +1040,7 @@ TEST_F(CodeGenTest, RecordPatternSubjectTypeMismatch) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== enum ADT (associated data) =====
+// ===== [contract] enum ADT (associated data) =====
 
 TEST_F(CodeGenTest, EnumADTCreate) {
     std::string src =
@@ -1073,7 +1077,7 @@ TEST_F(CodeGenTest, EnumADTSingleField) {
     EXPECT_EQ(runSource(src), "42\n");
 }
 
-// ===== ADT enum equality (payload-aware) =====
+// ===== [contract] ADT enum equality (payload-aware) =====
 
 static const char *kShapeEnum =
     "enum Shape:\n"
@@ -1176,7 +1180,7 @@ TEST_F(CodeGenTest, EnumADTEqNestedPayload) {
         "true\nfalse\nfalse\ntrue\n");
 }
 
-// ===== Generic enum =====
+// ===== [contract] Generic enum =====
 
 TEST_F(CodeGenTest, GenericEnumBasic) {
     std::string src =
@@ -1196,7 +1200,7 @@ TEST_F(CodeGenTest, GenericEnumFloat) {
     EXPECT_EQ(runSource(src), "3.14\n");
 }
 
-// ===== Explicit enum values =====
+// ===== [contract] Explicit enum values =====
 
 TEST_F(CodeGenTest, EnumExplicitValuePrint) {
     std::string src =
@@ -1246,7 +1250,7 @@ TEST_F(CodeGenTest, EnumExplicitValueNegative) {
     EXPECT_EQ(runSource(src), "Cold\n");
 }
 
-// ===== r-string =====
+// ===== [contract] r-string =====
 
 TEST_F(CodeGenTest, RawStringPrint) {
     EXPECT_EQ(runSource(R"(print(r"\n"))"), "\\n\n");
@@ -1256,7 +1260,7 @@ TEST_F(CodeGenTest, RawStringConcat) {
     EXPECT_EQ(runSource(R"(print(r"\t" + "hello"))"), "\\thello\n");
 }
 
-// ===== test matcher: toNotEq =====
+// ===== [contract] test matcher: toNotEq =====
 
 TEST_F(CodeGenTest, ExpectToNotEq) {
     std::string src = withStdlibDirectiveDecls(
@@ -1269,7 +1273,7 @@ TEST_F(CodeGenTest, ExpectToNotEq) {
     EXPECT_NO_THROW(runTestSource(src));
 }
 
-// ===== test matcher: toBeSome =====
+// ===== [contract] test matcher: toBeSome =====
 
 TEST_F(CodeGenTest, ExpectToBeSome) {
     std::string src = withStdlibDirectiveDecls(
@@ -1283,7 +1287,7 @@ TEST_F(CodeGenTest, ExpectToBeSome) {
     EXPECT_NO_THROW(runTestSource(src));
 }
 
-// ===== test matcher: toContain =====
+// ===== [contract] test matcher: toContain =====
 
 TEST_F(CodeGenTest, ExpectToContainList) {
     std::string src = withStdlibDirectiveDecls(
@@ -1309,7 +1313,7 @@ TEST_F(CodeGenTest, ExpectToContainString) {
     EXPECT_NO_THROW(runTestSource(src));
 }
 
-// ===== test matcher: toMatch =====
+// ===== [contract] test matcher: toMatch =====
 
 TEST_F(CodeGenTest, ExpectToMatchLiteral) {
     std::string src = withStdlibDirectiveDecls(
@@ -1355,7 +1359,7 @@ TEST_F(CodeGenTest, ExpectToBeCloseToCustomDecimals) {
     EXPECT_NO_THROW(runTestSource(src));
 }
 
-// ===== toBeBetween / toBeOneOf (#1689) =====
+// ===== [contract] toBeBetween / toBeOneOf (#1689) =====
 
 TEST_F(CodeGenTest, ExpectToBeBetweenIntInside) {
     std::string src = withStdlibDirectiveDecls(
@@ -1539,7 +1543,7 @@ TEST_F(CodeGenTest, ExpectToNotContainRejectsListOfLists) {
     EXPECT_THROW(runTestSource(src), std::runtime_error);
 }
 
-// ===== Field assignment subtype coercion (#359) =====
+// ===== [contract] Field assignment subtype coercion (#359) =====
 
 TEST_F(CodeGenTest, FieldAssignSubtypeCoercion) {
     std::string src =
@@ -1557,7 +1561,7 @@ TEST_F(CodeGenTest, FieldAssignSubtypeCoercion) {
     EXPECT_EQ(runSource(src), "Rex\n4\n");
 }
 
-// ===== ? operator subtype coercion (#360) =====
+// ===== [contract] ? operator subtype coercion (#360) =====
 
 TEST_F(CodeGenTest, ErrorPropagateSubtypeCoercion) {
     std::string src =
@@ -1565,7 +1569,7 @@ TEST_F(CodeGenTest, ErrorPropagateSubtypeCoercion) {
     EXPECT_EQ(runSource(src), "fail\n");
 }
 
-// ===== Generic record bounds (#297) =====
+// ===== [contract] Generic record bounds (#297) =====
 
 TEST_F(CodeGenTest, GenericRecordBound) {
     std::string src =
@@ -1670,7 +1674,7 @@ TEST_F(CodeGenTest, GenericRecordBoundAliasRejectsNonSubtype) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== Tail Call Optimization (#214) =====
+// ===== [contract] Tail Call Optimization (#214) =====
 
 TEST_F(CodeGenTest, TailCallOptimization) {
     // Deep self-recursive tail call should not stack overflow
@@ -1702,7 +1706,7 @@ TEST_F(CodeGenTest, NonTailRecursionStillWorks) {
         "print(factorial(10))"), "3628800\n");
 }
 
-// ===== Mutual Recursion (Forward Function References) =====
+// ===== [contract] Mutual Recursion (Forward Function References) =====
 
 TEST_F(CodeGenTest, MutualRecursion) {
     EXPECT_EQ(runSource(
@@ -1754,9 +1758,7 @@ TEST_F(CodeGenTest, ForwardFunctionReference) {
         "print(caller(5))"), "11\n");
 }
 
-// ============================================================
-// #1157: Result coerce — PHI-static disc via if-expr both-branches Ok
-// ============================================================
+// ===== [regression #1157] Result coerce — PHI-static disc via if-expr both-branches Ok =====
 
 TEST_F(CodeGenTest, ResultCoerceIfBothBranchesOk) {
     // Both branches of the if-expr emit Ok (disc=1 statically through PHI).

--- a/tests/test_codegen_arc.cpp
+++ b/tests/test_codegen_arc.cpp
@@ -1,3 +1,7 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 #include "ry/ry_layout.hpp"
 #include <cstdlib>
@@ -11,10 +15,7 @@ extern "C" int64_t *__ry_arc_counter_address();
 extern "C" int64_t  __ry_runtime_internal_arc_live_count();
 extern "C" void    *__ry_arc_alloc_counted(int64_t total_size);
 extern "C" void     __ry_arc_free_counted(void *header_ptr);
-// ============================================================
-//  ARC Header layout tests (pure C++ — validates the memory
-//  layout contract that codegen_arc.cpp relies on)
-// ============================================================
+// ===== [internal] ARC Header layout (pure C++ — validates the memory layout contract that codegen_arc.cpp relies on) =====
 
 namespace {
 
@@ -63,7 +64,7 @@ bool arcRelease(void *header) {
 
 } // anonymous namespace
 
-// ===== Layout & allocation =====
+// ===== [internal] Layout & allocation =====
 
 TEST(ArcInfraTest, HeaderSize) {
     EXPECT_EQ(sizeof(ArcHeader), 16u);
@@ -121,7 +122,7 @@ TEST(ArcInfraTest, SingleOwnerRelease) {
     EXPECT_TRUE(arcRelease(p));
 }
 
-// ===== Codegen structural tests =====
+// ===== [internal] Codegen structural tests =====
 // Verify that the ArcHeader LLVM type is created correctly
 // by compiling a trivial program and inspecting the CodeGen state.
 
@@ -134,7 +135,7 @@ TEST_F(CodeGenTest, ArcHeaderTypeExists) {
     });
 }
 
-// ===== Data integrity through ARC header =====
+// ===== [internal] Data integrity through ARC header =====
 
 TEST(ArcInfraTest, DataIntegrityThroughHeader) {
     // Allocate, write structured data after header, verify it survives retain/release
@@ -157,7 +158,7 @@ TEST(ArcInfraTest, DataIntegrityThroughHeader) {
     EXPECT_TRUE(arcRelease(p)); // strong = 0 → freed
 }
 
-// ===== Immortal sentinel tests =====
+// ===== [internal] Immortal sentinel tests =====
 
 TEST(ArcInfraTest, ImmortalSentinelSkipsRetain) {
     void *p = arcAlloc(16);
@@ -207,7 +208,7 @@ TEST(ArcInfraTest, ArcCounterAddressMatchesRuntimeCount) {
     EXPECT_EQ(__ry_runtime_internal_arc_live_count(), before);
 }
 
-// ===== Integration: collection literals under ARC (functional) =====
+// ===== [contract] Integration: collection literals under ARC (functional) =====
 
 TEST_F(CodeGenTest, ListLiteralProducesCorrectLength) {
     EXPECT_EQ(runSource("x = [1, 2, 3]\nprint(len(x))"), "3\n");

--- a/tests/test_codegen_call_json5_reject.cpp
+++ b/tests/test_codegen_call_json5_reject.cpp
@@ -1,3 +1,8 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file tag: [regression #1941] (subprocess-based emitJson5Load type rejection).
+
 #include <gtest/gtest.h>
 #include <array>
 #include <cerrno>

--- a/tests/test_codegen_call_json_reject.cpp
+++ b/tests/test_codegen_call_json_reject.cpp
@@ -1,3 +1,8 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file tag: [regression #1941] (subprocess-based emitJsonLoad type rejection).
+
 #include <gtest/gtest.h>
 #include <array>
 #include <cerrno>

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -1,8 +1,12 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ===== リスト型テスト =====
+// ===== [contract] リスト型テスト =====
 
 TEST_F(CodeGenTest, ListBasics) {
     // ListCreateAndAccess
@@ -77,7 +81,7 @@ TEST_F(CodeGenTest, ListNegativeIndexOutOfBounds) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ===== UFCS コード生成テスト =====
+// ===== [contract] UFCS コード生成テスト =====
 
 TEST_F(CodeGenTest, UFCSIntLiteral) {
     std::string src =
@@ -119,7 +123,7 @@ TEST_F(CodeGenTest, UFCSWithStruct) {
     EXPECT_EQ(runSource(src), "42\n");
 }
 
-// ===== Map型テスト =====
+// ===== [contract] Map型テスト =====
 
 TEST_F(CodeGenTest, MapBasicOperations) {
     // MapCreateAndAccess
@@ -203,7 +207,7 @@ TEST_F(CodeGenTest, MapTypeMismatch) {
     EXPECT_THROW(runSource("m = {\"a\": 1, \"b\": 3.14}"), std::runtime_error);
 }
 
-// ===== 文字列メソッドテスト =====
+// ===== [contract] 文字列メソッドテスト =====
 
 TEST_F(CodeGenTest, StringLength) {
     // StringLen
@@ -501,7 +505,7 @@ TEST_F(CodeGenTest, StringReplace) {
     EXPECT_EQ(runSource("s = \"foo bar foo\"\nprint(s.replace(\"foo\", \"baz\"))"), "baz bar baz\n");
 }
 
-// ===== Phase 2: テキスト変換テスト =====
+// ===== [contract] Phase 2: テキスト変換テスト =====
 
 TEST_F(CodeGenTest, StringToUpper) {
     // ToUpperBasic
@@ -587,7 +591,7 @@ TEST_F(CodeGenTest, StringReverse) {
     EXPECT_EQ(runSource("s = \"abc\"\nprint(s.reverse())"), "cba\n");
 }
 
-// ===== Phase 3: List<str> 連携テスト =====
+// ===== [contract] Phase 3: List<str> 連携テスト =====
 
 TEST_F(CodeGenTest, SplitVariants) {
     // SplitBasic
@@ -693,7 +697,7 @@ TEST_F(CodeGenTest, JoinVariants) {
     }
 }
 
-// ===== 関数オーバーロードテスト =====
+// ===== [contract] 関数オーバーロードテスト =====
 
 TEST_F(CodeGenTest, OverloadBasicResolution) {
     // OverloadByArgCount
@@ -871,7 +875,7 @@ TEST_F(CodeGenTest, OverloadSpecialArgs) {
     }
 }
 
-// ===== Operator overloading =====
+// ===== [contract] Operator overloading =====
 
 TEST_F(CodeGenTest, OperatorOverloadStruct) {
     // OperatorOverloadStructPlus
@@ -952,7 +956,7 @@ TEST_F(CodeGenTest, OperatorOverloadStruct) {
     }
 }
 
-// ===== Compound assignment operator overloading =====
+// ===== [contract] Compound assignment operator overloading =====
 
 TEST_F(CodeGenTest, CompoundAssignWithOperatorPlusEq) {
     // operator+= defined → called directly
@@ -1041,7 +1045,7 @@ TEST_F(CodeGenTest, IncrementDecrementStillWorks) {
     EXPECT_EQ(runSource(src), "6\n");
 }
 
-// ===== List element assignment =====
+// ===== [contract] List element assignment =====
 
 TEST_F(CodeGenTest, ListIndexAssignTypes) {
     // ListIndexAssignInt
@@ -1105,7 +1109,7 @@ TEST_F(CodeGenTest, ListIndexAssignNegativeOOB) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ===== For loop =====
+// ===== [contract] For loop =====
 
 TEST_F(CodeGenTest, ForLoopVariants) {
     // ForLoopBasic
@@ -1158,7 +1162,7 @@ TEST_F(CodeGenTest, ForLoopVariants) {
     }
 }
 
-// ===== Compound assignment =====
+// ===== [contract] Compound assignment =====
 
 TEST_F(CodeGenTest, CompoundAssignBasic) {
     // CompoundAssignPlus
@@ -1199,7 +1203,7 @@ TEST_F(CodeGenTest, CompoundAssignExtended) {
     EXPECT_EQ(runSource("x = 16\nx >>= 2\nprint(x)"), "4\n");
 }
 
-// ===== in / not in: List・Map対応 =====
+// ===== [contract] in / not in: List・Map対応 =====
 
 TEST_F(CodeGenTest, InNotInOperators) {
     // InListInt
@@ -1281,7 +1285,7 @@ TEST_F(CodeGenTest, InRejectsPointerElements) {
         notInErr);
 }
 
-// ===== List append / pop / reverse / slice =====
+// ===== [contract] List append / pop / reverse / slice =====
 
 TEST_F(CodeGenTest, ListAppendVariants) {
     // ListAppend
@@ -1356,7 +1360,7 @@ TEST_F(CodeGenTest, ListSliceNegativeIndex) {
     EXPECT_EQ(runSource("print(slice([1, 2, 3], -2, -3))"), "[]\n");
 }
 
-// ===== filter テスト =====
+// ===== [contract] filter テスト =====
 
 TEST_F(CodeGenTest, FilterBasics) {
     // FilterIntBasic
@@ -1432,7 +1436,7 @@ TEST_F(CodeGenTest, FilterUFCSAndErrors) {
     ), std::runtime_error);
 }
 
-// ===== map テスト =====
+// ===== [contract] map テスト =====
 
 TEST_F(CodeGenTest, MapBasics) {
     // MapIntToInt
@@ -1498,7 +1502,7 @@ TEST_F(CodeGenTest, MapClosureAndUntyped) {
     }
 }
 
-// ===== filter + map チェーンテスト =====
+// ===== [contract] filter + map チェーンテスト =====
 
 TEST_F(CodeGenTest, FilterMapChains) {
     // FilterThenMap
@@ -1527,7 +1531,7 @@ TEST_F(CodeGenTest, FilterMapChains) {
     }
 }
 
-// ===== sort テスト =====
+// ===== [contract] sort テスト =====
 
 TEST_F(CodeGenTest, SortBasics) {
     // SortIntAsc
@@ -1616,7 +1620,7 @@ TEST_F(CodeGenTest, SortUFCSAndComparator) {
     }
 }
 
-// ===== filter + map + sort 全チェーンテスト =====
+// ===== [contract] filter + map + sort 全チェーンテスト =====
 
 TEST_F(CodeGenTest, SortChains) {
     // FilterMapSort
@@ -1645,7 +1649,7 @@ TEST_F(CodeGenTest, SortChains) {
     }
 }
 
-// ===== TimSort / Hybrid Sort テスト =====
+// ===== [contract] TimSort / Hybrid Sort テスト =====
 
 TEST_F(CodeGenTest, SortLargeAndTimSort) {
     // SortLargerList
@@ -1717,7 +1721,7 @@ TEST_F(CodeGenTest, SortStability) {
     }
 }
 
-// ===== range() ステップ対応 =====
+// ===== [contract] range() ステップ対応 =====
 
 TEST_F(CodeGenTest, RangeStepVariants) {
     // RangeStep
@@ -1757,7 +1761,7 @@ TEST_F(CodeGenTest, RangeStepVariants) {
     }
 }
 
-// ===== reduce / fold =====
+// ===== [contract] reduce / fold =====
 
 TEST_F(CodeGenTest, ReduceVariants) {
     // ReduceBasic
@@ -1824,7 +1828,7 @@ TEST_F(CodeGenTest, FoldVariants) {
     }
 }
 
-// ===== keys / values / items =====
+// ===== [contract] keys / values / items =====
 
 TEST_F(CodeGenTest, MapKeys) {
     std::string src =
@@ -1842,7 +1846,7 @@ TEST_F(CodeGenTest, MapValues) {
     EXPECT_EQ(runSource(src), "2\n");
 }
 
-// ===== any / all =====
+// ===== [contract] any / all =====
 
 TEST_F(CodeGenTest, AnyAllPredicates) {
     // AnyTrue
@@ -1875,7 +1879,7 @@ TEST_F(CodeGenTest, AnyAllPredicates) {
     }
 }
 
-// ===== sum / min / max =====
+// ===== [contract] sum / min / max =====
 
 TEST_F(CodeGenTest, SumMinMax) {
     // SumInt
@@ -1913,7 +1917,7 @@ TEST_F(CodeGenTest, MaxEmptyListError) {
                 "runtime error: max\\(\\) on empty list");
 }
 
-// ----- #1886: variadic scalar form (in addition to the list form above) -----
+// ===== [contract] #1886 variadic scalar form (in addition to the list form above) =====
 
 TEST_F(CodeGenTest, SumVariadicInts) {
     EXPECT_EQ(runSource("print(sum(3, 5))"), "8\n");
@@ -1974,7 +1978,7 @@ TEST_F(CodeGenTest, MinMaxRejectU8Variadic) {
     expectCompileError("print(max(1u8, 2u8))", "int or float");
 }
 
-// ===== enumerate / zip =====
+// ===== [contract] enumerate / zip =====
 
 TEST_F(CodeGenTest, EnumerateBasic) {
     std::string src =
@@ -1993,7 +1997,7 @@ TEST_F(CodeGenTest, ZipBasic) {
     EXPECT_EQ(runSource(src), "3\n");
 }
 
-// ===== first / last / isEmpty =====
+// ===== [contract] first / last / isEmpty =====
 
 TEST_F(CodeGenTest, FirstLastIsEmpty) {
     // FirstBasic
@@ -2012,7 +2016,7 @@ TEST_F(CodeGenTest, FirstLastIsEmpty) {
     }
 }
 
-// ===== insert(list, i, val) =====
+// ===== [contract] insert(list, i, val) =====
 
 TEST_F(CodeGenTest, ListInsert) {
     std::string src =
@@ -2025,7 +2029,7 @@ TEST_F(CodeGenTest, ListInsert) {
     EXPECT_EQ(runSource(src), "1\n2\n3\n4\n");
 }
 
-// ===== removeAt(list, i) =====
+// ===== [contract] removeAt(list, i) =====
 
 TEST_F(CodeGenTest, ListRemoveAt) {
     std::string src =
@@ -2038,7 +2042,7 @@ TEST_F(CodeGenTest, ListRemoveAt) {
     EXPECT_EQ(runSource(src), "20\n2\n10\n30\n");
 }
 
-// ===== items(map) =====
+// ===== [contract] items(map) =====
 
 TEST_F(CodeGenTest, MapItems) {
     std::string src =
@@ -2048,7 +2052,7 @@ TEST_F(CodeGenTest, MapItems) {
     EXPECT_EQ(runSource(src), "1\n");
 }
 
-// ===== get(map, key, default) =====
+// ===== [contract] get(map, key, default) =====
 
 TEST_F(CodeGenTest, MapGetWithDefault) {
     std::string src =
@@ -2066,7 +2070,7 @@ TEST_F(CodeGenTest, MapGetTwoArgOption) {
     EXPECT_EQ(runSource(src), "Some(10)\nNone\n");
 }
 
-// ===== remove(map, key) =====
+// ===== [contract] remove(map, key) =====
 
 TEST_F(CodeGenTest, MapRemove) {
     std::string src =
@@ -2076,7 +2080,7 @@ TEST_F(CodeGenTest, MapRemove) {
     EXPECT_EQ(runSource(src), "1\n");
 }
 
-// ===== Set operations =====
+// ===== [contract] Set operations =====
 
 TEST_F(CodeGenTest, SetOperations) {
     // SetUnion
@@ -2135,7 +2139,7 @@ TEST_F(CodeGenTest, SetOperations) {
     }
 }
 
-// ===== remove(list, val) テスト =====
+// ===== [contract] remove(list, val) テスト =====
 
 TEST_F(CodeGenTest, ListRemoveByType) {
     // ListRemoveInt
@@ -2231,7 +2235,7 @@ TEST_F(CodeGenTest, RemoveRejectsPointerElements) {
         err);
 }
 
-// ===== distinct(list) テスト =====
+// ===== [contract] distinct(list) テスト =====
 
 TEST_F(CodeGenTest, DistinctVariants) {
     // DistinctInt
@@ -2281,7 +2285,7 @@ TEST_F(CodeGenTest, DistinctRejectsPointerElements) {
         err);
 }
 
-// ===== merge(map1, map2) テスト =====
+// ===== [contract] merge(map1, map2) テスト =====
 
 TEST_F(CodeGenTest, MapMergeVariants) {
     // MergeNoOverlap
@@ -2334,7 +2338,7 @@ TEST_F(CodeGenTest, MapMergeVariants) {
     }
 }
 
-// ===== flat(list) テスト =====
+// ===== [contract] flat(list) テスト =====
 
 TEST_F(CodeGenTest, FlattenVariants) {
     // FlattenIntLists
@@ -2362,7 +2366,7 @@ TEST_F(CodeGenTest, FlattenVariants) {
     }
 }
 
-// ===== for tuple destructuring =====
+// ===== [contract] for tuple destructuring =====
 
 TEST_F(CodeGenTest, ForTupleDestructuring) {
     // ForEnumerateDestructure
@@ -2466,7 +2470,7 @@ TEST_F(CodeGenTest, ForThreeVarCountMismatch) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== operator[] / operator[]= / operator in =====
+// ===== [contract] operator[] / operator[]= / operator in =====
 
 TEST_F(CodeGenTest, OperatorSubscriptReadSingleIndex) {
     std::string src =
@@ -2658,7 +2662,7 @@ TEST_F(CodeGenTest, OperatorAsGenericOptionTarget) {
     EXPECT_EQ(runSource(src), "42\n");
 }
 
-// ===== Bounds checking tests =====
+// ===== [contract] Bounds checking tests =====
 
 TEST_F(CodeGenTest, ListNegativeIndexWrapAll) {
     // -1 → last, -2 → second to last, -3 → first
@@ -2766,7 +2770,7 @@ TEST_F(CodeGenTest, RemoveAtNegativeIndexOOB) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ===== Discarded collection operation results (ExprStmt) =====
+// ===== [contract] Discarded collection operation results (ExprStmt) =====
 
 TEST_F(CodeGenTest, DiscardedCollectionResults) {
     // Collection operation results used as bare expression statements
@@ -2789,7 +2793,7 @@ TEST_F(CodeGenTest, DiscardedCollectionResults) {
         "print(len(xs))"), "3\n");
 }
 
-// ===== Collection equality: compile-time rejection of unsupported element types =====
+// ===== [contract] Collection equality: compile-time rejection of unsupported element types =====
 
 // List<function> == List<function> must be rejected at compile time.
 // Regression for the list_elem_fn_type_info guard added in #736.

--- a/tests/test_codegen_contract.cpp
+++ b/tests/test_codegen_contract.cpp
@@ -1,8 +1,14 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Note: "Design by Contract" 言語機能 (require / ensure / invariant) を対象とするため
+// section title 内の "contract" は DbC を指す。taxonomy tag の [contract] とは別概念。
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ===== require (precondition) tests =====
+// ===== [contract] Design by Contract: require (precondition) tests =====
 
 TEST_F(CodeGenTest, RequireSatisfied) {
     std::string src =
@@ -46,7 +52,7 @@ TEST_F(CodeGenTest, RequireMultipleConditionsSecondFails) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ===== ensure (postcondition) with variable binding =====
+// ===== [contract] Design by Contract: ensure (postcondition) with variable binding =====
 
 TEST_F(CodeGenTest, EnsureSatisfied) {
     // `abs` was carved out to emitBuiltinMath (#2340) so it is now reserved.
@@ -107,7 +113,7 @@ TEST_F(CodeGenTest, RequireAndEnsureCombined) {
     EXPECT_EQ(runSource(src), "600\n");
 }
 
-// ===== invariant tests =====
+// ===== [contract] Design by Contract: invariant tests =====
 
 TEST_F(CodeGenTest, InvariantSatisfiedOnConstruction) {
     std::string src =
@@ -174,7 +180,7 @@ TEST_F(CodeGenTest, InvariantViolationMessageIncludesRecordName) {
                 "Contract violation: invariant failed for Account");
 }
 
-// ===== Inherited invariant tests =====
+// ===== [contract] Design by Contract: Inherited invariant tests =====
 
 TEST_F(CodeGenTest, InheritedInvariantSatisfied) {
     std::string src =
@@ -231,7 +237,7 @@ TEST_F(CodeGenTest, DeepInheritedInvariantViolated) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ===== Nested function with contract: FnScope protects contract state =====
+// ===== [contract] Design by Contract: Nested function — FnScope protects contract state =====
 
 TEST_F(CodeGenTest, NestedFnWithEnsurePreservesOuterContract) {
     std::string src =
@@ -261,7 +267,7 @@ TEST_F(CodeGenTest, NestedFnWithEnsureViolation) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ===== Tuple destructuring in ensure =====
+// ===== [contract] Design by Contract: Tuple destructuring in ensure =====
 
 TEST_F(CodeGenTest, EnsureTupleDestructuring) {
     std::string src =
@@ -276,7 +282,7 @@ TEST_F(CodeGenTest, EnsureTupleDestructuring) {
     EXPECT_EQ(runSource(src), "3\n1\n");
 }
 
-// ===== ensure on Unit function is rejected =====
+// ===== [contract] Design by Contract: ensure on Unit function is rejected =====
 
 TEST_F(CodeGenTest, EnsureOnUnitFunctionRejected) {
     std::string src =
@@ -287,7 +293,7 @@ TEST_F(CodeGenTest, EnsureOnUnitFunctionRejected) {
     EXPECT_THROW(runSource(src), std::exception);
 }
 
-// ===== result and old as normal identifiers =====
+// ===== [contract] Design by Contract: result and old as normal identifiers =====
 
 TEST_F(CodeGenTest, ResultAsIdentifier) {
     std::string src =

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1,3 +1,7 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 #include "ry/runtime/native/io.hpp"
 #include <cstring>
@@ -57,7 +61,7 @@ static std::string withCoreAndTestingDirectiveDecls(const char *src) {
 
 class DirectiveTest : public CodeGenTest {};
 
-// --- ry::util::deriveRuntimeFnName tests ---
+// ===== [internal] ry::util::deriveRuntimeFnName tests =====
 
 TEST(NativeFnNaming, PackageFunction) {
     EXPECT_EQ(ry::util::deriveRuntimeFnName("base64", "encode"), "__ry_base64_encode");
@@ -86,7 +90,7 @@ TEST(NativeFnNaming, ErrorGetter) {
     EXPECT_EQ(ry::util::deriveRuntimeFnName("io", "get_last_error"), "__ry_io_get_last_error");
 }
 
-// --- NativeFnSignature registry tests ---
+// ===== [internal] NativeFnSignature registry tests =====
 
 TEST(NativeFnSigs, RegistryPopulatedAndKeyed) {
     // Compile source with @native declarations and verify the registry
@@ -571,7 +575,7 @@ TEST_F(DirectiveTest, DirectiveOnInvalidTarget) {
     }, std::runtime_error);
 }
 
-// ===== @native fn tests =====
+// ===== [contract] @native fn tests =====
 
 // 12. @native fn declaration - builtin function still works
 TEST_F(DirectiveTest, NativeFnDeclaration) {
@@ -623,7 +627,7 @@ TEST_F(DirectiveTest, MultipleNativeFnDeclarations) {
     EXPECT_EQ(output, "true\nWORLD\n");
 }
 
-// ===== @native fn type signature validation =====
+// ===== [contract] @native fn type signature validation =====
 
 TEST_F(DirectiveTest, NativeFnTypeCheckPass) {
     std::string output = runSource(
@@ -680,7 +684,7 @@ TEST_F(DirectiveTest, CoreStrDeclarationsWork) {
     EXPECT_EQ(output, "HELLO\ntrue\ntrue\n");
 }
 
-// ===== @native("libname") directive syntax tests =====
+// ===== [contract] @native("libname") directive syntax tests =====
 
 TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchForStdlibName) {
     // A user-declared @native("base64") fn encode(str) → str (not imported
@@ -730,7 +734,7 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchFallsThrough) {
     EXPECT_EQ(output, "int:42\n");
 }
 
-// ===== @native("libname") generic dispatch tests =====
+// ===== [contract] @native("libname") generic dispatch tests =====
 
 TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchEndToEnd) {
     // This test exercises the FULL generic dispatch path with a symbol
@@ -833,7 +837,7 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchResultBool) {
     EXPECT_EQ(output, "true\n");
 }
 
-// ===== @inline tests =====
+// ===== [contract] @inline tests =====
 
 TEST_F(DirectiveTest, InlineDefault) {
     std::string output = runSource(withCoreAndTestingDirectiveDecls(
@@ -918,7 +922,7 @@ TEST_F(DirectiveTest, InlineRecursive) {
     EXPECT_EQ(output, "120\n");
 }
 
-// ===== Generalized directive invocation syntax (#663) =====
+// ===== [contract] Generalized directive invocation syntax (#663) =====
 
 // @it("description") is parseable on a function declaration (AST check)
 TEST(DirectiveSyntax, ItDirectiveParsedOnFunction) {
@@ -1038,7 +1042,7 @@ TEST(DirectiveSyntax, MixedPositionalAndNamedArgsInOneDirective) {
     EXPECT_EQ(numExpr->value, 50);
 }
 
-// ===== @it / @describe directive codegen tests (#634) =====
+// ===== [contract] @it / @describe directive codegen tests (#634) =====
 
 // Basic @it on a named function compiles and runs as a test case
 TEST_F(DirectiveTest, ItDirectiveBasicCodegen) {
@@ -1432,7 +1436,7 @@ TEST(DirectiveSyntax, UnknownDirectiveParseSucceeds) {
     ASSERT_EQ((*fn)->directives[0].name, "unknown_directive");
 }
 
-// ===== @directive definition syntax (#708) — codegen smoke tests =====
+// ===== [contract] @directive definition syntax (#708) — codegen smoke tests =====
 
 // Codegen accepts a bare @directive definition (no IR is emitted; the stmt is a no-op).
 TEST_F(DirectiveTest, DirectiveDefCodegenSmokeBareDefinition) {
@@ -1469,7 +1473,7 @@ TEST_F(DirectiveTest, DirectiveDefCodegenSmokeMultiple) {
     EXPECT_EQ(output, "ok\n");
 }
 
-// ===== @directive registry & validation tests =====
+// ===== [contract] @directive registry & validation tests =====
 
 // A `@directive` definition registers itself in the per-program user registry
 // and a subsequent application of `@<name>(...)` passes validation.
@@ -1756,7 +1760,7 @@ TEST_F(DirectiveTest, BareDescribeRejectedWithoutTestingImport) {
     );
 }
 
-// ===== #1425: silent no-op when user-defined directive applied outside target=[...] =====
+// ===== [contract] silent no-op when user-defined directive applied outside target=[...] (#1425) =====
 //
 // Issue #1425 resolves user-defined directive target-mismatch behavior to
 // silent no-op: the directive's effect (future metadata/hooks) is suppressed,
@@ -1947,7 +1951,7 @@ TEST_F(DirectiveTest, TargetMatchStillValidatesArgs) {
     );
 }
 
-// ===== @public directive tests (#1545) =====
+// ===== [contract] @public directive tests (#1545) =====
 // Parser/registry-level acceptance only — visibility semantics are deferred
 // to #1544. The annotation is inert: codegen passes through with no effect.
 
@@ -1995,7 +1999,7 @@ TEST_F(DirectiveTest, PublicDirectiveRejectsArgs) {
     }, std::runtime_error);
 }
 
-// ===== #1687: @skip / @only / @todo test-selection directives =====
+// ===== [contract] @skip / @only / @todo test-selection directives (#1687) =====
 
 // Positive cases that must continue to parse and compile cleanly.
 TEST_F(DirectiveTest, SkipOnItCompiles) {
@@ -2133,9 +2137,7 @@ TEST_F(DirectiveTest, ImplicitSkipValidatesBody) {
     )), std::runtime_error);
 }
 
-// ============================================================
-// #1688: @timeout(ms) directive rejection branches
-// ============================================================
+// ===== [contract] @timeout(ms) directive rejection branches (#1688) =====
 
 TEST_F(DirectiveTest, TimeoutZeroIsRejected) {
     try {
@@ -2299,12 +2301,9 @@ TEST_F(DirectiveTest, TimeoutLargeValueAccepted) {
     )));
 }
 
-// ============================================================
-// #1686: lifecycle hook directives
-//   @beforeEach / @afterEach / @beforeAll / @afterAll
-// ============================================================
+// ===== [contract] lifecycle hook directives @beforeEach / @afterEach / @beforeAll / @afterAll (#1686) =====
 
-// --- Acceptance: declared at file top level (#1780) ---
+// ===== [contract] Acceptance: declared at file top level (#1780) =====
 //
 // Before #1780 these were rejection tests for "must be declared inside an
 // @describe block". File-top-level hooks now wrap every test in the file,
@@ -2344,7 +2343,7 @@ TEST_F(DirectiveTest, AfterAllAcceptedAtFileTop) {
     )));
 }
 
-// --- Rejection: duplicate hook of the same kind at file level (#1780) ---
+// ===== [contract] Rejection: duplicate hook of the same kind at file level (#1780) =====
 
 TEST_F(DirectiveTest, DuplicateBeforeAllAtFileTopRejected) {
     try {
@@ -2383,7 +2382,7 @@ TEST_F(DirectiveTest, DuplicateBeforeEachAtFileTopRejected) {
     }
 }
 
-// --- Rejection: file-level @beforeEach + @each @it (#1780 + #1686 reuse) ---
+// ===== [contract] Rejection: file-level @beforeEach + @each @it (#1780 + #1686 reuse) =====
 
 TEST_F(DirectiveTest, FileBeforeEachWithEachItRejected) {
     try {
@@ -2423,7 +2422,7 @@ TEST_F(DirectiveTest, FileBeforeEachWithPropertyItRejected) {
     }
 }
 
-// --- Rejection: parameters ---
+// ===== [contract] Rejection: parameters =====
 
 TEST_F(DirectiveTest, BeforeEachWithParameterRejected) {
     try {
@@ -2459,7 +2458,7 @@ TEST_F(DirectiveTest, AfterAllWithParameterRejected) {
     }
 }
 
-// --- Rejection: return type annotation ---
+// ===== [contract] Rejection: return type annotation =====
 
 TEST_F(DirectiveTest, BeforeAllWithReturnTypeRejected) {
     try {
@@ -2495,7 +2494,7 @@ TEST_F(DirectiveTest, AfterEachWithReturnTypeRejected) {
     }
 }
 
-// --- Rejection: async ---
+// ===== [contract] Rejection: async =====
 
 TEST_F(DirectiveTest, BeforeEachAsyncRejected) {
     try {
@@ -2514,7 +2513,7 @@ TEST_F(DirectiveTest, BeforeEachAsyncRejected) {
     }
 }
 
-// --- Rejection: generic ---
+// ===== [contract] Rejection: generic =====
 
 TEST_F(DirectiveTest, AfterAllGenericRejected) {
     try {
@@ -2533,7 +2532,7 @@ TEST_F(DirectiveTest, AfterAllGenericRejected) {
     }
 }
 
-// --- Rejection: duplicate hook in same @describe ---
+// ===== [contract] Rejection: duplicate hook in same @describe =====
 
 TEST_F(DirectiveTest, DuplicateBeforeEachInDescribeRejected) {
     try {
@@ -2575,7 +2574,7 @@ TEST_F(DirectiveTest, DuplicateBeforeAllInDescribeRejected) {
     }
 }
 
-// --- Rejection: combinations with other test directives ---
+// ===== [contract] Rejection: combinations with other test directives =====
 
 TEST_F(DirectiveTest, BeforeEachWithItRejected) {
     try {
@@ -2649,7 +2648,7 @@ TEST_F(DirectiveTest, BeforeEachWithAfterEachOnSameFnRejected) {
     }
 }
 
-// --- Rejection: hooks + @each / @property on the wrapped @it ---
+// ===== [contract] Rejection: hooks + @each / @property on the wrapped @it =====
 
 TEST_F(DirectiveTest, BeforeEachActiveBlocksEachIt) {
     // @beforeEach is active when an @each @it is encountered → reject.
@@ -2673,7 +2672,7 @@ TEST_F(DirectiveTest, BeforeEachActiveBlocksEachIt) {
     }
 }
 
-// --- Rejection: hook body containing declaration-like statements ---
+// ===== [contract] Rejection: hook body containing declaration-like statements =====
 
 TEST_F(DirectiveTest, BeforeEachBodyWithFnDeclarationRejected) {
     try {
@@ -2783,7 +2782,7 @@ TEST_F(DirectiveTest, AfterAllBodyWithReturnInCaseRejected) {
     }
 }
 
-// --- Acceptance: single hook inside @describe compiles ---
+// ===== [contract] Acceptance: single hook inside @describe compiles =====
 
 TEST_F(DirectiveTest, BeforeEachAcceptedInDescribe) {
     ASSERT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
@@ -2841,7 +2840,7 @@ TEST_F(DirectiveTest, AfterAllAcceptedInDescribe) {
     )));
 }
 
-// --- Acceptance: all 4 hooks together compile ---
+// ===== [contract] Acceptance: all 4 hooks together compile =====
 
 TEST_F(DirectiveTest, AllFourHooksAcceptedInDescribe) {
     ASSERT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
@@ -2866,7 +2865,7 @@ TEST_F(DirectiveTest, AllFourHooksAcceptedInDescribe) {
     )));
 }
 
-// --- Acceptance: @beforeAll position independent of source position ---
+// ===== [contract] Acceptance: @beforeAll position independent of source position =====
 
 TEST_F(DirectiveTest, BeforeAllAfterItStillAccepted) {
     // @beforeAll declared AFTER the @it should still compile — the
@@ -2884,7 +2883,7 @@ TEST_F(DirectiveTest, BeforeAllAfterItStillAccepted) {
     )));
 }
 
-// --- Execution: file @afterAll body actually runs after the last @it (#1780) ---
+// ===== [contract] Execution: file @afterAll body actually runs after the last @it (#1780) =====
 //
 // Ry assertions inside an @it cannot observe @afterAll because it fires AFTER
 // the last test body completes. Instead capture stdout and assert the
@@ -2919,7 +2918,7 @@ TEST_F(DirectiveTest, FileAfterAllBodyActuallyRunsAfterLastIt) {
         << "file @afterAll must run BEFORE the test summary: " << output;
 }
 
-// --- Execution: full 9-step ordering across file + describe hooks (#1780) ---
+// ===== [contract] Execution: full 9-step ordering across file + describe hooks (#1780) =====
 //
 // Issue #1780 specifies a 9-step execution order combining file-level and
 // describe-level hooks. Steps 1-7 are observable from inside an @it body
@@ -2978,8 +2977,7 @@ TEST_F(DirectiveTest, FullNineStepCascadeOrdering) {
     }
 }
 
-// --- Regression guards for #2235 (refactor: emit @it as ordinary fns
-// + synthesize sequential driver main) ---
+// ===== [regression #2235] Regression guards for refactor: emit @it as ordinary fns + synthesize sequential driver main =====
 //
 // The refactor splits emitItDirective / emitDescribeDirective into "fn
 // emission" and "driver fragment synthesis" phases, and extracts the
@@ -3036,7 +3034,7 @@ TEST_F(DirectiveTest, DescribeBeforeEachRunsBeforeItBody) {
         << output;
 }
 
-// ===== @doc directive tests (#1844) =====
+// ===== [contract] @doc directive tests (#1844) =====
 
 // @doc on a function — accepts a single string positional argument and the
 // declaration compiles without effect on emitted IR (metadata-only).

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -1,10 +1,12 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ============================================================
-// fail(msg) marks current test as failed with message
-// ============================================================
+// ===== [contract] fail(msg) marks current test as failed with message =====
 
 TEST_F(CodeGenTest, FailWithMessage) {
     EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
@@ -16,9 +18,7 @@ TEST_F(CodeGenTest, FailWithMessage) {
     )), "fail helper\n    \033[31mline 37: intentional failure\033[0m\n  \033[31m- marks test as failed\033[0m\n\n0 passed, 1 failed, 0 skipped, 0 todo\n");
 }
 
-// ============================================================
-// fail() with no argument uses generic message
-// ============================================================
+// ===== [contract] fail() with no argument uses generic message =====
 
 TEST_F(CodeGenTest, FailWithoutMessage) {
     EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
@@ -30,9 +30,7 @@ TEST_F(CodeGenTest, FailWithoutMessage) {
     )), "fail bare\n    \033[31mline 37: test failed\033[0m\n  \033[31m- fails generically\033[0m\n\n0 passed, 1 failed, 0 skipped, 0 todo\n");
 }
 
-// ============================================================
-// fail() outside test mode is rejected at compile time
-// ============================================================
+// ===== [contract] fail() outside test mode is rejected at compile time =====
 
 TEST_F(CodeGenTest, FailOutsideTestModeIsRejected) {
     EXPECT_THROW(runSource(
@@ -40,15 +38,12 @@ TEST_F(CodeGenTest, FailOutsideTestModeIsRejected) {
     ), std::runtime_error);
 }
 
-// ============================================================
-// Diagnostic precedence: when a call is made outside test mode
-// AND without `from testing import ...`, the "only allowed in
-// test mode" error must win over the missing-import error
-// (#715). This pins the order of the two checks at every site:
-// the `!test_mode_` guard fires first, the import guard second.
-// Use `runSource` (test_mode = false, no import injection) so
-// both conditions are simultaneously violated.
-// ============================================================
+// ===== [contract] Diagnostic precedence: only-allowed-in-test-mode wins over missing-import (#715) =====
+// When a call is made outside test mode AND without `from testing import ...`,
+// the "only allowed in test mode" error must win over the missing-import error.
+// This pins the order of the two checks at every site: the `!test_mode_` guard
+// fires first, the import guard second. Use `runSource` (test_mode = false, no
+// import injection) so both conditions are simultaneously violated.
 
 TEST_F(CodeGenTest, ExpectOutsideTestModeWinsOverImportCheck) {
     try {
@@ -63,20 +58,16 @@ TEST_F(CodeGenTest, ExpectOutsideTestModeWinsOverImportCheck) {
     }
 }
 
-// ============================================================
-// Testing intrinsics (expect / mock / fail) require the matching
-// `from testing import <name>`. Without it codegen must reject the
-// use even when running in test mode (#715).
-// `runTestSourceNoTestingImports` is the only fixture that does
-// not auto-inject the imports.
+// ===== [contract] Testing intrinsics (expect / mock / fail) require matching `from testing import` (#715) =====
+// Without the import, codegen must reject the use even when running in test mode.
+// `runTestSourceNoTestingImports` is the only fixture that does not auto-inject
+// the imports.
 //
-// Note: as of #722, `verify` is no longer a compiler-recognized
-// intrinsic — it lives as an ordinary `@public fn verify` in
-// `share/std/testing/testing.ry`. Calling `verify` without the
-// import now fails with the generic `undefined function: verify`
-// path rather than the import-enforcement diagnostic, so it is
-// not covered here.
-// ============================================================
+// Note: as of #722, `verify` is no longer a compiler-recognized intrinsic — it
+// lives as an ordinary `@public fn verify` in `share/std/testing/testing.ry`.
+// Calling `verify` without the import now fails with the generic
+// `undefined function: verify` path rather than the import-enforcement
+// diagnostic, so it is not covered here.
 
 TEST_F(CodeGenTest, ExpectRequiresTestingImport) {
     try {
@@ -146,16 +137,14 @@ TEST_F(CodeGenTest, FailRejectsListMessage) {
     }
 }
 
-// ============================================================
-// `@it` / `@describe` directives are declared in
-// `share/std/testing/testing.ry`. Without `from testing import it,
-// describe`, the directive declarations never enter
-// `user_directive_registry_`, so codegen rejects them via the general
-// `@directive` mechanism with `unknown directive '@<name>'` (#721).
-// `withStdlibDirectiveDecls` is intentionally NOT applied so the
-// rejection path mirrors what real user code sees (the only legal way
-// to use `@it` / `@describe` is via the testing import).
-// ============================================================
+// ===== [contract] @it / @describe rejected as unknown directive without testing import (#721) =====
+// `@it` / `@describe` directives are declared in `share/std/testing/testing.ry`.
+// Without `from testing import it, describe`, the directive declarations never
+// enter `user_directive_registry_`, so codegen rejects them via the general
+// `@directive` mechanism with `unknown directive '@<name>'`.
+// `withStdlibDirectiveDecls` is intentionally NOT applied so the rejection path
+// mirrors what real user code sees (the only legal way to use `@it` /
+// `@describe` is via the testing import).
 
 TEST_F(CodeGenTest, ItRejectedAsUnknownDirectiveWithoutTestingImport) {
     try {
@@ -189,9 +178,7 @@ TEST_F(CodeGenTest, DescribeRejectedAsUnknownDirectiveWithoutTestingImport) {
     }
 }
 
-// ============================================================
-// Null coalescing (`??`) rejects non-Option/non-Result operands
-// ============================================================
+// ===== [contract] Null coalescing (`??`) rejects non-Option/non-Result operands =====
 
 TEST_F(CodeGenTest, NullCoalesceRequiresOptionOrResult) {
     // Plain int on the LHS is not allowed.
@@ -226,9 +213,7 @@ TEST_F(CodeGenTest, NullCoalesceRejectsPtrBackedTypeMismatch) {
         "'" "??" "' on Result");
 }
 
-// ============================================================
-// `?` operator rejects non-Result/non-Option operands
-// ============================================================
+// ===== [contract] `?` operator rejects non-Result/non-Option operands =====
 
 TEST_F(CodeGenTest, QuestionRequiresResultOrOption) {
     expectCompileError(
@@ -238,9 +223,7 @@ TEST_F(CodeGenTest, QuestionRequiresResultOrOption) {
         "Result or Option");
 }
 
-// ============================================================
-// `?` on Option requires an Option-returning enclosing function
-// ============================================================
+// ===== [contract] `?` on Option requires an Option-returning enclosing function =====
 
 TEST_F(CodeGenTest, QuestionOnOptionRequiresOptionReturn) {
     expectCompileError(
@@ -260,9 +243,7 @@ TEST_F(CodeGenTest, QuestionOnOptionInResultFnRejected) {
         "fn that returns Option");
 }
 
-// ============================================================
-// `?` on Result requires a Result-returning enclosing function
-// ============================================================
+// ===== [contract] `?` on Result requires a Result-returning enclosing function =====
 
 TEST_F(CodeGenTest, QuestionOnResultInOptionFnRejected) {
     expectCompileError(
@@ -274,9 +255,7 @@ TEST_F(CodeGenTest, QuestionOnResultInOptionFnRejected) {
         "fn that returns Result");
 }
 
-// ============================================================
-// Option.map() requires a callable second argument
-// ============================================================
+// ===== [contract] Option.map() requires a callable second argument =====
 
 TEST_F(CodeGenTest, OptionMapRejectsNonCallableSecondArg) {
     expectCompileError(
@@ -285,9 +264,7 @@ TEST_F(CodeGenTest, OptionMapRejectsNonCallableSecondArg) {
         "map() on Option requires a function as second argument");
 }
 
-// ============================================================
-// Top-level `?` on `Result<_, E>` requires E == Error
-// ============================================================
+// ===== [contract] Top-level `?` on `Result<_, E>` requires E == Error =====
 
 TEST_F(CodeGenTest, TopLevelQuestionRejectsNonErrorResult) {
     expectCompileError(
@@ -297,9 +274,7 @@ TEST_F(CodeGenTest, TopLevelQuestionRejectsNonErrorResult) {
         "err type must be Error");
 }
 
-// ============================================================
-// Nested function is not visible outside its enclosing scope
-// ============================================================
+// ===== [contract] Nested function is not visible outside its enclosing scope =====
 
 TEST_F(CodeGenTest, NestedFunctionNotVisibleOutsideScope) {
     EXPECT_THROW(runSource(
@@ -311,9 +286,7 @@ TEST_F(CodeGenTest, NestedFunctionNotVisibleOutsideScope) {
     ), std::runtime_error);
 }
 
-// ============================================================
-// Captured variable cannot be modified inside nested named function
-// ============================================================
+// ===== [contract] Captured variable cannot be modified inside nested named function =====
 
 TEST_F(CodeGenTest, NestedFunctionCannotModifyCapturedVariable) {
     EXPECT_THROW(runSource(
@@ -327,17 +300,13 @@ TEST_F(CodeGenTest, NestedFunctionCannotModifyCapturedVariable) {
     ), std::runtime_error);
 }
 
-// ============================================================
-// math.pow(int, int) with a negative exponent aborts at runtime.
-//
-// Declares the @native("math") signatures inline so emitBuiltinMath
-// (#2340 carve-out) sees `math::pow` / `math::digits` registered and
-// intercepts the call. CodeGenTest::runSource goes Parser → CodeGen
-// directly without invoking ModuleLoader, so `from math import ...`
-// would fail with "unresolved import"; the explicit `("math")` tag
-// registers the sig under the right package key without loading the
-// stdlib `.ry` file.
-// ============================================================
+// ===== [contract] math.pow(int, int) with a negative exponent aborts at runtime =====
+// Declares the @native("math") signatures inline so emitBuiltinMath (#2340
+// carve-out) sees `math::pow` / `math::digits` registered and intercepts the
+// call. CodeGenTest::runSource goes Parser → CodeGen directly without invoking
+// ModuleLoader, so `from math import ...` would fail with "unresolved import";
+// the explicit `("math")` tag registers the sig under the right package key
+// without loading the stdlib `.ry` file.
 
 TEST_F(CodeGenTest, MathPowIntNegativeExponentAborts) {
     EXPECT_EXIT(
@@ -417,13 +386,10 @@ TEST_F(CodeGenTest, ThreadSpawnRejectsNamedFnReturningStrAsVariableReferenceWork
         "threadSpawn() MVP (#828) supports only");
 }
 
-// ============================================================
-// Generic inference for container parameters (#823).
-// An empty container literal yields no information for the
-// type variable, so inference must emit a clear error naming
-// the parameter and the function, not a vague codegen error or
-// an "undefined variable" message.
-// ============================================================
+// ===== [regression #823] Generic inference for container parameters — empty container clear error =====
+// An empty container literal yields no information for the type variable, so
+// inference must emit a clear error naming the parameter and the function, not
+// a vague codegen error or an "undefined variable" message.
 
 TEST_F(CodeGenTest, GenericInferenceEmptyListHasClearError) {
     expectCompileError(
@@ -433,11 +399,10 @@ TEST_F(CodeGenTest, GenericInferenceEmptyListHasClearError) {
         "could not infer type parameter 'T' in call to generic function 'firstOf'");
 }
 
-// ============================================================
-// When the same type parameter appears in two argument slots
-// and the concrete arguments disagree, inference must report a
-// clear conflict naming the parameter.
-// ============================================================
+// ===== [contract] Conflicting type inference for shared type parameter =====
+// When the same type parameter appears in two argument slots and the concrete
+// arguments disagree, inference must report a clear conflict naming the
+// parameter.
 
 TEST_F(CodeGenTest, GenericInferenceConflictingBindingError) {
     expectCompileError(
@@ -447,9 +412,7 @@ TEST_F(CodeGenTest, GenericInferenceConflictingBindingError) {
         "conflicting type inference for 'T'");
 }
 
-// ============================================================
-// print() named argument error cases
-// ============================================================
+// ===== [contract] print() named argument error cases =====
 
 TEST_F(CodeGenTest, PrintUnknownNamedArgError) {
     expectCompileError(
@@ -465,12 +428,10 @@ TEST_F(CodeGenTest, NamedArgsOnNonBuiltinError) {
         "named arguments are only supported for builtin functions");
 }
 
-// ============================================================
-// `+` on Map / Set collection operands: type-aware diagnostics.
-// Before #863 these fell through to the str-vs-non-str reject path.
-// After #866 Map + Map (merge) and Set + Set (union) are supported,
-// but mismatched types must still produce a clear diagnostic.
-// ============================================================
+// ===== [contract] `+` on Map / Set collection operands: type-aware diagnostics (#863, #866) =====
+// Before #863 these fell through to the str-vs-non-str reject path. After #866
+// Map + Map (merge) and Set + Set (union) are supported, but mismatched types
+// must still produce a clear diagnostic.
 
 TEST_F(CodeGenTest, ArithPlusRejectsMapPlusMapKeyMismatch) {
     // Different key types → error
@@ -517,17 +478,15 @@ TEST_F(CodeGenTest, ArithPlusListConcatMismatchMessageUnchanged) {
         "list concatenation requires matching element types");
 }
 
-// ============================================================
-// Map<K, any> / Set<any> / List<any>: #1697 lifts the old wrapInAny
-// rejection so List / Map / Set values can be assigned through an
-// `any` slot in any collection-mutating builtin. Flipped from
-// EXPECT_THROW to EXPECT_NO_THROW per "Relaxing a rejection branch
+// ===== [contract] Map<K, any> / Set<any> / List<any> accept collection inputs (#1697) =====
+// #1697 lifts the old wrapInAny rejection so List / Map / Set values can be
+// assigned through an `any` slot in any collection-mutating builtin. Flipped
+// from EXPECT_THROW to EXPECT_NO_THROW per "Relaxing a rejection branch
 // requires flipping (not deleting) existing EXPECT_THROW tests"
-// (.claude/skills/test-checklist/SKILL.md). The old "'any' can only
-// hold int/float/bool/str" error path is gone for collection inputs;
-// fn-ptr / resource still hit it (covered by
-// AnyTypeRejectionForFunctionPointer in test_codegen.cpp).
-// ============================================================
+// (.claude/skills/test-checklist/SKILL.md). The old "'any' can only hold
+// int/float/bool/str" error path is gone for collection inputs; fn-ptr /
+// resource still hit it (covered by AnyTypeRejectionForFunctionPointer in
+// test_codegen.cpp).
 
 TEST_F(CodeGenTest, MapAnyValueAcceptsCollectionType) {
     // Verify wrap → store → load → to_string round-trip (#1697): printing
@@ -693,9 +652,7 @@ TEST_F(CodeGenTest, AnyUnwrapToSetIntInGenericRejected) {
 // collection is parameterised by `any`. Users must drive the cast
 // explicitly via `case asType[List<any>](a):` and friends.
 
-// ============================================================
-// fold(): seed/return-type mismatch must still fire for typed lambda
-// ============================================================
+// ===== [contract] fold(): seed/return-type mismatch must still fire for typed lambda =====
 
 TEST_F(CodeGenTest, FoldTypedLambdaSeedTypeMismatch) {
     expectCompileError(
@@ -704,9 +661,7 @@ TEST_F(CodeGenTest, FoldTypedLambdaSeedTypeMismatch) {
         "fold() initial value type must match function return type");
 }
 
-// ============================================================
-// #1209: reduce(xs, init, fn) (3-arg, Python/JS style) suggests fold
-// ============================================================
+// ===== [contract] reduce(xs, init, fn) (3-arg, Python/JS style) suggests fold (#1209) =====
 
 TEST_F(CodeGenTest, ReduceThreeArgsSuggestsFold) {
     expectCompileError(
@@ -722,9 +677,7 @@ TEST_F(CodeGenTest, ReduceFourArgsUsesGenericError) {
         "takes exactly 2 arguments");
 }
 
-// ============================================================
-// #1570: sequence() rejects non-Result/Option element type
-// ============================================================
+// ===== [contract] sequence() rejects non-Result/Option element type (#1570) =====
 
 TEST_F(CodeGenTest, SequenceRejectsPlainIntList) {
     expectCompileError(
@@ -739,9 +692,7 @@ TEST_F(CodeGenTest, SequenceRejectsNonListArg) {
         "sequence() requires a list of Result or Option");
 }
 
-// ============================================================
-// #1027: octal literals must produce a targeted diagnostic
-// ============================================================
+// ===== [contract] octal literals produce a targeted diagnostic (#1027) =====
 
 TEST_F(CodeGenTest, OctalLiteralRejectedWithTargetedDiagnostic) {
     expectCompileError("x = 0o17\n",
@@ -752,22 +703,18 @@ TEST_F(CodeGenTest, OctalLiteralRejectedWithTargetedDiagnostic) {
                        "octal literals (0o...) are not supported");
 }
 
-// ============================================================
-// None() rejects non-zero arguments (#1043)
-// ============================================================
+// ===== [contract] None() rejects non-zero arguments (#1043) =====
 
 TEST_F(CodeGenTest, NoneWithArgsIsRejected) {
     expectCompileError("x: int? = None(1)\n",
                        "None() takes no arguments");
 }
 
-// ============================================================
-// base64.encodeBytes / encodeBytesUrlSafe reject non-u8 list
-// at compile time via requireListU8Arg gate (#1130). Post-#2285
-// the @native declaration is the source of truth, so the
-// declaration must spell the actual ABI (List<u8>); the gate
-// fires when a caller passes a non-u8 list against that declaration.
-// ============================================================
+// ===== [contract] base64.encodeBytes / encodeBytesUrlSafe reject non-u8 list at compile time (#1130) =====
+// requireListU8Arg gate enforces this. Post-#2285 the @native declaration is
+// the source of truth, so the declaration must spell the actual ABI
+// (List<u8>); the gate fires when a caller passes a non-u8 list against that
+// declaration.
 
 TEST_F(CodeGenTest, Base64EncodeBytesRejectsNonU8List) {
     expectCompileError(
@@ -787,11 +734,9 @@ TEST_F(CodeGenTest, Base64EncodeBytesUrlSafeRejectsNonU8List) {
         "requires List<u8>");
 }
 
-// ============================================================
-// #1157: coerceResultType must reject function-returned Result
-// when the discriminator is a runtime value, not a provably
-// literal Ok/Err. Without the fix, these silently miscompile.
-// ============================================================
+// ===== [regression #1157] coerceResultType must reject function-returned Result with runtime disc =====
+// When the discriminator is a runtime value, not a provably literal Ok/Err.
+// Without the fix, these silently miscompile.
 
 TEST_F(CodeGenTest, ResultCoerceFnReturnDifferentErrType) {
     // f() returns Result<bool, MyErr1>; binding to Result<bool, MyErr2> is
@@ -833,9 +778,7 @@ TEST_F(CodeGenTest, ResultCoerceFnReturnWideOkType) {
         "type error: annotation");
 }
 
-// ============================================================
-// #1156: tuple pattern on Option / Result must be rejected
-// ============================================================
+// ===== [regression #1156] tuple pattern on Option / Result must be rejected =====
 
 // Option<T> is represented as {i1, T} — a 2-element struct.  Before #1156
 // the structural guard only fired when subjectEnumType was non-empty, so an
@@ -1008,19 +951,15 @@ TEST_F(CodeGenTest, NestedGenericEnumFieldCompiles) {
         "  return Outer<int>::Wrap(Inner<int>::In(1))\n"));
 }
 
-// ============================================================
-// #1569: Referencing a multi-overload @native function as a
-// first-class value must produce a clear "ambiguous" diagnostic,
-// mirroring the user-fn behavior in emitExprVariant(VariableExpr).
-// Single-overload @native references succeed (covered by
-// tests/spec/native_first_class.test.ry); multi-overload
-// references must reject because the materialized thunk would
+// ===== [contract] Multi-overload @native first-class reference produces "ambiguous" diagnostic (#1569) =====
+// Mirrors the user-fn behavior in emitExprVariant(VariableExpr). Single-overload
+// @native references succeed (covered by tests/spec/native_first_class.test.ry);
+// multi-overload references must reject because the materialized thunk would
 // have no unambiguous signature.
 //
 // Inline @native declarations match what convert.ry exposes.
 // CodeGenTest::runSource bypasses ModuleLoader so we cannot
 // `from convert import str`.
-// ============================================================
 
 TEST_F(CodeGenTest, MultiOverloadNativeReferenceRejected) {
     expectCompileError(
@@ -1066,13 +1005,10 @@ TEST_F(CodeGenTest, UserFnMultiOverloadShadowsNativeFirstClass) {
         "undefined variable");
 }
 
-// ============================================================
-// #1577: type-check overloaded calls before codegen
-//
-// Calling `range`/`len`/`enumerate` with arg types that don't match any
-// overload must produce the canonical "no matching overload" diagnostic
-// with a candidate list, NOT a low-level LLVM IR verify error.
-// ============================================================
+// ===== [contract] type-check overloaded calls before codegen (#1577) =====
+// Calling `range`/`len`/`enumerate` with arg types that don't match any overload
+// must produce the canonical "no matching overload" diagnostic with a candidate
+// list, NOT a low-level LLVM IR verify error.
 
 // Note: `range` is a builtin whose @native signatures are normally provided
 // by `share/std/builtins.ry`, but the C++ test harness (`runSource` /
@@ -1147,14 +1083,11 @@ TEST_F(CodeGenTest, UserFnOverloadAmbiguousCallEmitsCandidateList) {
          "but called with: foo(int)"});
 }
 
-// ============================================================
-// `toMatch` matcher requires str operands on both sides
-// (#1676). The rejection branch lives in `emitStmt(ExpectStmt&)`
-// so it is only reachable in test_mode; use `runTestSource` plus
-// a manual try/catch (the `expectCompileError` helper compiles
-// outside test mode and would fail earlier on the `expect()`
-// guard). See `.claude/skills/test-checklist/SKILL.md`.
-// ============================================================
+// ===== [contract] `toMatch` matcher requires str operands on both sides (#1676) =====
+// The rejection branch lives in `emitStmt(ExpectStmt&)` so it is only reachable
+// in test_mode; use `runTestSource` plus a manual try/catch (the
+// `expectCompileError` helper compiles outside test mode and would fail earlier
+// on the `expect()` guard). See `.claude/skills/test-checklist/SKILL.md`.
 
 TEST_F(CodeGenTest, ExpectToMatchRejectsNonStrActual) {
     try {
@@ -1180,12 +1113,10 @@ TEST_F(CodeGenTest, ExpectToMatchRejectsNonStrPattern) {
     }
 }
 
-// ============================================================
-// `toBeCloseTo` matcher rejection branches (#1675).
-// Same harness pattern as the `toMatch` rejection tests above —
-// the checks live inside `emitStmt(ExpectStmt&)` so they only
-// fire under test_mode (`runTestSource`).
-// ============================================================
+// ===== [contract] `toBeCloseTo` matcher rejection branches (#1675) =====
+// Same harness pattern as the `toMatch` rejection tests above — the checks live
+// inside `emitStmt(ExpectStmt&)` so they only fire under test_mode
+// (`runTestSource`).
 
 TEST_F(CodeGenTest, ExpectToBeCloseToRejectsNonNumericActual) {
     try {
@@ -1253,12 +1184,9 @@ TEST_F(CodeGenTest, ExpectToBeCloseToRejectsNegativeDecimals) {
     }
 }
 
-// ============================================================
-// `using` statement (#1817): init expression must produce an
-// `io.File` value.  Codegen rejects int, str, List, and any
-// other non-File type at the `detectResourceKind` / `isFile`
-// gate in `emitStmt(UsingStmt)`.
-// ============================================================
+// ===== [contract] `using` statement init expression must produce an `io.File` value (#1817) =====
+// Codegen rejects int, str, List, and any other non-File type at the
+// `detectResourceKind` / `isFile` gate in `emitStmt(UsingStmt)`.
 
 TEST_F(CodeGenTest, UsingRejectsIntInit) {
     expectCompileError(
@@ -1281,16 +1209,12 @@ TEST_F(CodeGenTest, UsingRejectsListInit) {
         "using requires an io.File value");
 }
 
-// ============================================================
-// #1889: stdlib built-in function names cannot be shadowed by
-// user-defined top-level `fn`. Without this guard, the hardcoded
-// dispatch chain (`emitBuiltin*`) silently overrides the user fn,
-// most dangerously when the signature matches exactly
-// (`fn sum(v: List<int>) -> int: return 999` — body ignored,
-// stdlib executes instead). The guard fires for the user fn
-// declaration, not at the call site, so the error is surfaced
-// before any silent shadow has a chance to occur.
-// ============================================================
+// ===== [regression #1889] stdlib built-in function names cannot be shadowed by user-defined top-level `fn` =====
+// Without this guard, the hardcoded dispatch chain (`emitBuiltin*`) silently
+// overrides the user fn, most dangerously when the signature matches exactly
+// (`fn sum(v: List<int>) -> int: return 999` — body ignored, stdlib executes
+// instead). The guard fires for the user fn declaration, not at the call site,
+// so the error is surfaced before any silent shadow has a chance to occur.
 
 // Issue reproduction: 4 signature variants of `fn sum` — every one
 // must be rejected, including the exact-signature shadow that was
@@ -1443,11 +1367,9 @@ TEST_F(CodeGenTest, ReservedBuiltinGenericFilter) {
         "is reserved for a built-in");
 }
 
-// ============================================================
-// #1889 positive cases: the guard MUST NOT over-fire. False
-// positives would block legitimate code, so each accept-path is
-// pinned by a positive test that proves the input compiles.
-// ============================================================
+// ===== [regression #1889] positive cases — the guard MUST NOT over-fire =====
+// False positives would block legitimate code, so each accept-path is pinned by
+// a positive test that proves the input compiles.
 
 // Non-collision names compile cleanly even when they share a prefix
 // or suffix with a reserved name.
@@ -1552,23 +1474,18 @@ TEST_F(CodeGenTest, ReservedBuiltinAllowsNativeGenericDeclaration) {
     ));
 }
 
-// ============================================================
-// #2301: getPath / setPath rejection coverage
-//
+// ===== [contract] getPath / setPath rejection coverage (#2301) =====
 // Issue #1701 / PR #2287 added `getPath(map, path)` and
-// `setPath(map, path, value)` for nested Map<str, any> access.
-// `splitDotPath` (src/codegen_call_collection.cpp:17-34) and the
-// per-function receiver/literal checks (lines 1421/1427 for getPath,
-// 1523/1525/1529 for setPath) reject malformed calls at compile time,
-// and the setPath intermediate-walk loop (lines 1571-1616) aborts at
-// runtime when an intermediate segment is missing or not a Map.
-// None of these branches were exercised before #2301.
+// `setPath(map, path, value)` for nested Map<str, any> access. `splitDotPath`
+// and the per-function receiver/literal checks reject malformed calls at
+// compile time, and the setPath intermediate-walk loop aborts at runtime when
+// an intermediate segment is missing or not a Map. None of these branches were
+// exercised before #2301.
 //
-// `Map<str, any>` annotation and `m.getPath(...)` / `m.setPath(...)`
-// dispatch flow through `emitCollOp_getPath` / `emitCollOp_setPath`
-// in src/codegen_call_collection.cpp — no `from map import` is needed,
-// so these tests work in the ModuleLoader-less compileSource harness.
-// ============================================================
+// `Map<str, any>` annotation and `m.getPath(...)` / `m.setPath(...)` dispatch
+// flow through `emitCollOp_getPath` / `emitCollOp_setPath` in
+// `src/codegen_call_collection.cpp` — no `from map import` is needed, so these
+// tests work in the ModuleLoader-less compileSource harness.
 
 TEST_F(CodeGenTest, GetPathEmptyPathRejected) {
     expectCompileError(

--- a/tests/test_codegen_gc_visit.cpp
+++ b/tests/test_codegen_gc_visit.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file tag: [internal] (forces GC visitor thunk emission via test-only flag
+// and asserts emitted IR marker shape).
+//
 // Pilot G (#2196): verify that the GC visitor thunk emission generates
 // byte-equivalent IR after migrating from inline `builder_.Create*` to
 // crates/emit primitives. The thunk codegen path is currently unreachable from

--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -1,3 +1,7 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 #include <cerrno>
 #include <cstdlib>
@@ -159,11 +163,9 @@ protected:
     AllowPrivateHTTPGuard allow_private_;
 };
 
-// ============================================================
-// Manual server: tests HTTP response parsing via raw TCP.
-// Uses dynamic port allocation. Server binds in main scope,
-// passes listener to async fn for accept.
-// ============================================================
+// ===== [contract] Manual server: tests HTTP response parsing via raw TCP =====
+// Uses dynamic port allocation. Server binds in main scope, passes listener to
+// async fn for accept.
 
 TEST_F(CodeGenTest, ManualHttpServer200) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
@@ -222,9 +224,7 @@ case bind("127.0.0.1", 0):
 )"), "true\ntrue\n");
 }
 
-// ============================================================
-// Manual server echoing method:path via raw TCP.
-// ============================================================
+// ===== [contract] Manual server echoing method:path via raw TCP =====
 
 TEST_F(CodeGenTest, ManualHttpServerEcho) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
@@ -280,9 +280,7 @@ case bind("127.0.0.1", 0):
 )"), "true\n");
 }
 
-// ============================================================
-// 404 response
-// ============================================================
+// ===== [contract] 404 response =====
 
 TEST_F(CodeGenTest, HttpResponse404) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
@@ -338,9 +336,7 @@ case bind("127.0.0.1", 0):
 )"), "true\n");
 }
 
-// ============================================================
-// HttpHeader: server echoes a custom request header value
-// ============================================================
+// ===== [contract] HttpHeader: server echoes a custom request header value =====
 
 TEST_F(CodeGenTest, ManualHttpServerHeader) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
@@ -460,10 +456,8 @@ TEST_F(CodeGenHttpClientTest, HttpRequestCaseBindingPreservesHttpClientResponseM
     EXPECT_NE(captured_request.find("X-Test: 1"), std::string::npos);
 }
 
-// ============================================================
-// listen with max_requests: server exits after N requests
+// ===== [contract] listen with max_requests: server exits after N requests =====
 // Uses async fn + port_callback + blockOn to verify server lifecycle.
-// ============================================================
 
 static const std::string HTTP_LISTEN_DECLS = HTTP_DECLS + R"(
 @native("http")

--- a/tests/test_codegen_io.cpp
+++ b/tests/test_codegen_io.cpp
@@ -1,3 +1,7 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 #include <cstdio>
 #include <cstdlib>
@@ -42,9 +46,7 @@ fn toBytes(s: str) -> List<u8>
 fn bytesToStr(bs: List<u8>) -> Result<str, Error>
 )";
 
-// ============================================================
-// writeText / readText round-trip
-// ============================================================
+// ===== [contract] writeText / readText round-trip =====
 
 TEST_F(CodeGenTest, IOWriteReadText) {
     std::string path = tmpPath("write_read");
@@ -63,9 +65,7 @@ case writeText(")" + path + R"(", "hello world"):
     removeIfExists(path);
 }
 
-// ============================================================
-// appendText
-// ============================================================
+// ===== [contract] appendText =====
 
 TEST_F(CodeGenTest, IOAppendText) {
     std::string path = tmpPath("append");
@@ -88,9 +88,7 @@ case writeText(")" + path + R"(", "hello"):
     removeIfExists(path);
 }
 
-// ============================================================
-// exists
-// ============================================================
+// ===== [contract] exists =====
 
 TEST_F(CodeGenTest, IOFileExistsTrue) {
     std::string path = tmpPath("exists");
@@ -113,9 +111,7 @@ print(exists(")" + path + R"("))
 )"), "false\n");
 }
 
-// ============================================================
-// deleteFile
-// ============================================================
+// ===== [contract] deleteFile =====
 
 TEST_F(CodeGenTest, IODeleteFile) {
     std::string path = tmpPath("delete");
@@ -133,9 +129,7 @@ case writeText(")" + path + R"(", "temp"):
 )"), "false\n");
 }
 
-// ============================================================
-// toBytes / bytesToStr
-// ============================================================
+// ===== [contract] toBytes / bytesToStr =====
 
 TEST_F(CodeGenTest, IOStrToBytes) {
     EXPECT_EQ(runSource(IO_DECLS + R"(
@@ -158,9 +152,7 @@ case bytesToStr(bs):
 )"), "hello\n");
 }
 
-// ============================================================
-// readBytes / writeBytes round-trip
-// ============================================================
+// ===== [contract] readBytes / writeBytes round-trip =====
 
 TEST_F(CodeGenTest, IOWriteReadBytes) {
     std::string path = tmpPath("bytes");
@@ -185,9 +177,7 @@ case writeBytes(")" + path + R"(", bs):
     removeIfExists(path);
 }
 
-// ============================================================
-// Error case: readText on non-existent file returns Err
-// ============================================================
+// ===== [contract] Error case: readText on non-existent file returns Err =====
 
 TEST_F(CodeGenTest, IOReadTextNotFound) {
     EXPECT_EQ(runSource(IO_DECLS + R"(

--- a/tests/test_codegen_iterator.cpp
+++ b/tests/test_codegen_iterator.cpp
@@ -1,8 +1,12 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ===== Iterator tests =====
+// ===== [contract] Iterator tests =====
 
 TEST_F(CodeGenTest, IteratorBasicToList) {
     std::string src =

--- a/tests/test_codegen_mock.cpp
+++ b/tests/test_codegen_mock.cpp
@@ -1,10 +1,12 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ============================================================
-// Basic mock: function return value is replaced
-// ============================================================
+// ===== [contract] Basic mock: function return value is replaced =====
 
 TEST_F(CodeGenTest, MockBasicReplace) {
     EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
@@ -20,9 +22,7 @@ TEST_F(CodeGenTest, MockBasicReplace) {
     )), "mock basic\n  \033[32m+ replaces function\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
-// ============================================================
-// Mock with arguments
-// ============================================================
+// ===== [contract] Mock with arguments =====
 
 TEST_F(CodeGenTest, MockWithArgs) {
     EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
@@ -38,9 +38,7 @@ TEST_F(CodeGenTest, MockWithArgs) {
     )), "mock with args\n  \033[32m+ replaces function with args\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
-// ============================================================
-// Auto-restore between it blocks
-// ============================================================
+// ===== [contract] Auto-restore between it blocks =====
 
 TEST_F(CodeGenTest, MockAutoRestore) {
     EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
@@ -60,9 +58,7 @@ TEST_F(CodeGenTest, MockAutoRestore) {
     )), "mock restore\n  \033[32m+ mocks\033[0m\n  \033[32m+ auto-restores\033[0m\n\n2 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
-// ============================================================
-// verify() returns call count
-// ============================================================
+// ===== [contract] verify() returns call count =====
 
 TEST_F(CodeGenTest, MockVerifyCallCount) {
     EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
@@ -81,9 +77,7 @@ TEST_F(CodeGenTest, MockVerifyCallCount) {
     )), "verify\n  \033[32m+ counts calls\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
-// ============================================================
-// Mock function used as expression / return value
-// ============================================================
+// ===== [contract] Mock function used as expression / return value =====
 
 TEST_F(CodeGenTest, MockFunctionUsedAsExpr) {
     // verify() works when mock is called and function result is used
@@ -102,9 +96,7 @@ TEST_F(CodeGenTest, MockFunctionUsedAsExpr) {
     )), "mock expr\n  \033[32m+ tracks calls in expressions\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
-// ============================================================
-// mock() outside test mode -> compile error
-// ============================================================
+// ===== [contract] mock() outside test mode -> compile error =====
 
 TEST_F(CodeGenTest, MockOutsideTestModeError) {
     EXPECT_THROW(runSource(
@@ -114,9 +106,7 @@ TEST_F(CodeGenTest, MockOutsideTestModeError) {
     ), std::exception);
 }
 
-// ============================================================
-// mock() on non-existent function -> compile error
-// ============================================================
+// ===== [contract] mock() on non-existent function -> compile error =====
 
 TEST_F(CodeGenTest, MockNonExistentFunctionError) {
     EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
@@ -128,9 +118,7 @@ TEST_F(CodeGenTest, MockNonExistentFunctionError) {
     )), std::exception);
 }
 
-// ============================================================
-// mock() with type mismatch -> compile error
-// ============================================================
+// ===== [contract] mock() with type mismatch -> compile error =====
 
 TEST_F(CodeGenTest, MockTypeMismatchError) {
     EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
@@ -183,9 +171,7 @@ TEST_F(CodeGenTest, MockedFunctionStillChecksEnsure) {
     EXPECT_EXIT(runTestSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ============================================================
-// verifyCalledWith() rejection tests (#1677)
-// ============================================================
+// ===== [contract] verifyCalledWith() rejection tests (#1677) =====
 
 TEST_F(CodeGenTest, VerifyCalledWithUnmockedFunctionError) {
     EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
@@ -414,9 +400,7 @@ TEST_F(CodeGenTest, VerifyCalledWithListParamRejectedWithListOfDifferentElementT
     )), std::exception);
 }
 
-// ============================================================
-// verifyCalledWith(): Set<T> argument support (#1704)
-// ============================================================
+// ===== [contract] verifyCalledWith(): Set<T> argument support (#1704) =====
 
 TEST_F(CodeGenTest, VerifyCalledWithSetIntArgAccepted) {
     // Set<int> arg matches a recorded call with the same elements.
@@ -554,9 +538,7 @@ TEST_F(CodeGenTest, VerifyCalledWithSetParamRejectedWithListArg) {
     )), std::exception);
 }
 
-// ============================================================
-// verifyCalledWith(): Map<K, V> argument support (#1705)
-// ============================================================
+// ===== [contract] verifyCalledWith(): Map<K, V> argument support (#1705) =====
 
 TEST_F(CodeGenTest, VerifyCalledWithMapIntIntArgAccepted) {
     // Map<int, int>: integer key + integer value path (no ARC retain needed).
@@ -775,9 +757,7 @@ TEST_F(CodeGenTest, VerifyCalledWithSetParamRejectedWithMapArg) {
     )), std::exception);
 }
 
-// =============================================================================
-// verifyCalledWith(): record argument support (#1706)
-// =============================================================================
+// ===== [contract] verifyCalledWith(): record argument support (#1706) =====
 
 TEST_F(CodeGenTest, VerifyCalledWithRecordArgAccepted) {
     // Record argument with primitive fields: kind=9 path with field-by-field compare.
@@ -869,9 +849,7 @@ TEST_F(CodeGenTest, VerifyCalledWithRecordParamRejectedWithTupleArg) {
     )), std::exception);
 }
 
-// =============================================================================
-// verifyCalledWith(): tuple argument support (#1706)
-// =============================================================================
+// ===== [contract] verifyCalledWith(): tuple argument support (#1706) =====
 
 TEST_F(CodeGenTest, VerifyCalledWithTupleArgAccepted) {
     // Tuple argument with primitive elements: kind=10 path with arity+kinds compare.
@@ -1002,9 +980,7 @@ TEST_F(CodeGenTest, VerifyCalledWithOutsideTestModeError) {
     ), std::exception);
 }
 
-// ============================================================
-// spy() rejection tests (#1683)
-// ============================================================
+// ===== [contract] spy() rejection tests (#1683) =====
 
 // spy() outside test mode -> compile error
 TEST_F(CodeGenTest, SpyOutsideTestModeError) {
@@ -1126,9 +1102,7 @@ TEST_F(CodeGenTest, VerifyCalledWithSpiedFunction) {
     )), "vcw spy\n  \033[32m+ matches spied call\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
-// ============================================================
-// mockReturnValueOnce() rejection tests (#1681)
-// ============================================================
+// ===== [contract] mockReturnValueOnce() rejection tests (#1681) =====
 
 // First argument must be a string literal (parser converts `mockReturnValueOnce(name, ...)`
 // to a CallStmt where args[0] is StringExpr; non-literal must be rejected).
@@ -1275,12 +1249,10 @@ TEST_F(CodeGenTest, MockReturnValueOnceNoneOnNonOptionError) {
     )), std::exception);
 }
 
-// ============================================================
-// Signature-string syntax error tests (#1682)
-// `parseSigString` should emit a clear error for malformed sig
-// inputs instead of silently falling through to bare-name lookup
-// (which would yield a misleading "unknown function 'add(int'" message).
-// ============================================================
+// ===== [contract] Signature-string syntax error tests (#1682) =====
+// `parseSigString` should emit a clear error for malformed sig inputs instead
+// of silently falling through to bare-name lookup (which would yield a
+// misleading "unknown function 'add(int'" message).
 
 TEST_F(CodeGenTest, MockSigStringMissingCloseParenError) {
     EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(

--- a/tests/test_codegen_net.cpp
+++ b/tests/test_codegen_net.cpp
@@ -1,3 +1,7 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 #include "ry/runtime/native/net.hpp"
 #include "ry/runtime/native/io.hpp"
@@ -41,9 +45,7 @@ fn setSendTimeout(stream: TcpStream, ms: int) -> Unit
 fn sleep(ms: int) -> Unit
 )";
 
-// ============================================================
-// bind returns Result<TcpListener, Error>
-// ============================================================
+// ===== [contract] bind returns Result<TcpListener, Error> =====
 
 TEST_F(CodeGenTest, NetBindReturnsResult) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
@@ -56,9 +58,7 @@ case bind("127.0.0.1", 0):
 )"), "ok\n");
 }
 
-// ============================================================
-// connect to invalid address returns Err
-// ============================================================
+// ===== [contract] connect to invalid address returns Err =====
 
 TEST_F(CodeGenTest, NetConnectInvalidReturnsErr) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
@@ -80,9 +80,7 @@ case bind("127.0.0.1", 0):
 )"), "err\n");
 }
 
-// ============================================================
-// listen returns Result<Unit, Error>
-// ============================================================
+// ===== [contract] listen returns Result<Unit, Error> =====
 
 TEST_F(CodeGenTest, NetListenReturnsResult) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
@@ -99,10 +97,8 @@ case bind("127.0.0.1", 0):
 )"), "ok\n");
 }
 
-// ============================================================
-// Echo round-trip: server and client via async fn
+// ===== [contract] Echo round-trip: server and client via async fn =====
 // Binds in main scope, passes listener to async fn for accept.
-// ============================================================
 
 TEST_F(CodeGenTest, NetEchoRoundTrip) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
@@ -170,9 +166,7 @@ case bind("127.0.0.1", 0):
 )"), "echo:hello\n");
 }
 
-// ============================================================
-// __ry_tcp_send: closed fd returns -1 (no exit)
-// ============================================================
+// ===== [internal] __ry_tcp_send: closed fd returns -1 (no exit) =====
 
 TEST(TcpSend, ClosedFdReturnsNegative) {
     int fds[2];
@@ -191,9 +185,7 @@ TEST(TcpSend, ClosedFdReturnsNegative) {
     EXPECT_EQ(result, -1);
 }
 
-// ============================================================
-// __ry_send_all: basic full-send via socketpair
-// ============================================================
+// ===== [internal] __ry_send_all: basic full-send via socketpair =====
 
 TEST(SendAll, SmallPayload) {
     int fds[2];
@@ -269,9 +261,7 @@ TEST(SendAll, ZeroLengthSucceeds) {
     ::close(fds[1]);
 }
 
-// ============================================================
-// __ry_tcp_receive: peer close returns empty IOListHeader
-// ============================================================
+// ===== [internal] __ry_tcp_receive: peer close returns empty IOListHeader =====
 
 TEST(TcpRecv, PeerCloseReturnsEmptyList) {
     int fds[2];
@@ -303,9 +293,7 @@ TEST(TcpRecv, ErrorReturnsNull) {
     EXPECT_EQ(result, nullptr);
 }
 
-// ============================================================
-// setTimeout / setReceiveTimeout / setSendTimeout
-// ============================================================
+// ===== [contract] setTimeout / setReceiveTimeout / setSendTimeout =====
 
 TEST_F(CodeGenTest, NetSetTimeoutCompiles) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
@@ -411,9 +399,7 @@ case bind("127.0.0.1", 0):
 )"), "timeout\n");
 }
 
-// ============================================================
-// __ry_tcp_set_timeout: runtime-level test
-// ============================================================
+// ===== [internal] __ry_tcp_set_timeout: runtime-level test =====
 
 TEST(TcpTimeout, SetTimeoutSetsSocketOptions) {
     int fds[2];
@@ -437,9 +423,7 @@ TEST(TcpTimeout, SetTimeoutSetsSocketOptions) {
     ::close(fds[1]);
 }
 
-// ============================================================
-// tlsConnect to invalid host returns Err
-// ============================================================
+// ===== [contract] tlsConnect to invalid host returns Err =====
 
 TEST_F(CodeGenTest, TlsConnectInvalidReturnsErr) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
@@ -461,9 +445,7 @@ case bind("127.0.0.1", 0):
 )"), "tls err\n");
 }
 
-// ============================================================
-// TLS send/receive/close overloads compile for TlsStream
-// ============================================================
+// ===== [contract] TLS send/receive/close overloads compile for TlsStream =====
 
 TEST_F(CodeGenTest, TlsStreamOverloadsCompile) {
     EXPECT_EQ(runSource(NET_DECLS + R"(

--- a/tests/test_codegen_parameterized.cpp
+++ b/tests/test_codegen_parameterized.cpp
@@ -1,10 +1,12 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ============================================================
-// @each: basic parameterized test
-// ============================================================
+// ===== [contract] @each: basic parameterized test =====
 
 TEST_F(CodeGenTest, EachBasicInt) {
     auto output = runTestSource(withStdlibDirectiveDecls(
@@ -20,9 +22,7 @@ TEST_F(CodeGenTest, EachBasicInt) {
     EXPECT_NE(output.find("2 passed, 0 failed"), std::string::npos);
 }
 
-// ============================================================
-// @each: string parameters
-// ============================================================
+// ===== [contract] @each: string parameters =====
 
 TEST_F(CodeGenTest, EachStringParam) {
     auto output = runTestSource(withStdlibDirectiveDecls(
@@ -36,9 +36,7 @@ TEST_F(CodeGenTest, EachStringParam) {
     EXPECT_NE(output.find("2 passed, 0 failed"), std::string::npos);
 }
 
-// ============================================================
-// @each: failing test
-// ============================================================
+// ===== [contract] @each: failing test =====
 
 TEST_F(CodeGenTest, EachFailingTest) {
     auto output = runTestSource(withStdlibDirectiveDecls(
@@ -52,9 +50,7 @@ TEST_F(CodeGenTest, EachFailingTest) {
     EXPECT_NE(output.find("0 passed, 1 failed"), std::string::npos);
 }
 
-// ============================================================
-// @property: basic commutative test
-// ============================================================
+// ===== [contract] @property: basic commutative test =====
 
 TEST_F(CodeGenTest, PropertyCommutative) {
     auto output = runTestSource(withStdlibDirectiveDecls(
@@ -68,9 +64,7 @@ TEST_F(CodeGenTest, PropertyCommutative) {
     EXPECT_NE(output.find("1 passed, 0 failed"), std::string::npos);
 }
 
-// ============================================================
-// @property: bool parameter
-// ============================================================
+// ===== [contract] @property: bool parameter =====
 
 TEST_F(CodeGenTest, PropertyBoolParam) {
     auto output = runTestSource(withStdlibDirectiveDecls(

--- a/tests/test_codegen_regex.cpp
+++ b/tests/test_codegen_regex.cpp
@@ -1,10 +1,12 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ============================================================
-// regexMatch
-// ============================================================
+// ===== [contract] regexMatch =====
 
 TEST_F(CodeGenTest, RegexMatchTrue) {
     EXPECT_EQ(runSource(R"(
@@ -29,9 +31,7 @@ else:
 )"), "yes\n");
 }
 
-// ============================================================
-// regexSearch
-// ============================================================
+// ===== [contract] regexSearch =====
 
 TEST_F(CodeGenTest, RegexSearchFound) {
     EXPECT_EQ(runSource(R"(
@@ -47,9 +47,7 @@ print(pos)
 )"), "-1\n");
 }
 
-// ============================================================
-// regexReplace
-// ============================================================
+// ===== [contract] regexReplace =====
 
 TEST_F(CodeGenTest, RegexReplaceBasic) {
     EXPECT_EQ(runSource(R"(
@@ -65,9 +63,7 @@ print(s)
 )"), "hello\n");
 }
 
-// ============================================================
-// regexSplit
-// ============================================================
+// ===== [contract] regexSplit =====
 
 TEST_F(CodeGenTest, RegexSplitBasic) {
     EXPECT_EQ(runSource(R"(
@@ -88,9 +84,7 @@ print(parts[1])
 )"), "2\nhello\nworld\n");
 }
 
-// ============================================================
-// regexFindAll
-// ============================================================
+// ===== [contract] regexFindAll =====
 
 TEST_F(CodeGenTest, RegexFindAllBasic) {
     EXPECT_EQ(runSource(R"(
@@ -135,9 +129,7 @@ print(len(parts))
                 "error: regex error: unmatched '\\[' in pattern '\\['");
 }
 
-// ============================================================
-// UFCS: text.regexMatch(pattern)
-// ============================================================
+// ===== [contract] UFCS: text.regexMatch(pattern) =====
 
 TEST_F(CodeGenTest, RegexMatchUFCS) {
     EXPECT_EQ(runSource(R"(
@@ -160,9 +152,7 @@ print(s)
 )"), "aXbXcX\n");
 }
 
-// ============================================================
-// Range quantifiers
-// ============================================================
+// ===== [contract] Range quantifiers =====
 
 TEST_F(CodeGenTest, RegexQuantifierExact) {
     EXPECT_EQ(runSource(R"(
@@ -172,9 +162,7 @@ print(regexMatch("1234", "\\d{3}"))
 )"), "true\nfalse\nfalse\n");
 }
 
-// ============================================================
-// Non-greedy when
-// ============================================================
+// ===== [contract] Non-greedy when =====
 
 TEST_F(CodeGenTest, RegexLazyReplace) {
     EXPECT_EQ(runSource(R"(
@@ -192,9 +180,7 @@ print(tags[1].full)
 )"), "2\n<x>\n<yy>\n");
 }
 
-// ============================================================
-// Regex literal syntax /.../
-// ============================================================
+// ===== [contract] Regex literal syntax /.../ =====
 
 TEST_F(CodeGenTest, RegexLiteralMatch) {
     EXPECT_EQ(runSource(R"(

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1,3 +1,7 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 #include "ry/module/module_loader.hpp"
 #include <algorithm>
@@ -8,7 +12,7 @@
 
 
 using namespace ry;
-// ===== when expression =====
+// ===== [contract] when expression =====
 
 TEST_F(CodeGenTest, WhenExprBasics) {
     EXPECT_EQ(runSource("x = case:\n    true : 1\n    _ : 2\nprint(x)"), "1\n");
@@ -30,7 +34,7 @@ TEST_F(CodeGenTest, WhenExprListSameType) {
     EXPECT_EQ(runSource(src), "[1, 2]\n");
 }
 
-// ===== if / when codegen =====
+// ===== [contract] if / when codegen =====
 
 TEST_F(CodeGenTest, IfAndWhenBasics) {
     EXPECT_EQ(runSource("if true:\n    print(1)"), "1\n");
@@ -70,7 +74,7 @@ TEST_F(CodeGenTest, IfEdgeCases) {
         "        print(1)"), "1\n");
 }
 
-// ===== while codegen =====
+// ===== [contract] while codegen =====
 
 TEST_F(CodeGenTest, WhileLoopVariants) {
     // WhileFalseDoesNotExecute
@@ -107,7 +111,7 @@ TEST_F(CodeGenTest, WhileLoopVariants) {
         "    i = i + 1"), "2\n4\n");
 }
 
-// ===== function =====
+// ===== [contract] function =====
 
 TEST_F(CodeGenTest, FnBasicDefinitions) {
     // FnBasicAddCall
@@ -174,7 +178,7 @@ TEST_F(CodeGenTest, FnErrors) {
         "    return \"hello\""), std::runtime_error);
 }
 
-// ===== Block scope =====
+// ===== [contract] Block scope =====
 
 TEST_F(CodeGenTest, BlockScopeNotVisible) {
     // BlockScopeIfVarNotVisible
@@ -220,7 +224,7 @@ TEST_F(CodeGenTest, BlockScopeAccessible) {
         "print(c)"), "20\n");
 }
 
-// ===== Record =====
+// ===== [contract] Record =====
 
 TEST_F(CodeGenTest, RecordBasics) {
     // RecordBasicFieldAccess
@@ -321,7 +325,7 @@ TEST_F(CodeGenTest, RecordErrors) {
         "print(p)"), "Point(x: 1, y: 2)\n");
 }
 
-// ===== Record str =====
+// ===== [contract] Record str =====
 
 TEST_F(CodeGenTest, RecordToStr) {
     EXPECT_EQ(runSource(
@@ -388,7 +392,7 @@ TEST_F(CodeGenTest, UnknownTypeAnnotationThrows) {
     EXPECT_THROW(runSource("x: foo = 42"), std::runtime_error);
 }
 
-// ===== Unit type =====
+// ===== [contract] Unit type =====
 
 TEST_F(CodeGenTest, UnitTypeBasics) {
     // UnitFnNoReturnType
@@ -425,7 +429,7 @@ TEST_F(CodeGenTest, UnitFnReturnValueThrows) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== Option<T> =====
+// ===== [contract] Option<T> =====
 
 TEST_F(CodeGenTest, OptionPrintVariants) {
     // OptionIntSomePrint
@@ -501,7 +505,7 @@ TEST_F(CodeGenTest, OptionReassignment) {
     EXPECT_EQ(runSource("x: float? = 3.14\nprint(x)"), "Some(3.14)\n");
 }
 
-// ===== Null coalesce =====
+// ===== [contract] Null coalesce =====
 
 TEST_F(CodeGenTest, NullCoalesceVariants) {
     // NullCoalesceSome
@@ -520,7 +524,7 @@ TEST_F(CodeGenTest, NullCoalesceVariants) {
         "print(x)"), "None\n");
 }
 
-// ===== Tuple =====
+// ===== [contract] Tuple =====
 
 TEST_F(CodeGenTest, TupleBasics) {
     // TupleCreateAndAccess
@@ -671,7 +675,7 @@ TEST_F(CodeGenTest, ListDestructuringErrors) {
     EXPECT_THROW(runSource("a, a = [1, 2]"), std::runtime_error);
 }
 
-// ===== import =====
+// ===== [contract] import =====
 
 class ImportTest : public CodeGenTest {
 protected:
@@ -1244,7 +1248,7 @@ TEST_F(ImportTest, SearchPathRYPATH) {
     std::filesystem::remove_all(lib_dir);
 }
 
-// ===== directory module tests =====
+// ===== [contract] directory module tests =====
 
 TEST_F(ImportTest, DirectoryModuleImportAll) {
     writeFile("mypack/math.ry",
@@ -1290,7 +1294,7 @@ TEST_F(ImportTest, DirectoryModuleFallbackToFile) {
         "7\n");
 }
 
-// ===== Cross-package visibility tests (#1544) =====
+// ===== [contract] Cross-package visibility tests (#1544) =====
 
 // Same-package callers see exportable definitions even without `@public`.
 TEST_F(ImportTest, SamePackageImportSeesNonPublicSymbols) {
@@ -1385,7 +1389,7 @@ TEST_F(ImportTest, UnrootedCallerCannotSeeNonPublicFromRootedPackage) {
     std::filesystem::remove_all(unrooted_caller);
 }
 
-// ===== Directive definition (@directive) export tests (#709) =====
+// ===== [contract] Directive definition (@directive) export tests (#709) =====
 
 TEST_F(ImportTest, DirectiveDefSelectiveImport) {
     writeFile("dirmod1/mod.ry",
@@ -1441,7 +1445,7 @@ TEST_F(ImportTest, DirectiveDefCrossPackageWildcardIncludesAllForCodegen) {
     EXPECT_EQ(directive_names.count("nonPubDir"), 1u);
 }
 
-// ===== enum / type-alias cross-package visibility (#1544) =====
+// ===== [contract] enum / type-alias cross-package visibility (#1544) =====
 
 // Cross-package wildcard import includes both `@public` and non-`@public`
 // enums in the importer's program for codegen (#1560 REQ-B3). Named import
@@ -1556,7 +1560,7 @@ TEST_F(ImportTest, SamePackageEnumAndTypeAliasVisibleWithoutPublic) {
     EXPECT_TRUE(saw_alias);
 }
 
-// ===== REQ-B3 wrapper pattern (#1560) =====
+// ===== [regression #1560] REQ-B3 wrapper pattern =====
 //
 // A `@public` facade in a public-facing module is allowed to call a
 // non-`@public` helper from the same package. The importer can `from foo
@@ -1706,7 +1710,7 @@ TEST_F(ImportTest, ImportedDirectiveValidatesAtUseSite) {
         "7\n");
 }
 
-// ===== testing module intrinsic import allow-list (#712) =====
+// ===== [contract] testing module intrinsic import allow-list (#712) =====
 //
 // `from testing import expect / mock / fail` references compiler intrinsics
 // that have no AST declaration in `share/std/testing/testing.ry`. The loader
@@ -2187,7 +2191,7 @@ TEST_F(ImportTest, QualifiedImportUserDefinedRecordConstructor) {
         "print(p.y)\n"), "3\n4\n");
 }
 
-// ===== #1888: import of C++-registered resource kinds and builtin records =====
+// ===== [regression #1888] import of C++-registered resource kinds and builtin records =====
 //
 // Resource kinds (File / TcpListener / Thread / ...) and the builtin record
 // Match (regex) are registered programmatically in C++ rather than declared
@@ -2360,7 +2364,7 @@ TEST_F(ImportTest, ImportAliasBuiltinRecordWorksCacheHit) {
     });
 }
 
-// ===== #2351: legacy stdlib import forms rejected as hard errors =====
+// ===== [contract] legacy stdlib import forms rejected as hard errors (#2351) =====
 //
 // Promoted from #2350 deprecation warnings. Each rejection site lives in
 // ModuleLoader::resolveImports() under the `rp.from_stdlib` guard, so a
@@ -2520,7 +2524,7 @@ TEST_F(CodeGenTest, TypeAliasLiteralUnionMetaDoesNotCrashOnReassignment) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
-// ===== for k, v in map / range =====
+// ===== [contract] for k, v in map / range =====
 
 TEST_F(CodeGenTest, ForKVInMap) {
     std::string src =
@@ -2545,7 +2549,7 @@ TEST_F(CodeGenTest, RangeExprVariants) {
         "print(total)"), "6\n");
 }
 
-// ===== Concurrency: async/await =====
+// ===== [contract] Concurrency: async/await =====
 
 TEST_F(CodeGenTest, AsyncAwaitBasics) {
     // blockOn awaits direct async call
@@ -2600,7 +2604,7 @@ TEST_F(CodeGenTest, AvailableParallelismBuiltin) {
     EXPECT_EQ(runSource("print(availableParallelism() > 0)"), "true\n");
 }
 
-// ===== Parallel for =====
+// ===== [contract] Parallel for =====
 
 // TODO: print output interleaves across threads (#473)
 // TEST_F(CodeGenTest, ParallelForBasics) {
@@ -2645,7 +2649,7 @@ TEST_F(CodeGenTest, ParallelForErrors) {
         "    print(helper())\n")), std::runtime_error);
 }
 
-// ===== Int literal type =====
+// ===== [contract] Int literal type =====
 
 TEST_F(CodeGenTest, IntLiteralType) {
     // IntLiteralTypeSingle
@@ -2669,7 +2673,7 @@ TEST_F(CodeGenTest, IntLiteralTypeVarReassignDynamicFail) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ===== Range type =====
+// ===== [contract] Range type =====
 
 TEST_F(CodeGenTest, RangeType) {
     // RangeTypeSuccess
@@ -2699,7 +2703,7 @@ TEST_F(CodeGenTest, RangeTypeVarReassignDynamicFail) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ===== Str literal type =====
+// ===== [contract] Str literal type =====
 
 TEST_F(CodeGenTest, StrLiteralType) {
     // StrLiteralTypeSuccess
@@ -2719,7 +2723,7 @@ TEST_F(CodeGenTest, StrLiteralTypeVarReassignDynamicFail) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
-// ===== Type alias with refined types =====
+// ===== [contract] Type alias with refined types =====
 
 TEST_F(CodeGenTest, TypeAliasRefinedTypes) {
     // TypeAliasRangeType
@@ -2743,7 +2747,7 @@ TEST_F(CodeGenTest, TypeAliasRefinedTypes) {
         "print(d)"), "5\n");
 }
 
-// ===== Type constraint integer overflow (#2307) =====
+// ===== [regression #2307] Type constraint integer overflow =====
 
 TEST_F(CodeGenTest, TypeConstraintIntOverflow) {
     // Single int literal — large positive overflow
@@ -2779,7 +2783,7 @@ TEST_F(CodeGenTest, TypeConstraintIntOverflow) {
               "9223372036854775807\n");
 }
 
-// ===== Tuple field index integer overflow (#2308) =====
+// ===== [regression #2308] Tuple field index integer overflow =====
 
 TEST_F(CodeGenTest, TupleIndexOverflow) {
     // Oversized decimal index (42 nines) used to abort via uncaught
@@ -2801,7 +2805,7 @@ TEST_F(CodeGenTest, TupleIndexOverflow) {
               "10\n20\n");
 }
 
-// ===== Function type alias =====
+// ===== [contract] Function type alias =====
 
 TEST_F(CodeGenTest, TypeAliasFnType) {
     // TypeAliasFnType
@@ -2831,7 +2835,7 @@ TEST_F(CodeGenTest, TypeAliasFnType) {
         "print(apply(add, 5, 6))"), "11\n");
 }
 
-// ===== Function parameter constraints =====
+// ===== [contract] Function parameter constraints =====
 
 TEST_F(CodeGenTest, FnParamConstraints) {
     // FnParamRangeTypeSuccess
@@ -2856,7 +2860,7 @@ TEST_F(CodeGenTest, FnParamConstraints) {
         "f(2)"), std::runtime_error);
 }
 
-// ===== Ellipsis =====
+// ===== [contract] Ellipsis =====
 
 TEST_F(CodeGenTest, EllipsisVariants) {
     // EllipsisNoOp
@@ -2888,7 +2892,7 @@ TEST_F(CodeGenTest, EllipsisVariants) {
         "print(\"done\")"), "done\n");
 }
 
-// ===== Short-circuit evaluation =====
+// ===== [contract] Short-circuit evaluation =====
 
 TEST_F(CodeGenTest, ShortCircuitEvaluation) {
     // AndShortCircuitFalse
@@ -2921,7 +2925,7 @@ TEST_F(CodeGenTest, ShortCircuitEvaluation) {
         "print(res)"), "side\ntrue\n");
 }
 
-// ===== Default arguments =====
+// ===== [contract] Default arguments =====
 
 TEST_F(CodeGenTest, DefaultArgBasic) {
     EXPECT_EQ(runSource(
@@ -2963,7 +2967,7 @@ TEST_F(CodeGenTest, DefaultArgGenericError) {
         "print(identity(42))"), std::runtime_error);
 }
 
-// ===== unimported stdlib module diagnostic (#1746) =====
+// ===== [regression #1746] unimported stdlib module diagnostic =====
 //
 // `<mod>.fn(...)` / `<mod>.field` where `<mod>` names a registered
 // stdlib package but the user forgot to `import <mod>` must produce an

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -1,10 +1,12 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 
 
 using namespace ry;
-// ============================================================
-// Struct type rejected by arithmetic operators
-// ============================================================
+// ===== [contract] Struct type rejected by arithmetic operators =====
 
 TEST_F(CodeGenTest, RecordAddRejected) {
     EXPECT_THROW(runSource(
@@ -76,9 +78,7 @@ TEST_F(CodeGenTest, RecordPowerRejected) {
     ), std::runtime_error);
 }
 
-// ============================================================
-// Struct type rejected by unary operators
-// ============================================================
+// ===== [contract] Struct type rejected by unary operators =====
 
 TEST_F(CodeGenTest, RecordNegationRejected) {
     EXPECT_THROW(runSource(
@@ -100,9 +100,7 @@ TEST_F(CodeGenTest, RecordBitwiseNotRejected) {
     ), std::runtime_error);
 }
 
-// ============================================================
-// Pointer/str type rejected by unary operators
-// ============================================================
+// ===== [contract] Pointer/str type rejected by unary operators =====
 
 TEST_F(CodeGenTest, StringNegationRejected) {
     EXPECT_THROW(runSource(
@@ -116,9 +114,7 @@ TEST_F(CodeGenTest, StringBitwiseNotRejected) {
     ), std::runtime_error);
 }
 
-// ============================================================
-// Struct type rejected by bitwise operators
-// ============================================================
+// ===== [contract] Struct type rejected by bitwise operators =====
 
 TEST_F(CodeGenTest, RecordBitwiseAndRejected) {
     EXPECT_THROW(runSource(
@@ -150,9 +146,7 @@ TEST_F(CodeGenTest, RecordBitwiseXorRejected) {
     ), std::runtime_error);
 }
 
-// ============================================================
-// Struct type rejected by comparison operators (< <= > >=)
-// ============================================================
+// ===== [contract] Struct type rejected by comparison operators (< <= > >=) =====
 
 TEST_F(CodeGenTest, RecordLessThanRejected) {
     EXPECT_THROW(runSource(
@@ -176,9 +170,7 @@ TEST_F(CodeGenTest, RecordGreaterThanRejected) {
     ), std::runtime_error);
 }
 
-// ============================================================
-// Regression: Struct == and != must still work
-// ============================================================
+// ===== [contract] Regression: Struct == and != must still work =====
 
 TEST_F(CodeGenTest, RecordEqualityStillWorks) {
     EXPECT_EQ(runSource(
@@ -202,17 +194,14 @@ TEST_F(CodeGenTest, RecordInequalityStillWorks) {
     ), "true\n");
 }
 
-// ============================================================
-// IR verify error sweep — #805, #818, #821
-//
+// ===== [regression #805 #818 #821] IR verify error sweep =====
 // These used to reach LLVM IR verification and crash with cryptic
 // "icmp ne ptr, i0 0" or "Terminator found in the middle of a basic
 // block" messages. After the sweep, each case is either handled
 // frontend-side with a clear diagnostic or silently accepted with a
 // trailing dead block that LLVM DCE removes.
-// ============================================================
 
-// ---- #818: pointer-backed collection/str types cannot be conditions ----
+// ===== [regression #818] pointer-backed collection/str types cannot be conditions =====
 
 TEST_F(CodeGenTest, ListInIfConditionRejected) {
     EXPECT_THROW(runSource(
@@ -298,7 +287,7 @@ TEST_F(CodeGenTest, LengthGreaterZeroIdiomWorks) {
     ), "non-empty\n");
 }
 
-// ---- #821: code after exit() must not trigger IR verify error ----
+// ===== [regression #821] code after exit() must not trigger IR verify error =====
 //
 // Using compileSource() here instead of runSource(): calling exit(0) from a
 // JIT-loaded module would terminate the test process itself. We only need to
@@ -347,9 +336,7 @@ TEST_F(CodeGenTest, GenericResultToStrStillWorks) {
     ), "Ok(42)\n");
 }
 
-// ============================================================
-// findMatchingCloseParen — depth-tracking paren matcher (#768)
-// ============================================================
+// ===== [regression #768] findMatchingCloseParen — depth-tracking paren matcher =====
 
 TEST(FindMatchingCloseParen, Simple) {
     // fn(int) -> int
@@ -386,9 +373,7 @@ TEST(FindMatchingCloseParen, NoMatch) {
     ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 2), std::string::npos);
 }
 
-// ============================================================
-// Cross-category type duplicate rejection (#815)
-// ============================================================
+// ===== [regression #815] Cross-category type duplicate rejection =====
 
 TEST_F(CodeGenTest, RecordThenEnumWithSameNameRejected) {
     expectCompileError(
@@ -458,9 +443,7 @@ TEST_F(CodeGenTest, DuplicateGenericEnumRejected) {
         "generic enum 'Foo' is already defined");
 }
 
-// ============================================================
-// Type alias cross-category duplicate rejection (#850)
-// ============================================================
+// ===== [regression #850] Type alias cross-category duplicate rejection =====
 
 TEST_F(CodeGenTest, TypeAliasThenRecordWithSameNameRejected) {
     expectCompileError(
@@ -544,9 +527,7 @@ TEST_F(CodeGenTest, DuplicateUnionTypeAliasRejected) {
         "type alias 'Foo' is already defined");
 }
 
-// ============================================================
-// bool rejected in arithmetic operators (#1030)
-// ============================================================
+// ===== [contract] bool rejected in arithmetic operators (#1030) =====
 
 TEST_F(CodeGenTest, BoolLhsAddRejected) {
     expectCompileError("x = true + 1\n",
@@ -630,9 +611,7 @@ TEST_F(CodeGenTest, BoolCompoundAddAssignRejected) {
         "bool cannot be used with arithmetic operator");
 }
 
-// ============================================================
-// bool rejected in bitwise operators (#1030)
-// ============================================================
+// ===== [contract] bool rejected in bitwise operators (#1030) =====
 
 TEST_F(CodeGenTest, BoolBitwiseAndRejected) {
     expectCompileError("x = true & 1\n",
@@ -676,9 +655,7 @@ TEST_F(CodeGenTest, BoolCompoundAndAssignRejected) {
         "bool cannot be used with bitwise operator");
 }
 
-// ============================================================
-// str does not support index access (#1026)
-// ============================================================
+// ===== [contract] str does not support index access (#1026) =====
 
 TEST_F(CodeGenTest, StrIndexAccessRejected) {
     expectCompileError(
@@ -717,9 +694,7 @@ TEST_F(CodeGenTest, StrFnReturnVarIndexAssignmentRejected) {
         {"str", "immutable"});
 }
 
-// ============================================================
-// bytesToStr / writeBytes require List<u8> (#1055)
-// ============================================================
+// ===== [regression #1055] bytesToStr / writeBytes require List<u8> =====
 
 static const std::string IO_DECLS_1055 = R"(
 @native("io")
@@ -752,9 +727,7 @@ case bytesToStr([97u16, 0u16, 98u16]):
 )", {"bytesToStr", "List<u8>"});
 }
 
-// ============================================================
-// List<T> annotation propagates element suffix (#1079)
-// ============================================================
+// ===== [contract] List<T> annotation propagates element suffix (#1079) =====
 
 TEST_F(CodeGenTest, ListU8AnnotationAccepted) {
     EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
@@ -793,9 +766,7 @@ print(len(xs))
 )"));
 }
 
-// ============================================================
-// List<T> reassignment propagates element suffix (#1085)
-// ============================================================
+// ===== [contract] List<T> reassignment propagates element suffix (#1085) =====
 
 TEST_F(CodeGenTest, ListU8ReassignmentAccepted) {
     EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
@@ -844,9 +815,7 @@ case bytesToStr(bs):
 )"));
 }
 
-// ============================================================
-// List<T> compound assignment propagates element suffix (#1102)
-// ============================================================
+// ===== [contract] List<T> compound assignment propagates element suffix (#1102) =====
 
 TEST_F(CodeGenTest, ListU8CompoundAssignmentAccepted) {
     EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
@@ -893,9 +862,7 @@ print(len(bs))
 )", {"u8 literal out of range"});
 }
 
-// ============================================================
-// reverse!() on a string is rejected with a clear diagnostic (#1124)
-// ============================================================
+// ===== [regression #1124] reverse!() on a string is rejected with a clear diagnostic =====
 
 TEST_F(CodeGenTest, ReverseMutOnStringRejected) {
     expectCompileError(
@@ -904,9 +871,7 @@ TEST_F(CodeGenTest, ReverseMutOnStringRejected) {
         {"reverse!", "list", "immutable"});
 }
 
-// ============================================================
-// range-index (..) on non-list receivers is rejected (#1184)
-// ============================================================
+// ===== [regression #1184] range-index (..) on non-list receivers is rejected =====
 
 TEST_F(CodeGenTest, StrRangeIndexRejected) {
     expectCompileError(

--- a/tests/test_coverage_runtime.cpp
+++ b/tests/test_coverage_runtime.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — drives __ry_coverage_* runtime entry
+// points directly with hand-built file/line pairs.
+
 #include "ry/coverage/coverage_runtime.hpp"
 #include <gtest/gtest.h>
 #include <cstdio>

--- a/tests/test_emit_abi_guards.cpp
+++ b/tests/test_emit_abi_guards.cpp
@@ -1,3 +1,11 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — drives the extern "C" emit ABI
+// (`ry_emit_*`) directly to lock NULL / out-of-range guard branches that are
+// unreachable from the supported CodeGen caller. Inline `// --- ... ---`
+// markers within a section retain the [internal] tag of the enclosing section.
+
 // Direct-call regression tests for the emit ABI input-validation
 // guards (#2028 review hardening). These exercise the NULL / None reject
 // branches that are unreachable from the normal CodeGen caller (which always
@@ -249,8 +257,7 @@ TEST_F(EmitAbiGuardTest, ArcCounterDeltaNullCtxDoesNotCrash) {
     SUCCEED();
 }
 
-// =============================================================================
-// #2080 — uniform input-validation guards across the remaining entry points
+// ===== [internal] #2080 — uniform input-validation guards across the remaining entry points =====
 // (control_flow / collection / bounds / option / lifecycle), mirroring the
 // validated runtime_call / result / any / cow contract via the shared
 // `checked_cx` / `resolve_value` / `ffi_slice` helpers.
@@ -266,7 +273,6 @@ TEST_F(EmitAbiGuardTest, ArcCounterDeltaNullCtxDoesNotCrash) {
 // pointer / out-param and crashed the process, so a clean "red" is impossible —
 // the tests are authored against the fixed guards (same convention as the
 // ResultBranch* cases above).
-// =============================================================================
 
 // --- ctx == NULL → sentinel (value-returning entries) ---
 
@@ -454,8 +460,7 @@ TEST_F(EmitAbiGuardTest, OptionWrapSomeNullResolvedInnerReturnsZero) {
     ry_emit_ctx_destroy(ctx);
 }
 
-// =============================================================================
-// #2072 — scalar / memory IR primitive guards ([C] = (ii) boundary move).
+// ===== [internal] #2072 — scalar / memory IR primitive guards ([C] = (ii) boundary move) =====
 // The eleven new `ry_emit_*` primitives (alloca / load / store / gep / icmp /
 // and / or / add / sub / select / const_int) share the same `checked_cx` /
 // `resolve_value` contract, so a representative sample of each guard SHAPE
@@ -464,7 +469,6 @@ TEST_F(EmitAbiGuardTest, OptionWrapSomeNullResolvedInnerReturnsZero) {
 // (`icmp_pred_from → None`) with no precedent above, so it gets its own case.
 // Same test-vs-document split: the inner corrupted-ctx guards stay documented in
 // .claude/rules/tests-cpp-conventions.md.
-// =============================================================================
 
 // --- ctx == NULL → sentinel / no-op ---
 
@@ -525,14 +529,13 @@ TEST_F(EmitAbiGuardTest, SelectNullResolvedOperandReturnsZero) {
     ry_emit_ctx_destroy(ctx);
 }
 
-// =============================================================================
-// #2096 — `mul` / `sdiv` share the binary primitive shape with #2072's
-// `add` / `sub`, so the resolve_value and name guards are covered by
+// ===== [internal] #2096 — mul / sdiv binary primitive smoke tests =====
+// `mul` / `sdiv` share the binary primitive shape with #2072's `add` / `sub`,
+// so the resolve_value and name guards are covered by
 // `AddNullResolvedOperandReturnsZero` above (the representative-sample
 // principle in the #2072 comment). Each new entry gets a `nullptr ctx` smoke
 // test so a future regression that removes `checked_cx` from one extern but
 // not the other still trips.
-// =============================================================================
 
 TEST_F(EmitAbiGuardTest, MulNullCtxReturnsZero) {
     EXPECT_EQ(ry_emit_mul(nullptr, /*lhs_id=*/0, /*rhs_id=*/0, "x"), 0u);
@@ -542,13 +545,12 @@ TEST_F(EmitAbiGuardTest, SDivNullCtxReturnsZero) {
     EXPECT_EQ(ry_emit_sdiv(nullptr, /*lhs_id=*/0, /*rhs_id=*/0, "x"), 0u);
 }
 
-// =============================================================================
-// #2092 — numeric reduce builtins (sum / min / max). Four value-returning
-// entries; each gets the same three-guard contract: ctx == NULL, an operand id
-// that resolves to None, and a NULL element-type handle. All return the sentinel
-// 0. (No FFI-array params — the variadic forms are per-step ops, not array
-// folds — so there is no ffi_slice guard to exercise here.)
-// =============================================================================
+// ===== [internal] #2092 — numeric reduce builtins (sum / min / max) =====
+// Four value-returning entries; each gets the same three-guard contract:
+// ctx == NULL, an operand id that resolves to None, and a NULL element-type
+// handle. All return the sentinel 0. (No FFI-array params — the variadic forms
+// are per-step ops, not array folds — so there is no ffi_slice guard to
+// exercise here.)
 
 // --- ctx == NULL → sentinel 0 ---
 
@@ -662,8 +664,7 @@ TEST_F(EmitAbiGuardTest, ReduceMinmaxStepNullElemTyReturnsZero) {
     ry_emit_ctx_destroy(ctx);
 }
 
-// =============================================================================
-// #2098 — function definition + indirect call primitive guards
+// ===== [internal] #2098 — function definition + indirect call primitive guards =====
 // ([C] = (ii) boundary move). The five new entries (create_function / get_param
 // / struct_gep / call_indirect / ret) share the same checked_cx / handle-NULL /
 // resolve_value / ffi_slice contract, so each guard SHAPE gets a representative
@@ -671,7 +672,6 @@ TEST_F(EmitAbiGuardTest, ReduceMinmaxStepNullElemTyReturnsZero) {
 // create_function unknown-linkage reject is genuinely new logic (`linkage_from →
 // None`) with no precedent above, so it gets its own case. The corrupted-ctx
 // inner guards stay documented in .claude/rules/tests-cpp-conventions.md.
-// =============================================================================
 
 // --- ctx == NULL → sentinel / no-op ---
 
@@ -828,13 +828,11 @@ TEST_F(EmitAbiGuardTest, CallIndirectNullArgArrayReturnsZero) {
     ry_emit_ctx_destroy(ctx);
 }
 
-// =============================================================================
-// #2093 — collection copy-generation ops (keys / values / take / appended /
-// concat). Three value-returning entries. ry_emit_list_copy_full also has a
+// ===== [internal] #2093 — collection copy-generation ops (keys / values / take / appended / concat) =====
+// Three value-returning entries. ry_emit_list_copy_full also has a
 // kind-selector guard (list_copy_kind_from → None) and ry_emit_list_concat a
 // NULL elem_ty guard; the others share the ctx == NULL + resolve_value → None
 // contract. All return the sentinel 0. (No FFI-array params.)
-// =============================================================================
 
 // --- ctx == NULL → sentinel 0 ---
 

--- a/tests/test_header_layout.cpp
+++ b/tests/test_header_layout.cpp
@@ -1,3 +1,10 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — pins C++ <-> Rust collection / ARC
+// header layout parity by inspecting listHeaderTy_ / mapHeaderTy_ / setHeaderTy_
+// / arcHeaderTy_ and the Rust mirror via `ry_emit_test_header_layout`.
+//
 // Cross-language parity guard for the internal collection / ARC header layout
 // (#2071). The Rust emit crate rebuilds the list/map/set/arc header structs from
 // a single field-kind table (crates/emit/src/core.rs `header_fields`), used both

--- a/tests/test_native_call_descriptor.cpp
+++ b/tests/test_native_call_descriptor.cpp
@@ -1,18 +1,22 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — calls inferLibraryName, knownNativeLibs,
+// CodeGen::getNativeCallDescriptors, ResourceKindRegistry directly to assert
+// internal descriptor state.
+
 #include "test_codegen_common.hpp"
 #include "ry/native_call_descriptor.hpp"
 #include "ry/stdlib_registry.hpp"
 
 using namespace ry;
 
-// =============================================================================
-// Pure-function inference rule tests
-//
+// ===== [internal] Pure-function inference rule tests =====
 // inferLibraryName is a pure function over (directiveTag, declaringModule),
 // so rule (a) / rule (b) / both-empty cases can be exercised directly without
 // driving a full compile. This avoids the runSource harness's inability to
 // forge `SourceLocation::file_id` to look like `share/std/<M>/<M>.ry` (which
 // is what `deriveNativePackage` reads to produce `sig.package`).
-// =============================================================================
 
 TEST(NativeCallDescriptor, InferLibrary_ExplicitTagWins) {
     // rule (a): non-empty tag returns as-is regardless of declaring module.
@@ -54,15 +58,12 @@ TEST(NativeCallDescriptor, KnownNativeLibsLocalLiteral) {
     EXPECT_EQ(knownNativeLibs(), expected);
 }
 
-// =============================================================================
-// End-to-end descriptor storage test (rule (a) only)
-//
+// ===== [internal] End-to-end descriptor storage test (rule (a) only) =====
 // runSource bypasses ModuleLoader, so embedded source's `s->loc` cannot be
 // forged to look like `share/std/io/io.ry`; rule (b) end-to-end is therefore
 // out of reach until a consumer (e.g. dispatchIO descriptor migration) drives
 // a real share/std/ source through the build pipeline. Rule (a) works via
 // the @native("<lib>") directive tag without any file-path dependency.
-// =============================================================================
 
 TEST(NativeCallDescriptor, DescriptorStorage_PopulatedForLibTaggedNative) {
     std::string src =
@@ -95,11 +96,10 @@ TEST(NativeCallDescriptor, DescriptorStorage_PopulatedForLibTaggedNative) {
     EXPECT_EQ(desc.require_list_u8_arg, -1);
 }
 
-// =============================================================================
-// Pilot field population tests (#2337) — exercise each populate path so a
-// regression in codegen_fn.cpp's descriptor-build site (or in
-// inferReturnWrapping) is caught directly, not only via the IR-diff gate.
-// =============================================================================
+// ===== [internal] Pilot field population tests (#2337) =====
+// Exercise each populate path so a regression in codegen_fn.cpp's
+// descriptor-build site (or in inferReturnWrapping) is caught directly, not
+// only via the IR-diff gate.
 
 TEST(NativeCallDescriptor, DescriptorStorage_RequireListU8ArgPopulated) {
     // encodeBytes(input: List<u8>) -> str: descriptor captures arg index 0
@@ -213,15 +213,12 @@ TEST(NativeCallDescriptor, DescriptorStorage_ResultOutParamWithType) {
     EXPECT_EQ(desc.error_channel, "__ry_filesystem_get_last_error");
 }
 
-// =============================================================================
-// Installment 2-a (#2338): resource_kind population
-//
+// ===== [internal] Installment 2-a (#2338): resource_kind population =====
 // inferResourceKind looks up the inner type of a Result<T, Error> against
 // ResourceKindRegistry. For io::open's `Result<File, Error>` return type
 // the registered "File" kind (rk_file, registered at static init in
 // src/codegen_call_io.cpp) is captured on the descriptor. Non-resource
 // returners (str, int, List<u8>, Unit) get NONE.
-// =============================================================================
 
 TEST(NativeCallDescriptor, DescriptorStorage_ResourceKindForOpenReturnsFile) {
     // io::open(path: str, mode: str) -> Result<File, Error>: the descriptor
@@ -302,16 +299,12 @@ TEST(NativeCallDescriptor, DescriptorStorage_ResourceKindNoneForFilesystemFileSi
     EXPECT_EQ(it->second[0].resource_kind, ResourceKindRegistry::NONE);
 }
 
-// =============================================================================
-// Installment 2-b (#2339): per-entry error_channel override via
-// ResourceKindRegistry::Info::errorChannelLibrary
-//
+// ===== [internal] Installment 2-b (#2339): per-entry error_channel override via ResourceKindRegistry::Info::errorChannelLibrary =====
 // TlsStream is the only resource today whose error channel module differs
 // from its owning library: it lives in the http library (linkage) but
 // reports errors through __ry_tls_get_last_error. The descriptor populator
 // reads `errorChannelLibrary` and overrides `error_channel` accordingly,
 // independent of the @native package tag.
-// =============================================================================
 
 TEST(NativeCallDescriptor, ErrorChannelOverride_TlsStreamGoesToTlsChannel) {
     // @native("net") tlsConnect(...) -> Result<TlsStream, Error>:

--- a/tests/test_regex_runtime.cpp
+++ b/tests/test_regex_runtime.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — drives __ry_regex_* runtime entry
+// points directly via byte-length-aware C API.
+
 #include <gtest/gtest.h>
 #include "ry/runtime/core/arc.hpp"
 #include "ry/runtime/core/regex.hpp"
@@ -11,9 +17,7 @@
 
 using namespace ry;
 
-// ============================================================
-// Local helpers matching the runtime list layout
-// ============================================================
+// ===== [internal] Local helpers matching the runtime list layout =====
 
 struct ListHeader {
     int64_t len;
@@ -78,9 +82,7 @@ static std::string regexLastError() {
     return msg;
 }
 
-// ============================================================
-// regexMatch tests
-// ============================================================
+// ===== [internal] regexMatch tests =====
 
 TEST(RegexRuntime, MatchLiteral) {
     EXPECT_EQ(rm("hello", "hello"), 1);
@@ -186,9 +188,7 @@ TEST(RegexRuntime, MatchShorthandClasses) {
     EXPECT_EQ(rm("\\D+", "123"), 0);
 }
 
-// ============================================================
-// regexSearch tests
-// ============================================================
+// ===== [internal] regexSearch tests =====
 
 TEST(RegexRuntime, SearchBasic) {
     EXPECT_EQ(rs("world", "hello world"), 6);
@@ -218,9 +218,7 @@ TEST(RegexRuntime, InvalidPatternReturnsRecoverableErrorForSearch) {
     EXPECT_EQ(regexLastError(), "regex error: unmatched '(' in pattern '('");
 }
 
-// ============================================================
-// regexReplace tests
-// ============================================================
+// ===== [internal] regexReplace tests =====
 
 TEST(RegexRuntime, ReplaceBasic) {
     const char *result = rr("world", "hello world", "universe");
@@ -251,9 +249,7 @@ TEST(RegexRuntime, InvalidPatternReturnsNullForReplace) {
     EXPECT_EQ(regexLastError(), "regex error: unmatched '(' in pattern '('");
 }
 
-// ============================================================
-// Capture group backreference tests (#829)
-// ============================================================
+// ===== [internal] Capture group backreference tests (#829) =====
 
 TEST(RegexRuntime, ReplaceCaptureFastPath) {
     // No backreferences → existing fast path, groups have no effect
@@ -355,9 +351,7 @@ TEST(RegexRuntime, ReplaceMalformedBrace) {
     freeStringSlot(const_cast<char *>(r2));
 }
 
-// ============================================================
-// regexSplit tests
-// ============================================================
+// ===== [internal] regexSplit tests =====
 
 TEST(RegexRuntime, SplitBasic) {
     auto *list = rsp(",", "a,b,c");
@@ -384,9 +378,7 @@ TEST(RegexRuntime, SplitNoMatch) {
     freeStringList(list);
 }
 
-// ============================================================
-// regexFindAll tests
-// ============================================================
+// ===== [internal] regexFindAll tests =====
 
 TEST(RegexRuntime, FindAllBasic) {
     auto *list = rfa("[0-9]+", "a1b23c456");
@@ -445,9 +437,7 @@ TEST(RegexRuntime, FindAllUnmatchedOptionalGroup) {
     freeMatchList(list);
 }
 
-// ============================================================
-// Range quantifier tests {n}, {n,m}, {n,}
-// ============================================================
+// ===== [internal] Range quantifier tests {n}, {n,m}, {n,} =====
 
 TEST(RegexRuntime, QuantifierExact) {
     EXPECT_EQ(rm("a{3}", "aaa"), 1);
@@ -510,9 +500,7 @@ TEST(RegexRuntime, QuantifierFindAll) {
     freeMatchList(list);
 }
 
-// ============================================================
-// Non-greedy (lazy) when tests
-// ============================================================
+// ===== [internal] Non-greedy (lazy) when tests =====
 
 TEST(RegexRuntime, LazyStarReplace) {
     // Greedy: ".*" matches the longest string between first and last quote
@@ -575,9 +563,7 @@ TEST(RegexRuntime, LazyFindAll) {
     freeMatchList(list);
 }
 
-// ============================================================
-// Word boundary \b / \B tests
-// ============================================================
+// ===== [internal] Word boundary \b / \B tests =====
 
 TEST(RegexRuntime, WordBoundarySearch) {
     // \bworld\b matches "world" in "hello world"
@@ -622,9 +608,7 @@ TEST(RegexRuntime, WordBoundaryFindAll) {
     freeMatchList(list);
 }
 
-// ============================================================
-// Case-insensitive (?i) tests
-// ============================================================
+// ===== [internal] Case-insensitive (?i) tests =====
 
 TEST(RegexRuntime, CaseInsensitiveMatch) {
     EXPECT_EQ(rm("(?i)hello", "HELLO"), 1);
@@ -667,9 +651,7 @@ TEST(RegexRuntime, CaseInsensitiveFindAll) {
     freeMatchList(list);
 }
 
-// ============================================================
-// Performance regression tests (issue #107)
-// ============================================================
+// ===== [regression #107] Performance regression tests =====
 
 TEST(RegexRuntime, PerfSearchLongNonMatch) {
     // Pattern "a" on 10000 'b's: previously O(n^2), now O(n*s)
@@ -727,7 +709,7 @@ TEST(RegexRuntime, LazyFindAllLeftmostStart) {
     freeMatchList(list);
 }
 
-// --- ReDoS protection tests ---
+// ===== [internal] ReDoS protection tests =====
 
 TEST(RegexSecurity, ModerateGroupNestingSucceeds) {
     // 10 nested groups should work fine
@@ -740,9 +722,7 @@ TEST(RegexSecurity, NormalPatternWithStepLimit) {
     EXPECT_TRUE(rm("(a+)(b+)(c+)", "aaabbbccc"));
 }
 
-// ============================================================
-// NUL byte safety tests (#1052)
-// ============================================================
+// ===== [regression #1052] NUL byte safety tests =====
 
 TEST(RegexNul, MatchWithNulSubject) {
     // "a.b" should match "a\0b" because '.' matches any byte including NUL
@@ -823,9 +803,7 @@ TEST(RegexNul, PatternWithNul) {
     EXPECT_EQ(__ry_regex_match(pat, 3, bad,  3), 0);
 }
 
-// ============================================================
-// Multibyte char-index tests (#2265)
-// ============================================================
+// ===== [regression #2265] Multibyte char-index tests =====
 
 TEST(RegexMultibyte, SearchAfterThreeByteCodepoint) {
     // "あx": 'あ' = 3 bytes, 'x' at char index 1
@@ -852,9 +830,7 @@ TEST(RegexMultibyte, SearchWithNulAndMultibyte) {
     EXPECT_EQ(__ry_regex_search("x", 1, text, 5), 2);
 }
 
-// ============================================================
-// __ry_regex_is_match tests — partial (unanchored) match semantics (#1197)
-// ============================================================
+// ===== [regression #1197] __ry_regex_is_match tests — partial (unanchored) match semantics =====
 
 TEST(RegexRuntime, IsMatchPartial_FoundAnywhere) {
     EXPECT_EQ(rim("[0-9]+", "Hello 123 World"), 1);

--- a/tests/test_runtime_any.cpp
+++ b/tests/test_runtime_any.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — constructs RyAny by hand and calls
+// __ry_any_* runtime entry points directly.
+
 #include "ry/runtime/core/any.hpp"
 #include "ry/runtime/core/string.hpp"
 #include <gtest/gtest.h>
@@ -15,7 +21,7 @@ protected:
     }
 };
 
-// ===== Helpers =====
+// ===== [internal] Helpers =====
 
 static RyAny mkInt(int64_t v) {
     RyAny a;
@@ -79,7 +85,7 @@ static const char *getStr(const RyAny *a) {
     return v;
 }
 
-// ===== Type error (#224) =====
+// ===== [internal] Type error (#224) =====
 
 TEST_F(RuntimeAnyDeathTest, TypeErrorPrintsMessageAndExits) {
     EXPECT_EXIT(
@@ -97,7 +103,7 @@ TEST_F(RuntimeAnyDeathTest, TypeErrorDifferentOps) {
     );
 }
 
-// ===== Arithmetic: add (#221) =====
+// ===== [internal] Arithmetic: add (#221) =====
 
 TEST(RuntimeAnyArith, AddVariants) {
     // IntPlusInt
@@ -139,7 +145,7 @@ TEST(RuntimeAnyArith, AddVariants) {
     }
 }
 
-// ===== Arithmetic: sub =====
+// ===== [internal] Arithmetic: sub =====
 
 TEST(RuntimeAnyArith, SubVariants) {
     // IntMinusInt
@@ -158,7 +164,7 @@ TEST(RuntimeAnyArith, SubVariants) {
     }
 }
 
-// ===== Arithmetic: mul =====
+// ===== [internal] Arithmetic: mul =====
 
 TEST(RuntimeAnyArith, MulVariants) {
     // IntTimesInt
@@ -206,7 +212,7 @@ TEST(RuntimeAnyArith, MulVariants) {
     }
 }
 
-// ===== Arithmetic: div =====
+// ===== [internal] Arithmetic: div =====
 
 TEST(RuntimeAnyArith, DivVariants) {
     // IntDivInt
@@ -248,7 +254,7 @@ TEST(RuntimeAnyArith, DivVariants) {
     }
 }
 
-// ===== Arithmetic: mod =====
+// ===== [internal] Arithmetic: mod =====
 
 TEST(RuntimeAnyArith, ModVariants) {
     // IntModInt
@@ -267,7 +273,7 @@ TEST(RuntimeAnyArith, ModVariants) {
     }
 }
 
-// ===== Arithmetic: floordiv =====
+// ===== [internal] Arithmetic: floordiv =====
 
 TEST(RuntimeAnyArith, FloordivVariants) {
     // IntFloorDivInt
@@ -300,7 +306,7 @@ TEST(RuntimeAnyArith, FloordivVariants) {
     }
 }
 
-// ===== Arithmetic: pow =====
+// ===== [internal] Arithmetic: pow =====
 
 TEST(RuntimeAnyArith, PowVariants) {
     // IntPowInt
@@ -333,7 +339,7 @@ TEST(RuntimeAnyArith, PowVariants) {
     }
 }
 
-// ===== Arithmetic: neg =====
+// ===== [internal] Arithmetic: neg =====
 
 TEST(RuntimeAnyArith, NegVariants) {
     // NegInt
@@ -352,7 +358,7 @@ TEST(RuntimeAnyArith, NegVariants) {
     }
 }
 
-// ===== Comparison: eq/ne (#222) =====
+// ===== [internal] Comparison: eq/ne (#222) =====
 
 TEST(RuntimeAnyCmp, EqNeVariants) {
     // IntEqInt
@@ -404,7 +410,7 @@ TEST(RuntimeAnyCmp, EqNeVariants) {
     }
 }
 
-// ===== Comparison: ordering (#222) =====
+// ===== [internal] Comparison: ordering (#222) =====
 
 TEST(RuntimeAnyCmp, OrdVariants) {
     // IntLtInt
@@ -442,7 +448,7 @@ TEST(RuntimeAnyCmp, OrdVariants) {
     }
 }
 
-// ===== NaN comparisons =====
+// ===== [internal] NaN comparisons =====
 
 TEST(RuntimeAnyCmp, NaNComparisons) {
     RyAny nan = mkFloat(NAN), one = mkFloat(1.0), iVal = mkInt(42);
@@ -486,9 +492,9 @@ TEST(RuntimeAnyCmp, NaNComparisons) {
     EXPECT_EQ(__ry_any_ge(&nan, &iVal), 0);
 }
 
-// ===== Death tests: arithmetic errors =====
+// ===== [internal] Death tests: arithmetic errors =====
 
-// ===== String auto-concatenation (#393) =====
+// ===== [internal] String auto-concatenation (#393) =====
 
 TEST(RuntimeAnyArith, AddIntPlusStr) {
     RyAny a = mkInt(1), b = mkStr("x"), r;
@@ -556,7 +562,7 @@ TEST_F(RuntimeAnyDeathTest, NegStrError) {
     );
 }
 
-// ===== Death tests: ordering type errors =====
+// ===== [internal] Death tests: ordering type errors =====
 
 TEST_F(RuntimeAnyDeathTest, OrdDifferentTypesError) {
     RyAny a = mkInt(1), b = mkStr("x");
@@ -576,7 +582,7 @@ TEST_F(RuntimeAnyDeathTest, OrdGtReportsCorrectOp) {
     );
 }
 
-// ===== Death tests: NaN ordering with incompatible types =====
+// ===== [internal] Death tests: NaN ordering with incompatible types =====
 
 TEST_F(RuntimeAnyDeathTest, NaNOrderingWithBool) {
     RyAny nan = mkFloat(NAN);
@@ -608,7 +614,7 @@ TEST_F(RuntimeAnyDeathTest, NaNOrderingWithString) {
     EXPECT_EXIT(__ry_any_ge(&str, &nan), ::testing::ExitedWithCode(1), ".*");
 }
 
-// ===== __ry_any_to_string =====
+// ===== [internal] __ry_any_to_string =====
 
 TEST(RuntimeAnyToString, IntToString) {
     RyAny a = mkInt(42);
@@ -658,7 +664,7 @@ TEST(RuntimeAnyToString, UnitToString) {
     freeStringSlot(const_cast<char*>(s));
 }
 
-// ===== __ry_any_to_string_in_collection =====
+// ===== [internal] __ry_any_to_string_in_collection =====
 
 TEST(RuntimeAnyToStringInCollection, StrQuoted) {
     RyAny a = mkStr("hello");

--- a/tests/test_runtime_arc_contention_stress.cpp
+++ b/tests/test_runtime_arc_contention_stress.cpp
@@ -1,3 +1,10 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — replicates the atomic retain/release
+// ops emitted by emitArcRetain / emitArcRelease. Section header tag:
+// [regression #872].
+
 #include "ry/ry_layout.hpp"
 #include "ry/runtime/core/alloc.hpp"
 

--- a/tests/test_runtime_gc.cpp
+++ b/tests/test_runtime_gc.cpp
@@ -1,3 +1,7 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+
 #include "test_codegen_common.hpp"
 #include "ry/runtime/native/gc.hpp"
 #include "ry/ry_layout.hpp"
@@ -7,10 +11,7 @@
 
 
 using namespace ry;
-// ============================================================
-//  Cycle Collector tests (pure C++ — validates the runtime
-//  trial deletion algorithm)
-// ============================================================
+// ===== [internal] Cycle Collector tests (pure C++ — validates the runtime trial deletion algorithm) =====
 
 namespace {
 
@@ -99,7 +100,7 @@ void dtorContainer(void *data) {
 
 } // anonymous namespace
 
-// ===== Basic API tests =====
+// ===== [internal] Basic API tests =====
 
 TEST(GcTest, CollectEmptyReturnsZero) {
     // Ensure initial state is clean.
@@ -128,7 +129,7 @@ TEST(GcTest, SetThreshold) {
     __ry_gc_setThreshold(700);
 }
 
-// ===== Cycle detection and collection =====
+// ===== [internal] Cycle detection and collection =====
 
 TEST(GcTest, SimpleCycleCollected) {
     __ry_gc_enable();
@@ -328,7 +329,7 @@ TEST(GcTest, ImmortalObjectSkipped) {
     std::free(hdrA);
 }
 
-// ===== Record visit function tests =====
+// ===== [internal] Record visit function tests =====
 
 TEST(GcTest, RecordCycleCollected) {
     // Simulates a cycle through record types embedded in ARC objects:

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — exercises __ry_http_* runtime entry
+// points directly with socketpair / mock TCP harness.
+
 #include <gtest/gtest.h>
 #include <cstdlib>
 #include <cstring>
@@ -74,7 +80,7 @@ struct TcpStreamHandle {
     int fd;
 };
 
-// --- Merged unit test for __ry_http_reason_phrase ---
+// ===== [internal] Merged unit test for __ry_http_reason_phrase =====
 
 TEST(RuntimeHttp, ReasonPhraseAll) {
     // 1xx
@@ -145,7 +151,7 @@ TEST(RuntimeHttp, ReasonPhraseAll) {
     EXPECT_STREQ(__ry_http_reason_phrase(299), "Unknown");
 }
 
-// --- Merged unit test for __ry_http_parse_content_length ---
+// ===== [internal] Merged unit test for __ry_http_parse_content_length =====
 
 TEST(RuntimeHttp, ParseContentLength) {
     // Valid
@@ -175,7 +181,7 @@ TEST(RuntimeHttp, ParseContentLength) {
     EXPECT_EQ(__ry_http_parse_content_length("  100  "), 100);
 }
 
-// --- socketpair integration tests for __ry_http_read_request ---
+// ===== [internal] socketpair integration tests for __ry_http_read_request =====
 
 // Helper: write data to fd and close the write end
 static void send_and_close(int fd, const std::string &data) {
@@ -327,7 +333,7 @@ TEST(RuntimeHttp, ReadRequestPostBodySplitAcrossRecv) {
     free(handle);
 }
 
-// --- Query parameter tests ---
+// ===== [internal] Query parameter tests =====
 
 TEST(RuntimeHttp, QueryParamsBasic) {
     int fds[2];
@@ -554,7 +560,7 @@ TEST(RuntimeHttp, QueryAllDuplicateFirstWins) {
     free(handle);
 }
 
-// --- Merged URL parsing tests ---
+// ===== [internal] Merged URL parsing tests =====
 
 TEST(RuntimeHttpClient, ParseUrlValid) {
     // Basic
@@ -656,7 +662,7 @@ TEST(RuntimeHttpClient, ParseUrlInvalid) {
     EXPECT_EQ(__ry_http_parse_url("http://example.com:abc/path"), nullptr);
 }
 
-// --- HTTP client integration tests ---
+// ===== [internal] HTTP client integration tests =====
 
 static void mock_http_server(int fd, const std::string &response) {
     char buf[4096];
@@ -935,7 +941,7 @@ TEST_F(RuntimeHttpClientTest, HopByHopHeadersFiltered) {
     free(map);
 }
 
-// --- Cookie tests ---
+// ===== [internal] Cookie tests =====
 
 TEST(RuntimeHttp, CookieBasic) {
     int fds[2];
@@ -1104,7 +1110,7 @@ TEST(RuntimeHttp, CookiesAllDuplicateFirstWins) {
     free(handle);
 }
 
-// --- Chunked transfer encoding tests ---
+// ===== [internal] Chunked transfer encoding tests =====
 
 TEST(RuntimeHttp, ChunkedRequestBasic) {
     int fds[2];
@@ -1362,7 +1368,7 @@ TEST_F(RuntimeHttpClientTest, ChunkedClientResponseMultipleChunks) {
     ::close(srv);
 }
 
-// --- SSRF protection tests ---
+// ===== [internal] SSRF protection tests =====
 
 TEST(HttpSSRF, PrivateHostLoopback) {
     EXPECT_TRUE(__ry_is_private_host("127.0.0.1", 80));
@@ -1388,7 +1394,7 @@ TEST(HttpSSRF, PublicHostAllowed) {
     EXPECT_FALSE(__ry_is_private_host("8.8.8.8", 80));
 }
 
-// --- IPv4-mapped IPv6 SSRF tests ---
+// ===== [internal] IPv4-mapped IPv6 SSRF tests =====
 
 TEST(HttpSSRF, PrivateHostIPv4MappedLoopback) {
     EXPECT_TRUE(__ry_is_private_host("::ffff:127.0.0.1", 80));
@@ -1402,7 +1408,7 @@ TEST(HttpSSRF, PublicHostIPv4MappedPublic) {
     EXPECT_FALSE(__ry_is_private_host("::ffff:8.8.8.8", 80));
 }
 
-// --- DNS resolve and private addrinfo tests ---
+// ===== [internal] DNS resolve and private addrinfo tests =====
 
 TEST(HttpSSRF, ResolveLocalhost) {
     struct addrinfo *result = nullptr;
@@ -1450,7 +1456,7 @@ TEST(HttpSSRF, PublicAddrInfoSynthetic) {
     EXPECT_FALSE(__ry_is_private_addrinfo(&ai));
 }
 
-// --- Additional SSRF range tests (IPv4) ---
+// ===== [internal] Additional SSRF range tests (IPv4) =====
 
 TEST(HttpSSRF, PrivateHostCarrierGradeNAT) {
     EXPECT_TRUE(__ry_is_private_host("100.64.0.1", 80));
@@ -1522,7 +1528,7 @@ TEST(HttpSSRF, PublicHostBelowMulticast) {
     EXPECT_FALSE(__ry_is_private_host("223.255.255.255", 80));
 }
 
-// --- Additional SSRF range tests (IPv6 synthetic) ---
+// ===== [internal] Additional SSRF range tests (IPv6 synthetic) =====
 
 TEST(HttpSSRF, PrivateAddrIPv6Unspecified) {
     struct sockaddr_in6 sin6{};
@@ -1543,7 +1549,7 @@ TEST(HttpSSRF, PrivateAddrNullSockaddr) {
     EXPECT_FALSE(__ry_is_private_addr(nullptr));
 }
 
-// --- Multipart form-data tests ---
+// ===== [internal] Multipart form-data tests =====
 
 TEST(RuntimeHttp, FormFieldBasic) {
     int fds[2];
@@ -1825,7 +1831,7 @@ TEST(RuntimeHttp, FormFieldNoBody) {
     free(handle);
 }
 
-// --- NUL byte regression tests (#281) ---
+// ===== [regression #281] NUL byte regression tests =====
 
 // Helper: write raw bytes (including NUL) to fd and close
 static void send_raw_and_close(int fd, const char *data, size_t len) {
@@ -2114,7 +2120,7 @@ TEST(RuntimeHttp, FormFileDefaultContentType) {
     free(handle);
 }
 
-// --- Response header CRLF injection tests ---
+// ===== [internal] Response header CRLF injection tests =====
 
 // Helper to build a MapHeader for response CRLF tests
 static MapHeader *build_response_headers(

--- a/tests/test_runtime_io_file.cpp
+++ b/tests/test_runtime_io_file.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — drives __ry_io_file_* runtime entry
+// points directly.
+
 #include "ry/runtime/native/io.hpp"
 #include "ry/runtime/core/string.hpp"
 #include "ry/runtime/core/arc.hpp"

--- a/tests/test_runtime_json.cpp
+++ b/tests/test_runtime_json.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — drives __ry_json_parse_to_any /
+// __ry_json_release_any with hand-built RyAny.
+
 #include "ry/runtime/native/json.hpp"
 #include "ry/runtime/core/any.hpp"
 #include "ry/runtime/core/arc.hpp"
@@ -39,7 +45,7 @@ static const ::testing::Environment *const kMsCleanup =
 // nested list/map elements so list/map smoke tests stay ASan/LSan clean.
 static void releaseAny(RyAny &v) { __ry_json_release_any(&v); }
 
-// ---- Primitives ----
+// ===== [internal] Primitives =====
 
 TEST(JsonParseToAny, ParsesNullToUnitTag) {
     RyAny out{};
@@ -95,7 +101,7 @@ TEST(JsonParseToAny, ParsesStringToStrTag) {
     releaseAny(out);
 }
 
-// ---- Arrays ----
+// ===== [internal] Arrays =====
 
 TEST(JsonParseToAny, ParsesArrayToListTag) {
     RyAny out{};
@@ -118,7 +124,7 @@ TEST(JsonParseToAny, ParsesEmptyArrayToListTag) {
     releaseAny(out);
 }
 
-// ---- Objects ----
+// ===== [internal] Objects =====
 
 TEST(JsonParseToAny, ParsesObjectToMapTag) {
     RyAny out{};
@@ -141,7 +147,7 @@ TEST(JsonParseToAny, ParsesEmptyObjectToMapTag) {
     releaseAny(out);
 }
 
-// ---- Errors ----
+// ===== [internal] Errors =====
 
 TEST(JsonParseToAny, RejectsInvalidInput) {
     RyAny out{};
@@ -161,7 +167,7 @@ TEST(JsonParseToAny, RejectsEmptyInput) {
     EXPECT_NE(status, 0);
 }
 
-// ---- Depth limit ----
+// ===== [internal] Depth limit =====
 
 TEST(JsonParseToAny, AcceptsMaxNestingDepth) {
     std::string deep;
@@ -182,7 +188,7 @@ TEST(JsonParseToAny, RejectsTooDeepNesting) {
     EXPECT_NE(status, 0);
 }
 
-// ---- Stringify primitives ----
+// ===== [internal] Stringify primitives =====
 
 TEST(JsonStringifyAny, EncodesUnitAsNull) {
     RyAny v = anyFromUnit();
@@ -228,7 +234,7 @@ TEST(JsonStringifyAny, EncodesNulInsideString) {
     freeStringSlot(const_cast<char *>(s));
 }
 
-// ---- Unified stringify ABI (#1890) ----
+// ===== [internal] Unified stringify ABI (#1890) =====
 //
 // __ry_json_stringify_any_ex / _safe_ex are the codegen-facing entry
 // points after #1890. The four name-encoded variants (`_sorted`, `_safe`,

--- a/tests/test_runtime_json5.cpp
+++ b/tests/test_runtime_json5.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — drives __ry_json5_parse_to_any /
+// __ry_json5_release_any with hand-built RyAny.
+
 #include "ry/runtime/native/json5.hpp"
 #include "ry/runtime/core/any.hpp"
 #include "ry/runtime/core/arc.hpp"
@@ -36,7 +42,7 @@ static const ::testing::Environment *const kMsCleanupJson5 =
 
 static void releaseAny(RyAny &v) { __ry_json5_release_any(&v); }
 
-// ---- Strict-JSON parity: every json input still parses ----
+// ===== [internal] Strict-JSON parity: every json input still parses =====
 
 TEST(Json5ParseToAny, ParsesNullToUnitTag) {
     RyAny out{};
@@ -118,7 +124,7 @@ TEST(Json5ParseToAny, ParsesObjectToMapTag) {
     releaseAny(out);
 }
 
-// ---- Errors ----
+// ===== [internal] Errors =====
 
 TEST(Json5ParseToAny, RejectsEmptyInput) {
     RyAny out{};
@@ -132,7 +138,7 @@ TEST(Json5ParseToAny, RejectsTrailingContent) {
     EXPECT_NE(status, 0);
 }
 
-// ---- JSON5-specific extensions ----
+// ===== [internal] JSON5-specific extensions =====
 
 TEST(Json5ParseToAny, AcceptsLineComment) {
     RyAny out{};
@@ -297,7 +303,7 @@ TEST(Json5ParseToAny, AcceptsLineContinuationInString) {
     releaseAny(out);
 }
 
-// ---- Stringify primitives (JSON5 difference for non-finite floats) ----
+// ===== [internal] Stringify primitives (JSON5 difference for non-finite floats) =====
 
 TEST(Json5StringifyAnyEx, EncodesIntegerAsDigits) {
     RyAny v = anyFromInt(7);
@@ -357,7 +363,7 @@ TEST(Json5StringifyAnyEx, SortKeysSortsMapKeys) {
     releaseAny(m);
 }
 
-// ---- Round-trip ----
+// ===== [internal] Round-trip =====
 
 TEST(Json5RoundTrip, NaNRoundTrips) {
     // load("NaN") → stringify → "NaN" → load → NaN

--- a/tests/test_runtime_json5_any_panic.cpp
+++ b/tests/test_runtime_json5_any_panic.cpp
@@ -1,3 +1,10 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file tag: [regression #1811] mirror (json5) — guards typed-non-any
+// collection OOB on json5.stringify(any) by driving runtime entry points
+// directly.
+
 #include "ry/runtime/core/alloc.hpp"
 #include "ry/runtime/core/any.hpp"
 #include "ry/runtime/core/any_typed_coll.hpp"

--- a/tests/test_runtime_json_any_panic.cpp
+++ b/tests/test_runtime_json_any_panic.cpp
@@ -1,3 +1,10 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file tag: [regression #1811] — guards against the typed-non-any
+// collection OOB by driving __ry_any_register_typed_coll / __ry_json_stringify_any
+// directly.
+
 #include "ry/runtime/core/alloc.hpp"
 #include "ry/runtime/core/any.hpp"
 #include "ry/runtime/core/any_typed_coll.hpp"
@@ -29,9 +36,7 @@ protected:
     }
 };
 
-// =========================================================================
-// Rejection branch: typed-non-any collection wrapped in any → panic
-// =========================================================================
+// ===== [regression #1811] Rejection branch: typed-non-any collection wrapped in any → panic =====
 
 TEST_F(JsonAnyTypedCollPanicTest, StringifyListIntPanics) {
     EXPECT_EXIT({
@@ -88,13 +93,10 @@ TEST_F(JsonAnyTypedCollPanicTest, StringifyMapStrIntPanics) {
        "any holds typed collection 'Map<str, int>'");
 }
 
-// =========================================================================
-// Positive siblings: List<any> / Map<str, any> still stringify normally.
-// (No side-table entry — the wrap arm's gate `meta->*_elem != anyTy_`
-//  excludes these.) Required by `.claude/skills/test-checklist/SKILL.md`:
-// "New rejections that narrow a form need a positive test for the
-//  preserved sibling".
-// =========================================================================
+// ===== [regression #1811] Positive siblings: List<any> / Map<str, any> still stringify normally =====
+// No side-table entry — the wrap arm's gate `meta->*_elem != anyTy_` excludes
+// these. Required by `.claude/skills/test-checklist/SKILL.md`: "New rejections
+// that narrow a form need a positive test for the preserved sibling".
 
 TEST_F(JsonAnyTypedCollPanicTest, StringifyListAnyIsOk) {
     // List<any> = [1, "x", true]

--- a/tests/test_runtime_lock_stress.cpp
+++ b/tests/test_runtime_lock_stress.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — drives __ry_lock_acquire /
+// __ry_lock_release under high contention. Section header tag: [regression #872].
+
 #include "ry/runtime/native/thread.hpp"
 
 #include <gtest/gtest.h>

--- a/tests/test_runtime_print.cpp
+++ b/tests/test_runtime_print.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — exercises __ry_sprint_* runtime entry
+// points directly to assert depth limit and buffer behavior.
+
 #include "ry/runtime/core/print.hpp"
 #include "ry/runtime/core/string.hpp"
 #include <gtest/gtest.h>

--- a/tests/test_runtime_rwlock_stress.cpp
+++ b/tests/test_runtime_rwlock_stress.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — exercises __ry_rwlock_acquire / release
+// dispatch directly under contention. Section header tag: [regression #871].
+
 #include "ry/runtime/native/thread.hpp"
 #include "ry/runtime/core/arc.hpp"
 #include "ry/runtime/native/io.hpp"

--- a/tests/test_runtime_string.cpp
+++ b/tests/test_runtime_string.cpp
@@ -1,3 +1,10 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — calls makeString / freeStringSlot /
+// stringByteLen / stringHeaderPtr / __ry_str_split directly to assert layout
+// invariants.
+
 #include "ry/runtime/core/string.hpp"
 #include "ry/runtime/core/list.hpp"
 #include "ry/ry_layout.hpp"
@@ -9,7 +16,7 @@ extern "C" void *__ry_str_split(const char *s, int64_t sLen,
 
 using namespace ry;
 
-// ===== Layout constants =====
+// ===== [internal] Layout constants =====
 
 TEST(StringHeader, LayoutConstants) {
     EXPECT_EQ(STRING_HEADER_EXTRA, 8u);
@@ -19,7 +26,7 @@ TEST(StringHeader, LayoutConstants) {
     EXPECT_EQ(STRING_HEADER_SIZE, ARC_HEADER_SIZE + 8u);
 }
 
-// ===== makeString =====
+// ===== [internal] makeString =====
 
 TEST(StringHeader, MakeStringEmpty) {
     char *s = makeString("", 0);
@@ -68,7 +75,7 @@ TEST(StringHeader, MakeStringSingleNulByte) {
     freeStringSlot(s);
 }
 
-// ===== makeStringUninit =====
+// ===== [internal] makeStringUninit =====
 
 TEST(StringHeader, MakeStringUninitSetsLenAndTerminator) {
     char *s = makeStringUninit(7);
@@ -86,7 +93,7 @@ TEST(StringHeader, MakeStringUninitZeroLength) {
     freeStringSlot(s);
 }
 
-// ===== stringByteLen =====
+// ===== [internal] stringByteLen =====
 
 TEST(StringHeader, ByteLenReflectsActualLength) {
     char *s = makeString("xyz", 3);
@@ -117,7 +124,7 @@ TEST(StringHeader, ByteLenIsIndependentOfStrcmp) {
     freeStringSlot(b);
 }
 
-// ===== stringHeaderPtr =====
+// ===== [internal] stringHeaderPtr =====
 
 TEST(StringHeader, HeaderPtrIsOffsetBeforeData) {
     char *s = makeString("test", 4);
@@ -131,14 +138,14 @@ TEST(StringHeader, HeaderPtrIsOffsetBeforeData) {
     freeStringSlot(s);
 }
 
-// ===== freeStringSlot =====
+// ===== [internal] freeStringSlot =====
 
 TEST(StringHeader, FreeStringSlotNullIsNoop) {
     // Should not crash
     freeStringSlot(nullptr);
 }
 
-// ===== NUL-safe operations =====
+// ===== [internal] NUL-safe operations =====
 
 TEST(StringHeader, MemcmpCanDistinguishNulEmbeddedStrings) {
     const char a_src[] = {'a', '\0', 'b'};
@@ -169,7 +176,7 @@ TEST(StringHeader, ConcatViaMemcpy) {
     freeStringSlot(buf);
 }
 
-// ===== __ry_str_split =====
+// ===== [internal] __ry_str_split =====
 
 // Helper: cast __ry_str_split result to ListHeader*.
 static ry::ListHeader *doSplit(const char *s, int64_t sLen,

--- a/tests/test_runtime_utf8.cpp
+++ b/tests/test_runtime_utf8.cpp
@@ -1,3 +1,9 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+// Per-test exceptions use an inline `// [regression: #NNNN]` comment.
+// Whole-file dominant tag: [internal] — drives __ry_utf8_* runtime entry points
+// directly to assert byte-level behavior.
+
 #include <gtest/gtest.h>
 #include "ry/runtime/core/string.hpp"
 #include <cstdlib>
@@ -124,7 +130,7 @@ TEST(RuntimeUtf8, CharIndexMixed) {
     EXPECT_EQ(__ry_utf8_char_index("caf\xC3\xA9", 3), 3);
 }
 
-// --- __ry_utf8_char_at_checked tests ---
+// ===== [internal] __ry_utf8_char_at_checked tests =====
 
 TEST(RuntimeUtf8, CharAtCheckedAscii) {
     expectStr(__ry_utf8_char_at_checked("hello", 5, 0), "h");
@@ -158,7 +164,7 @@ TEST(RuntimeUtf8, CharAtCheckedNegativeUtf8) {
 // death tests: StringCharAtOutOfRange, StringCharAtNegativeOOB,
 // StringCharAtEmptyString, StringCharAtUTF8OutOfRange.
 
-// --- NUL-safe tests (#1049) ---
+// ===== [regression #1049] NUL-safe tests =====
 
 TEST(RuntimeUtf8, SubstringNulEmbedded) {
     // "a\0b" (byteLen=3): substr(0,3) must return all 3 bytes


### PR DESCRIPTION
## Summary

#1831 / PR #2294 で `tests/test_parser.cpp` に試行した contract / internal / regression section header 規約を、codegen 層 (`tests/test_codegen_*.cpp`)、runtime / ABI 層 (`tests/test_runtime_*.cpp`, `tests/test_abi_layout.cpp`, `tests/test_coverage_runtime.cpp`, `tests/test_regex_runtime.cpp`)、および ABI / native-descriptor 隣接ファイル (`tests/test_header_layout.cpp`, `tests/test_emit_abi_guards.cpp`, `tests/test_native_call_descriptor.cpp`) に適用。テスト名・本体は完全に無変更で section header コメントのみ。

`docs/reference/test-taxonomy.md`:
- `## カテゴリ分布は層によって偏る` を「予測」から「pilot 観察に基づく分布表」に書き換え (parser 47/4/0、codegen+ABI 273/26/22、runtime 0/8/78)。`[internal]` が立った具体ファイルもリスト化。
- section header が立たない単一スコープ file 用に whole-file dominant tag 規約を追記。
- `tests/test_emit_llvm_ir.cpp` は CLI subprocess black-box テスト (`tests/test_codegen_*` glob 外) のため適用対象外であることを明記。
- `## 関連` の "適用 pilot" 行を "適用済み (parser + codegen + runtime + ABI)" に更新。

## Design notes (review surface)

- `// ---` markers の扱い: `test_runtime_http.cpp` / `test_runtime_utf8.cpp` / `test_codegen_directive.cpp` では `// --- Title ---` が当該ファイルの主 section header だったため `// ===== [tag] Title =====` に統一。一方 `test_emit_abi_guards.cpp` では `// =====` per-issue ブロックが上位、`// ---` は中の sub-marker のため、taxonomy doc L50-52 の dominant-category rule に従い `// ---` は据え置き。
- `changelog.d/<issue>-taxonomy-expansion.md`: issue close criteria #4 が optional 指定で内部規約変更のみのため意図的に skip。
- ASan / UBSan / TSan: コメント編集のみで binary 振る舞いが同一のため parser pilot PR #2294 と同様に省略。
- スコープ外と判断: sema / diagnostic / CLI / lexer / formatter テスト (本 issue の codegen / runtime / ABI スコープ外)、`tests/test_emit_llvm_ir.cpp` (CLI subprocess black box)、`tests/test_regression_2246_*.cpp` / `tests/test_regression_2248_*.cpp` (`tests/test_regression_<issue>_<desc>.cpp` 独立 file 規約に従う既存運用)。

## Test plan

- [x] `cmake --build build-rust --target ry_tests` 成功
- [x] `./build-rust/ry_tests` → 2997/2997 PASSED (本数 #2294 から不変)
- [x] 全 39 ファイルで `TEST(_F|_P)?(...)` の sorted 名 diff vs HEAD = 空 (本体不変)
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` clean

Closes #2383