### PR TITLE
chore(examples): restore inventory_ledger realistic small-program example (#2392)

### DIFF
--- a/examples/inventory_ledger.ry
+++ b/examples/inventory_ledger.ry
@@ -1,0 +1,115 @@
+# 在庫台帳 — Map<str, int> への動的キー挿入で SKU 別在庫を更新し Result で不正操作を拒否する
+
+record Item:
+  sku: str
+  name: str
+  category: str
+
+enum InventoryOp:
+  Receive(int)
+  Ship(int)
+  Adjust(int)
+
+record Transaction:
+  sku: str
+  op: InventoryOp
+
+fn applyOp(stock: Map<str, int>, tx: Transaction) -> Result<Map<str, int>, Error>:
+  current = case get(stock, tx.sku):
+    Some(n) : n
+    None : 0
+  case tx.op:
+    InventoryOp::Receive(n):
+      if n <= 0:
+        return Err(Error(f"receive qty must be positive for {tx.sku}"))
+      stock[tx.sku] = current + n
+      return Ok(stock)
+    InventoryOp::Ship(n):
+      if n <= 0:
+        return Err(Error(f"ship qty must be positive for {tx.sku}"))
+      if n > current:
+        return Err(Error(f"insufficient stock for {tx.sku}: have {current}, need {n}"))
+      stock[tx.sku] = current - n
+      return Ok(stock)
+    InventoryOp::Adjust(n):
+      next = current + n
+      if next < 0:
+        return Err(Error(f"adjust would make {tx.sku} negative ({next})"))
+      stock[tx.sku] = next
+      return Ok(stock)
+
+fn runAll(stock: Map<str, int>, txs: List<Transaction>) -> Result<Map<str, int>, Error>:
+  current = stock
+  for tx in txs:
+    case applyOp(current, tx):
+      Ok(updated):
+        current = updated
+      Err(e):
+        return Err(e)
+  return Ok(current)
+
+fn totalsByCategory(items: List<Item>, stock: Map<str, int>) -> Map<str, int>:
+  totals: Map<str, int> = {}
+  for it in items:
+    qty = case get(stock, it.sku):
+      Some(n) : n
+      None : 0
+    prev = case get(totals, it.category):
+      Some(n) : n
+      None : 0
+    totals[it.category] = prev + qty
+  return totals
+
+fn printStock(items: List<Item>, stock: Map<str, int>):
+  for it in items:
+    qty = case get(stock, it.sku):
+      Some(n) : n
+      None : 0
+    print(f"  {it.sku} {it.name} ({it.category}): {qty}")
+
+# --- demo: opening stock and successful transaction sequence ---
+
+catalog: List<Item> = [
+  Item("BOOK-01", "Hitchhiker's Guide", "books"),
+  Item("BOOK-02", "Crime and Punishment", "books"),
+  Item("MUG-01", "Coffee mug", "kitchenware"),
+  Item("PEN-01", "Ballpoint pen", "stationery")
+]
+
+initial: Map<str, int> = {"BOOK-01": 10, "BOOK-02": 5, "MUG-01": 20, "PEN-01": 50}
+
+transactions: List<Transaction> = [
+  Transaction("BOOK-01", InventoryOp::Receive(7)),
+  Transaction("MUG-01", InventoryOp::Ship(3)),
+  Transaction("PEN-01", InventoryOp::Ship(10)),
+  Transaction("BOOK-02", InventoryOp::Adjust(2))
+]
+
+print("opening stock:")
+printStock(catalog, initial)
+
+case runAll(initial, transactions):
+  Ok(final):
+    print("\nafter transactions:")
+    printStock(catalog, final)
+    print("\ncategory totals:")
+    for k, v in totalsByCategory(catalog, final):
+      print(f"  {k}: {v}")
+  Err(e):
+    print(f"unexpected error: {e.message}")
+
+# --- demo: error path — each guard exercised independently ---
+
+errCases: List<Transaction> = [
+  Transaction("PEN-01", InventoryOp::Ship(9999)),
+  Transaction("BOOK-01", InventoryOp::Receive(0)),
+  Transaction("MUG-01", InventoryOp::Adjust(-9999))
+]
+
+print("\nerror paths:")
+for tx in errCases:
+  case applyOp(initial, tx):
+    Ok(_):
+      print(f"  unexpected: {tx.sku} succeeded")
+    Err(e):
+      print(f"  rejected: {e.message}")


### PR DESCRIPTION
## Summary

- PR #2372 (close #2328) で realistic small-program 11 件追加予定のうち、CI 失敗で drop された 2 件のうち `inventory_ledger.ry` を復元 (もう片方 `temperature_aggregate.ry` は #2376 / PR #2385 で復元済み、依存 SIGSEGV は #2375 / PR #2386 で fix 済み)。
- Map<str, int> 動的キー挿入を主題とした in-place 在庫更新の小規模ドメインモデル (List 半 copy の `examples/stock_ledger.ry` と対をなす設計)。115 行、canonical 品質ルール準拠。
- error path を 3 guard (insufficient stock / non-positive receive / adjust-to-negative) 独立 exercise に展開し `examples/stock_ledger.ry` の慣用に整合。

## Test plan

- [x] `./build-rust/ry run examples/inventory_ledger.ry` exit 0、3 つの error guard すべて発火を確認 (macOS / rust-emit)。
- [x] `bash scripts/check-examples.sh` 102/102 canonical pass (macOS / rust-emit)。
- [ ] CI で Linux / default-emit の examples check pass。

Closes #2392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inventory ledger example that tracks stock by item and processes receive, ship, and adjust transactions.
  * Includes sequential transaction handling with clear success and error outcomes.
  * Adds stock reporting by item and by category, plus sample output for both successful and invalid scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->