### PR TITLE
refactor(codegen): complete descriptor-driven dispatch migration (#2393)

### DIFF
--- a/docs/architecture/native-call-boundary.md
+++ b/docs/architecture/native-call-boundary.md
@@ -36,12 +36,15 @@ The descriptor's field-level shape (intent, not C++ representation — concrete 
 |---|---|---|
 | `module_name` | string | derived from the declaration's containing module (filesystem-driven) |
 | `library_name` | optional string | `@native("<lib>")` tag if present (rule (a) below); else inferred per rule (b); absent for `ry_lib`-resolved symbols |
-| `exported_symbol` | string | currently the `rtSuffix` field in `NativeDispatchEntry`, or `__ry_<pkg>_<name>` for Pattern C |
+| `exported_symbol` | string | per-overload override from `kOverrides` (`src/codegen_native_call_descriptor.cpp`) for the entries whose runtime symbols predate the `__ry_<pkg>_<snake_callee>` convention (`__ry_io_file_open`, `__ry_listen`, `__ry_lock_acquire`, `__ry_tcp_set_timeout`, `__ry_http_body`, …); empty = derive from convention |
 | `signature` | reuse existing `NativeFnSignature` | already defined in `include/ry/codegen.hpp` — keep the field, do not duplicate |
-| `return_wrapping` | `ReturnWrapping` enum | already exists; `Direct` / `ResultPtr` / `ResultStatus` / `ResultOutParam` / `BoolFromI64` / `ResultPtrWithListMeta` |
-| `error_channel` | string | currently per-emitter (`__ry_get_last_error` default; 6 module-specific channels enumerated below) |
-| `resource_kind` | optional registry index | currently a per-emitter call to `addResourceKind(res, rk_X)` after `wrapPtrAsResult` |
+| `return_wrapping` | `CodeGenReturnWrapping` enum (see `include/ry/codegen_native_dispatch.hpp`) | `Direct` / `ResultPtr` / `ResultStatus` / `ResultOutParam` / `BoolFromI64` / `ResultPtrWithListMeta` (pilot, #2337); + `OptionFromNullablePtr` / `ResultOutParamOption` / `IteratorFromHandle` (Installment 2-c, #2381); + `ResourceFree` (Installment 3, #2393 — thread `lockFree` / `rwlockFree` / `semaphoreFree` / `barrierFree`, emits `emitResourceFree`'s null-check + ARC-release sequence with no runtime fn call) |
+| `error_channel` | string | derived from `library_name` for packages with a per-module `__ry_<pkg>_get_last_error` symbol (the `kHasModuleLastError` allow-list in `codegen_fn.cpp`: `base64` / `convert` / `filesystem` / `io` / `net` / `http` / `path` / `regex`); empty otherwise (consumed as `__ry_get_last_error` default at dispatch time — covers `thread` / `gc` / `testing` / `json` / `json5`); overridden by the resource's `errorChannelLibrary` when the resource is declared with one (today only TlsStream → `__ry_tls_get_last_error`) |
+| `resource_kind` | optional registry index | auto-derived from the declared return type: `Result<T, Error>` (pilot, #2338) and bare resource returns (#2393 — `lockNew() -> Lock`, `rwlockNew() -> RWLock`, `atomicIntNew(int) -> AtomicInt`, `atomicBoolNew(bool) -> AtomicBool`). The `Direct` and `ResultPtr` paths in `emitGenericNativeCall` consume it to tag the result via `addResourceKind` |
 | `require_list_u8_arg` | optional arg index | already exists in `NativeDispatchEntry` |
+| `handle_param_index` / `handle_resource_kind` | optional index + registry id | Installment 2-c (#2381). First declared param whose type names a registered resource. Drives emit-time type checks, ResourceFree's destructor lookup (#2393), and `emitGenericNativeCall`'s resource-kind disambiguation for same-LLVM-signature overloads (`body(HttpRequest)` vs `body(HttpClientResponse)`) |
+| `nul_checks` | ordered specs | Installment 2-c (#2381). Per-overload NUL-check specs (param index + hint + per-prefix `err_global_prefix` for byte-exact static-global counters + Ry-visible error message). The vector ordering controls emit-time nesting (httpRequest: outer = method, inner = url) |
+| `iterator_elem_type_name` | string | Installment 2-c (#2381). Iterator<T> element type spelling for `IteratorFromHandle` wrapping; empty otherwise |
 | `mockable` | bool | currently inferred from `test_mode_` + customEmitter path |
 | `overload_group_id` | optional group id | enables multi-arity grouping (current `math_table` ad-hoc) |
 
@@ -105,7 +108,7 @@ The migration follows this discriminator entry-by-entry; the audit deliverable i
 
 ## Pattern B carve-out: hand-written handlers calling into separate libraries
 
-A small set of Pattern B handlers (compiler builtins, no descriptor) calls into a `libry_<mod>` symbol that lives outside `ry_lib`. Today this is expressed as a hand-written `used_native_libraries_.insert("<mod>")` at the top of the relevant branch:
+A small set of Pattern B handlers (compiler builtins, no descriptor) calls into a `libry_<mod>` symbol that lives outside `ry_lib`:
 
 | Caller | Library registered | Why Pattern B intercepts |
 |---|---|---|
@@ -113,14 +116,13 @@ A small set of Pattern B handlers (compiler builtins, no descriptor) calls into 
 | `emitBuiltinConversion`'s `float(s)` → `__ry_str_to_float` (`src/codegen_call.cpp:42`) | `convert` | same |
 | `emitBuiltinCore`'s `input(...)` → `__ry_io_read_line` / `__ry_io_input_prompt` (`src/codegen_call.cpp:615`) | `io` | bare builtin; no `import io` required, so library registration must happen here |
 | `emitBuiltinCore`'s `close(f)` → `__ry_io_file_close` (`src/codegen_call.cpp:726`) | `io` | bare builtin; same |
+| `emitArcRelease` / `emitCowCheckSlot` → `__ry_gc_track` / `__ry_gc_untrack` | `gc` | emitted through the `ry_emit_arc_release` / `ry_emit_cow_ensure_unique` C-ABI boundary (not `getRuntimeFn`) — gc lives in a `libry_gc` shared library but the codegen-side caller has no symbol name to look up |
+| `emitHttpListen` (synthesized 3+-arg HTTP `listen`) → `__ry_net_bind` / `__ry_listen` / `__ry_accept` / `__ry_tcp_*` / `__ry_http_*` | `net` + `http` | declaratively-inexpressible control-flow synthesis (bind / listen / accept loop / dispatch / send_response / close) |
+| `emitBuiltinThread` atomics (`atomicIntNew` etc.) → `__ry_atomic_int_*` / `__ry_atomic_bool_*` | `thread` | value-transform IR (i1↔i64 zext/trunc, CAS i64→i1 trunc, non-callee SSA names like "atomic_int") that the descriptor's wrapping enum does not express |
 
-These four sites are **not** removable by the descriptor-driven inference rule above, because Pattern B handlers never build a descriptor for the call. Three resolutions are possible; none are chosen here:
+**Resolution chosen (#2393, supersedes the v1 "preferred carve-out" stance):** the symbol → library reverse map (formerly described as a deferred alternative). The map lives in `codegen.cpp::kRuntimeSymbolLibraries` as a static prefix table; `getRuntimeFn` and `emitRuntimeCallDirect` consult it on every runtime-symbol reference and call `linkNativeLibrary(<lib>)` for any match. Pattern B carve-outs (the `convert` / `io` rows above, plus `emitHttpListen`'s synthesized `__ry_net_*` / `__ry_http_*` calls and `emitBuiltinThread`'s atomic family) no longer hand-name their library: they emit through `getRuntimeFn` / `emitRuntimeCallDirect` and the auto-link covers them. The `gc` row stays a hand-call because its emit goes through the `ry_emit_arc_release` / `ry_emit_cow_ensure_unique` C-ABI boundary, which the symbol → library hook cannot see — those two sites call `linkNativeLibrary("gc")` directly.
 
-- **Keep as carve-out (preferred for v1).** Pattern B remains hand-written. Retire the general dispatcher-registration rule when descriptor-driven dispatch lands, but keep the carve-out clause for these four sites.
-- **Add a symbol → library reverse map.** Build a `__ry_*` symbol-to-library index from descriptor registration data so Pattern B handlers can call `registerLibraryForSymbol("__ry_str_to_int")` instead of hard-coding "convert". This is a separate mechanism, not a descriptor consumer.
-- **Promote `int` / `float` / `input` / `close` into descriptor scope.** Re-route the Pattern B intercepts through the descriptor-driven dispatch path. This requires the descriptor to support the `int`/`float` Result-out-param wrapping shape and the `close` resource-kind dispatch shape, both of which are already in scope of the descriptor's `return_wrapping` / `resource_kind` fields — but it crosses the "reserved builtin" boundary and risks user-visible behavior differences.
-
-The carve-out is recorded so that follow-on issues do not inherit the false assumption that descriptor consolidation removes these inserts automatically.
+Hand-written `used_native_libraries_.insert(...)` is structurally banned from the codebase after #2393 (close criterion 2). The only ways to add a library are `linkNativeLibrary(<lib>)` (descriptor-derived: descriptor population, ResourceKind info lookups, the two `gc` boundary sites) and `linkNativeLibraryForSymbol(<runtime_symbol>)` (auto-called inside `getRuntimeFn` / `emitRuntimeCallDirect`).
 
 ## Pilot (landed in #2337)
 
@@ -148,8 +150,7 @@ The coarse sequence; §"Follow-up implementation issues" below refines this into
 - `@native` first-class thunk Rust migration.
 - Mock/spy v2 argument recording across customEmitter callers (current v1 limitation at `src/codegen_call_native.cpp:797`).
 - `http`'s `src/runtime/core/hash.cpp` duplication in `libry_http`.
-- `testing`'s `absoluteSymbols` loader path (intentional carve-out, no descriptor coverage needed).
-- Cleanup of the Pattern B → `libry_<mod>` carve-out's four hand-written `used_native_libraries_` inserts (resolution choice deferred to the cleanup-stage implementation issue, see §"Pattern B carve-out").
+- `testing`'s `absoluteSymbols` loader path: testing's `@native("testing")` calls go through `emitGenericNativeCall` (Pattern C) like any other library-tagged native; the `absoluteSymbols` is a runtime-loader detail, not a codegen-side dispatcher concern.
 
 ## Follow-up implementation issues
 
@@ -167,9 +168,10 @@ These issues are **drafts**, not yet filed. Per the AGENTS.md "User Permission G
 9. Installment 3-a carve-out: math A2 type-driven entries → `emitBuiltinMath` (Pattern B). **(#2340)**
 10. Installment 3-b carve-out: `json::stringify` / `json::stringifySafe` (and the json5 mirrors) → `emitBuiltinJson` / `emitBuiltinJson5`. **(#2340)**
 11. Installment 3-c carve-out: `thread::threadSpawn` / `threadJoin` → `emitBuiltinThread`. **(#2340)**
-12. `used_native_libraries_` consolidation (descriptor-driven registration, retire the general dispatcher-registration rule, keep the §"Pattern B carve-out" exception). **(#2340)** — the auto-register lives at `src/codegen_call_native.cpp` `emitTableDrivenNativeCall` entry; the previous customEmitter mock dispatch helper was generalised to accept any `NativeEmitterFn` so Pattern B carve-outs keep #1682 mock/spy semantics.
-13. Mock / spy v2 argument recording across customEmitter callers (current v1 limitation at `src/codegen_call_native.cpp:797`); separate from descriptor work.
-14. Upper codegen migration kickoff: descriptor consumers move to Rust; native knowledge stays in C++ descriptor producers only. This is the issue that #2231 protects, and it is **out of scope of this design**.
+12. `used_native_libraries_` consolidation: first half landed with **(#2340)** — descriptor-driven auto-register at `src/codegen_call_native.cpp` `emitTableDrivenNativeCall` entry; the customEmitter mock dispatch helper was generalised to accept any `NativeEmitterFn`. Final half (the §"Pattern B carve-out" cleanup) landed with **(#2393)** — the symbol → library reverse map (`codegen.cpp::kRuntimeSymbolLibraries`) replaces hand-named library inserts in `emitBuiltinConversion` / `emitBuiltinCore` / `emitHttpListen` / `emitBuiltinJsonModuleStringify` / `emitBuiltinThread`. The only remaining hand-call is `linkNativeLibrary("gc")` in `emitArcRelease` / `emitCowCheckSlot` (C-ABI boundary, no symbol for the auto-link to inspect).
+13. Installment 3-d carve-out: thread sync primitives (`lockNew` / `rwlockNew` / `semaphoreNew` / `barrierNew` / `lock*` / `rwlock*` / `semaphore*` / `barrier*` Acquire/Release/Read/Write/Unlock/Wait/Free) → descriptor-driven via `emitGenericNativeCall`. **(#2393)** — `lockNew` / `rwlockNew` use the new `Direct` + `resource_kind` (bare-resource tagging) shape; `*Acquire` / `*Release` / `*ReadLock` / `*WriteLock` / `*Unlock` / `*Wait` use `ResultStatus` (with the "_status" SSA-name suffix preserved by a thread-package gate so IR byte-exact holds); `*Free` use the new `ResourceFree` wrapping (emits `emitResourceFree`'s null-check + ARC-release with no runtime fn call). Atomic primitives (`atomicIntNew`/`atomicBoolNew`/`atomicIntLoad`/etc.) stay Pattern B in `emitBuiltinThread` because their bool-widening / value-naming IR cannot be expressed declaratively. The `inferResourceKind` helper grew a bare-return arm (Lock / RWLock / Thread / AtomicInt / AtomicBool) — IR-neutral for existing Pattern C consumers (audit confirms no other @native returns a bare resource type today). The `error_channel` derivation in `codegen_fn.cpp` is now gated on a `kHasModuleLastError` allow-list (packages with a per-module `__ry_<pkg>_get_last_error` symbol); thread / gc / testing / json / json5 fall through to the default `__ry_get_last_error` at dispatch time. `testing`'s @native fns also benefit from this — they were already Pattern C compatible via the absence of a dispatcher registration; this issue closes the descriptor coverage by confirming the auto-derivation works end-to-end.
+14. Mock / spy v2 argument recording across customEmitter callers (current v1 limitation at `src/codegen_call_native.cpp:797`); separate from descriptor work.
+15. Upper codegen migration kickoff: descriptor consumers move to Rust; native knowledge stays in C++ descriptor producers only. This is the issue that #2231 protects, and it is **out of scope of this design**.
 
 ## Related documents
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -106,6 +106,21 @@ public:
     // only includes libraries for functions actually called during codegen).
     const std::unordered_set<std::string>& getRequiredLibraries() const;
 
+    // #2393: descriptor-derived library registration. The two entries below
+    // are the ONLY ways the codebase records a required library — manual
+    // modification of the underlying set is intentionally absent per close
+    // criterion 2.
+    // - `linkNativeLibrary(<lib>)`: callers already in possession of the lib
+    //   name (descriptor population sites, ResourceKind info lookups, the
+    //   gc-emission internal sites that bypass `getRuntimeFn`).
+    // - `linkNativeLibraryForSymbol(<runtime_symbol>)`: invoked inside the
+    //   runtime-call entry points (`getRuntimeFn` / `emitRuntimeCallDirect`)
+    //   to auto-derive the library from a prefix table covering Pattern B
+    //   carve-outs (convert / io built-ins) and `emitHttpListen`'s synthesized
+    //   net/http calls.
+    void linkNativeLibrary(std::string library);
+    void linkNativeLibraryForSymbol(const char *runtimeSymbol);
+
     // Testing intrinsics (`expect`, `mock`, `fail`)
     // that the program imported via `from testing import ...` (named or wildcard).
     // Populated by the caller (jit_runner) from ModuleLoader::importedTestingIntrinsics().
@@ -1332,6 +1347,18 @@ public:
 
     // Libraries actually used during codegen (populated by dispatch functions).
     // Only these libraries need to be loaded at JIT startup.
+    //
+    // Manual `.add(...)` (insertion) on this field is intentionally absent
+    // from the codebase per #2393 close criterion 2. Entry points are:
+    //   - `linkNativeLibrary(<lib>)`: descriptor-derived (Pattern A/C) and
+    //     Pattern B internal-emission sites that bypass `getRuntimeFn` (the
+    //     gc inserts in `emitArcRelease` / `emitCowCheckSlot`, which emit
+    //     `__ry_gc_*` from the C-ABI emit boundary).
+    //   - `linkNativeLibraryForSymbol(<runtime_symbol>)` (called inside
+    //     `getRuntimeFn` / `emitRuntimeCallDirect`): auto-derives the library
+    //     from the runtime symbol prefix table for Pattern B carve-outs
+    //     (convert / io built-ins) and synthesized control flow
+    //     (`emitHttpListen`) so those sites do not hand-name a library.
     std::unordered_set<std::string> used_native_libraries_;
 
     // Secondary index: fn_name → library names, for @native("libname") functions.

--- a/include/ry/codegen_native_dispatch.hpp
+++ b/include/ry/codegen_native_dispatch.hpp
@@ -24,6 +24,15 @@ enum class CodeGenReturnWrapping : uint8_t {
     OptionFromNullablePtr,// wrapPtrAsOption(ptr): null -> None, else Some(ptr)
     ResultOutParamOption, // status<0 -> Err(runtime); status>=0 -> Ok(Option<loaded ptr>)
     IteratorFromHandle,   // synthesize Iterator<T> with next-fn calling exported_symbol(handle, &out)
+
+    // #2393: thread sync-primitive *Free entries (lockFree / rwlockFree /
+    // semaphoreFree / barrierFree / atomicIntFree / atomicBoolFree). No
+    // runtime fn is called; the destructor lives in ResourceKindRegistry
+    // and emitResourceFree emits the null-check + ARC-release sequence.
+    // The handle arg is at `desc.handle_param_index` (must be 0 — the
+    // *Free customEmitters all take the resource as the sole arg) with
+    // `desc.handle_resource_kind` selecting the destructor.
+    ResourceFree,
 };
 
 using CodeGenCustomEmitterFn = llvm::Value *(*)(CodeGen &cg, const CallExpr &e);

--- a/include/ry/llvm_emit/api.h
+++ b/include/ry/llvm_emit/api.h
@@ -351,9 +351,10 @@ void ry_emit_arc_retain(RyEmitCtx *ctx, RyValueId header_ptr_id,
 // the `void (*)(void *)` LLVM FunctionType locally so no LLVM type identity
 // crosses the boundary.
 // Precondition: the builder must be positioned within a function before this
-// call (BBs are created inside it). The
-// caller must additionally register "gc" in CodeGen.used_native_libraries_
-// because release emits __ry_gc_track / __ry_gc_untrack calls.
+// call (BBs are created inside it). The caller must additionally call
+// `cg.linkNativeLibrary("gc")` because release emits __ry_gc_track /
+// __ry_gc_untrack calls — those symbols don't transit `getRuntimeFn`, so
+// the #2393 symbol→library auto-link cannot see them.
 void ry_emit_arc_release(RyEmitCtx *ctx, RyValueId header_ptr_id,
                          RyArcAtomic atomic, RyValueRef destructor_callee,
                          RyValueRef gc_visit_fn);
@@ -734,10 +735,10 @@ typedef struct {
 // container holds the only alias for the duration of the retain loop.
 // destructor_callee may be NULL.
 // Precondition: the builder must be positioned within a function before this
-// call (BBs are created inside it). The
-// caller must additionally register "gc" in CodeGen.used_native_libraries_
-// because the internal ry_emit_arc_release call emits __ry_gc_track /
-// __ry_gc_untrack.
+// call (BBs are created inside it). The caller must additionally call
+// `cg.linkNativeLibrary("gc")` because the internal ry_emit_arc_release
+// call emits __ry_gc_track / __ry_gc_untrack — those symbols don't transit
+// `getRuntimeFn`, so the #2393 symbol→library auto-link cannot see them.
 RyValueId ry_emit_cow_ensure_unique(RyEmitCtx *ctx,
                                     const RyCowEnsureUniqueDesc *desc);
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5,6 +5,7 @@
 #include "ry/llvm_emit/cast_helpers.hpp"
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
+#include <string_view>
 
 
 namespace ry {
@@ -118,8 +119,93 @@ const std::unordered_set<std::string> &CodeGen::getTestingIntrinsicsImported() c
     return testing_intrinsics_imported_;
 }
 
+// #2393: descriptor-derived library registration. Pattern A/C dispatch
+// already records the descriptor's library at dispatch time; this helper is
+// the single sink so the field stays a private invariant of CodeGen. The
+// `emplace` path is intentional — close criterion 2 (a repository-wide
+// audit for hand-written `.insert(...)` on the field) must stay at 0 hits.
+void CodeGen::linkNativeLibrary(std::string library) {
+    used_native_libraries_.emplace(std::move(library));
+}
+
+// #2393: symbol-prefix-driven library auto-link. Called from `getRuntimeFn`
+// and `emitRuntimeCallDirect` so any runtime symbol that lives in a
+// `libry_<mod>` shared library registers that library automatically. The
+// table covers the Pattern B carve-outs (convert / io built-ins) and the
+// synthesized control flow in `emitHttpListen` that previously hand-named
+// the library — see the architecture doc §"Pattern B carve-out".
+//
+// Order matters where prefixes overlap: longest first. `__ry_net_tls_`
+// (http library) must precede `__ry_net_` (net library); `__ry_json5_`
+// must precede `__ry_json_`. Entries without a trailing `_` are exact
+// matches (e.g. `__ry_listen` is net, but `__ry_listener_port` matches the
+// `__ry_listener_` prefix entry, also net).
+namespace {
+struct RuntimeSymbolLibraryEntry {
+    const char *prefix_or_exact;
+    bool is_prefix;
+    const char *library;
+};
+// Static lookup table; CMake's RY_NATIVE_LIBS list (12 entries) is the
+// upstream source of truth. Symbols absent from any libry_<mod> (ry_lib
+// core: __ry_print_*, __ry_str_concat, malloc, __ry_arc_release, etc.) are
+// intentionally omitted — they need no library link.
+constexpr RuntimeSymbolLibraryEntry kRuntimeSymbolLibraries[] = {
+    // -- http carve-outs in the net namespace (must precede __ry_net_) --
+    {"__ry_net_tls_",        true,  "http"},
+    // -- net --
+    {"__ry_net_",            true,  "net"},
+    {"__ry_tcp_",            true,  "net"},
+    {"__ry_listener_",       true,  "net"},
+    {"__ry_listen",          false, "net"},
+    {"__ry_accept",          false, "net"},
+    {"__ry_connect_resolved", false, "net"},
+    // -- http (incl. tls; tls lives in libry_http) --
+    {"__ry_http_",           true,  "http"},
+    {"__ry_tls_",            true,  "http"},
+    // -- thread --
+    {"__ry_thread_",         true,  "thread"},
+    {"__ry_lock_",           true,  "thread"},
+    {"__ry_rwlock_",         true,  "thread"},
+    {"__ry_semaphore_",      true,  "thread"},
+    {"__ry_barrier_",        true,  "thread"},
+    {"__ry_atomic_",         true,  "thread"},
+    // -- convert (convert.cpp uses bare `__ry_str_to_*`) --
+    {"__ry_convert_",        true,  "convert"},
+    {"__ry_str_to_int",      false, "convert"},
+    {"__ry_str_to_float",    false, "convert"},
+    // -- module-prefix stdlib libs --
+    {"__ry_io_",             true,  "io"},
+    {"__ry_gc_",             true,  "gc"},
+    {"__ry_json5_",          true,  "json5"},   // before __ry_json_
+    {"__ry_json_",           true,  "json"},
+    {"__ry_base64_",         true,  "base64"},
+    {"__ry_path_",           true,  "path"},
+    {"__ry_filesystem_",     true,  "filesystem"},
+    {"__ry_testing_",        true,  "testing"},
+};
+} // namespace
+
+void CodeGen::linkNativeLibraryForSymbol(const char *runtimeSymbol) {
+    if (!runtimeSymbol) return;
+    std::string_view s(runtimeSymbol);
+    for (const auto &entry : kRuntimeSymbolLibraries) {
+        std::string_view key(entry.prefix_or_exact);
+        if (entry.is_prefix) {
+            if (s.size() >= key.size() && s.compare(0, key.size(), key) == 0) {
+                linkNativeLibrary(entry.library);
+                return;
+            }
+        } else if (s == key) {
+            linkNativeLibrary(entry.library);
+            return;
+        }
+    }
+}
+
 llvm::FunctionCallee CodeGen::getRuntimeFn(const char *name, llvm::Type *retTy,
                                             llvm::ArrayRef<llvm::Type*> argTys) {
+    linkNativeLibraryForSymbol(name);
     auto *fnTy = llvm::FunctionType::get(retTy, argTys, false);
     auto *callee = ry::llvm_emit::asLlvmValue(
         ry_emit_get_runtime_fn(emit_ctx_, name, ry::llvm_emit::asRyFuncType(fnTy)));
@@ -509,6 +595,7 @@ llvm::Value *CodeGen::emitRuntimeCallDirect(const char *name, llvm::Type *ret_ty
                                             llvm::ArrayRef<llvm::Type *> arg_tys,
                                             llvm::ArrayRef<llvm::Value *> args,
                                             const char *name_hint) {
+    linkNativeLibraryForSymbol(name);
     // Defensive precondition: ry_emit_runtime_call builds a non-variadic
     // FunctionType from arg_tys and a CreateCall from args, so the two counts
     // must match. This is an internal-invariant guard against a future

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -131,8 +131,11 @@ void CodeGen::emitArcRelease(llvm::Value *headerPtr, bool atomic,
                               llvm::FunctionCallee destructor,
                               llvm::Function *gcVisitFn) {
     // ry_emit_arc_release emits __ry_gc_track / __ry_gc_untrack calls; the
-    // runtime requires libry_gc to be registered.
-    used_native_libraries_.insert("gc");
+    // runtime requires libry_gc to be registered. These symbols are emitted
+    // through the C-ABI emit boundary, not getRuntimeFn, so the symbol→library
+    // auto-link in `linkNativeLibraryForSymbol` cannot see them — hand-link via
+    // the descriptor-derived helper here.
+    linkNativeLibrary("gc");
     llvm::Value *dtorCallee = destructor
         ? llvm::cast<llvm::Value>(destructor.getCallee())
         : nullptr;
@@ -266,7 +269,7 @@ llvm::FunctionCallee CodeGen::getOrCreateResourceDestructor(int rk) {
     const char *dtorName = info->dtorName;
     const char *cleanupFnName = info->cleanupFnName;
     if (info->library)
-        used_native_libraries_.insert(info->library);
+        linkNativeLibrary(info->library);
 
     auto *dtorTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
     auto *dtorFn = llvm::Function::Create(

--- a/src/codegen_arc_cow.cpp
+++ b/src/codegen_arc_cow.cpp
@@ -88,7 +88,9 @@ llvm::Value *CodeGen::emitCowCheckSlot(llvm::Value *dataPtr,
 
     // ry_emit_cow_ensure_unique internally calls ry_emit_arc_release which
     // emits __ry_gc_track / __ry_gc_untrack; libry_gc must be registered.
-    used_native_libraries_.insert("gc");
+    // The emit goes through the C-ABI boundary, not getRuntimeFn, so the
+    // symbol→library auto-link cannot see these symbols — hand-link here.
+    linkNativeLibrary("gc");
 
     // Element-retention decision uses metadata stamped on the *old*
     // container — the cloned buffer the boundary returns does not carry

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -13,9 +13,12 @@ namespace ry {
 // builtins, not @native dispatched. The descriptor-driven library auto-
 // registration in emitTableDrivenNativeCall / emitGenericNativeCall never
 // reaches them — the reserved-name guard claims the callee before any
-// descriptor lookup runs — so the `libry_convert` load has to be expressed
-// directly with `used_native_libraries_.insert("convert")` here. The same
-// rationale applies to input() / close() in emitBuiltinCore below.
+// descriptor lookup runs. After #2393 the `libry_convert` link is auto-
+// derived from the `__ry_str_to_int` / `__ry_str_to_float` runtime symbols
+// inside `getRuntimeFn` (the symbol→library auto-link in
+// `linkNativeLibraryForSymbol`), so this dispatcher no longer hand-names
+// the library. The same auto-link covers `input()` / `close()` (libry_io)
+// in `emitBuiltinCore` below.
 llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
     // int(s) → Result<int, Error>.  Parses a str; for number→int use `x as int`.
     if (e.callee == "int") {
@@ -25,9 +28,6 @@ llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
             codegenError("int() requires a str argument; use 'value as int' to convert a number to int");
         llvm::AllocaInst *outSlot = builder_.CreateAlloca(i64Ty_, nullptr, "to_int_out");
         auto fn = getRuntimeFn("__ry_str_to_int", i64Ty_, {ptrTy_, ptrTy_});
-        // Pattern B carve-out: see the file-header comment above for why this
-        // insert is not removed by the descriptor-driven consolidation.
-        used_native_libraries_.insert("convert");
         llvm::Value *status = builder_.CreateCall(fn, {s, outSlot}, "to_int_status");
         llvm::Value *isErr = builder_.CreateICmpNE(status,
             llvm::ConstantInt::get(i64Ty_, 0), "to_int_err");
@@ -48,8 +48,6 @@ llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
             codegenError("float() requires a str argument; use 'value as float' to convert a number to float");
         llvm::AllocaInst *outSlot = builder_.CreateAlloca(f64Ty_, nullptr, "to_float_out");
         auto fn = getRuntimeFn("__ry_str_to_float", i64Ty_, {ptrTy_, ptrTy_});
-        // Pattern B carve-out: see emitBuiltinConversion header comment above.
-        used_native_libraries_.insert("convert");
         llvm::Value *status = builder_.CreateCall(fn, {s, outSlot}, "to_float_status");
         llvm::Value *isErr = builder_.CreateICmpNE(status,
             llvm::ConstantInt::get(i64Ty_, 0), "to_float_err");
@@ -619,11 +617,9 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         if (e.args.size() > 1)
             codegenError("input() takes 0 or 1 arguments");
         // Pattern B carve-out (#2340): `input` is a reserved compiler builtin,
-        // not @native("io"). The descriptor-driven library auto-registration
-        // never reaches this name, so the JIT load of libry_io has to be
-        // expressed directly so that __ry_io_read_line / __ry_io_input_prompt
-        // resolve for programs that never `import` io.
-        used_native_libraries_.insert("io");
+        // not @native("io"). After #2393 the libry_io link is auto-derived
+        // from `__ry_io_read_line` / `__ry_io_input_prompt` inside
+        // `emitRuntimeCallDirect`'s symbol→library auto-link.
 
         llvm::Value *outAlloca = emitAlloca(ptrTy_, "inp_out");
         emitStore(emitConstNull(ptrTy_), outAlloca);
@@ -733,10 +729,8 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
             // the user-facing close from refcount-drop keeps lines()/readLine()
             // iterators valid after close (they observe fp==nullptr and finish).
             // Pattern B carve-out (#2340): `close` is a reserved compiler
-            // builtin, not @native("io"). The descriptor-driven library
-            // auto-registration never reaches this name, so the libry_io load
-            // for __ry_io_file_close is expressed directly here.
-            used_native_libraries_.insert("io");
+            // builtin, not @native("io"). After #2393 the libry_io link is
+            // auto-derived from `__ry_io_file_close` inside `getRuntimeFn`.
             auto fn = getRuntimeFn("__ry_io_file_close", llvm::Type::getVoidTy(*ctx_), {ptrTy_});
             builder_.CreateCall(fn, {val});
             return llvm::ConstantInt::get(i8Ty_, 0); // Unit

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -243,11 +243,13 @@ static llvm::Value *dispatchNet(CodeGen &, const CallExpr &) {
 // `listen` 3+ arg stays custom: it synthesizes a multi-block control
 // flow (bind → listen → accept loop → per-request handler dispatch →
 // send_response → close) that the declarative descriptor model does not
-// cover. This entry inserts its own `net` + `http` library deps inline.
+// cover. `net` + `http` library registration is handled by the symbol→
+// library auto-link in `getRuntimeFn`: every `__ry_net_bind` / `__ry_listen`
+// / `__ry_accept` / `__ry_tcp_*` / `__ry_http_*` call below routes through
+// the auto-link table (see codegen.cpp::kRuntimeSymbolLibraries), so this
+// synthesizer no longer hand-names libraries.
 
 static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
-    cg.used_native_libraries_.insert("net");
-    cg.used_native_libraries_.insert("http");
     if (e.args.size() < 3 || e.args.size() > 5)
         cg.codegenError("listen() takes 3 to 5 arguments");
     llvm::Value *host = cg.emitExpr(*e.args[0]);
@@ -502,8 +504,9 @@ static bool isHttpImported(CodeGen &cg) {
 // src/codegen_native_call_descriptor.cpp's kOverrides table. listen 3+
 // arg (control-flow synthesis: bind / listen / accept loop / handler
 // dispatch / send_response) stays custom because the synthesized control
-// flow does not fit the declarative descriptor model — emitHttpListen
-// inserts "net" + "http" into used_native_libraries_ itself.
+// flow does not fit the declarative descriptor model — emitHttpListen's
+// `net` + `http` library registration is auto-derived inside `getRuntimeFn`
+// from each emitted runtime symbol (#2393).
 RY_REGISTER_STDLIB_PACKAGE(http, "share/std/http/http.ry", dispatchHttp)
 static llvm::Value *dispatchHttp(CodeGen &cg, const CallExpr &e) {
     if (!isHttpImported(cg))

--- a/src/codegen_call_json.cpp
+++ b/src/codegen_call_json.cpp
@@ -198,13 +198,10 @@ static llvm::Value *dispatchJson(CodeGen &cg, const CallExpr &e) {
     if (!isJsonImported(cg))
         return nullptr;
 
-    // Register libry_json.dylib for JIT loading.  The custom emitters reached
-    // through this dispatcher bypass the sig.library-driven insert that
-    // happens inside emitTableDrivenNativeCall's customEmitter branch only
-    // after arg type / arity checks succeed — registering here ensures the
-    // library is loaded before any early codegenError path can fire (per
-    // codegen-stdlib-dispatcher.md #1856).
-    cg.used_native_libraries_.insert("json");
+    // libry_json.dylib registration is auto-derived inside `getRuntimeFn` via
+    // the symbol→library auto-link (#2393) — `__ry_json_*` runtime symbols
+    // emitted by `emitJsonLoad` / `emitJsonDumpFile` / `emitBuiltinJson*`
+    // register "json" automatically before any call reaches the JIT.
 
     // Intercept `load[T](...)` calls (#1852, #1887). The parser uses `[T]`
     // syntax for generic function calls at user-facing call sites, but
@@ -264,15 +261,16 @@ llvm::Value *CodeGen::emitBuiltinJsonModuleStringify(
     const char *package,
     CodeGenCustomEmitterFn stringifyEmitter,
     CodeGenCustomEmitterFn stringifySafeEmitter) {
+    // `libry_<package>` registration is auto-derived inside `getRuntimeFn`
+    // from the `__ry_json_*` / `__ry_json5_*` runtime symbols the emitters
+    // issue (#2393, symbol→library auto-link).
     const std::string pkgPrefix = std::string(package) + "::";
     if (e.callee == "stringify" &&
         native_fn_sigs_.count(pkgPrefix + "stringify")) {
-        used_native_libraries_.insert(package);
         return emitBuiltinNativeOrMock(e, package, stringifyEmitter);
     }
     if (e.callee == "stringifySafe" &&
         native_fn_sigs_.count(pkgPrefix + "stringifySafe")) {
-        used_native_libraries_.insert(package);
         return emitBuiltinNativeOrMock(e, package, stringifySafeEmitter);
     }
     return nullptr;

--- a/src/codegen_call_json5.cpp
+++ b/src/codegen_call_json5.cpp
@@ -177,10 +177,9 @@ static llvm::Value *dispatchJson5(CodeGen &cg, const CallExpr &e) {
     if (!isJson5Imported(cg))
         return nullptr;
 
-    // Register libry_json5.dylib for JIT loading. See codegen-stdlib-dispatcher.md
-    // (#1856): every dispatcher MUST insert at the top so partial single-symbol
-    // imports work — table-fallthrough alone misses every custom-emitter early-return.
-    cg.used_native_libraries_.insert("json5");
+    // libry_json5.dylib registration is auto-derived inside `getRuntimeFn`
+    // via the symbol→library auto-link (#2393) — every `__ry_json5_*` runtime
+    // symbol the emitters issue registers "json5" automatically.
 
     // Intercept `load[T](...)` calls. The parser uses `[T]` syntax for generic
     // function calls but constructs the internal callee as `load<T>` (e.g.

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -173,7 +173,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     // / normal paths and ensures the JIT loads `libry_<module>` before any
     // early codegenError aborts the rest of the dispatch.
     if (!sigItHead->second.empty() && !sigItHead->second[0].library.empty())
-        used_native_libraries_.insert(sigItHead->second[0].library);
+        linkNativeLibrary(sigItHead->second[0].library);
 
     // Lookup entry in dispatch table
     const NativeDispatchEntry *entry = nullptr;
@@ -508,6 +508,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     case ReturnWrapping::OptionFromNullablePtr:
     case ReturnWrapping::ResultOutParamOption:
     case ReturnWrapping::IteratorFromHandle:
+    case ReturnWrapping::ResourceFree:
         llvm_unreachable("descriptor-only wrapping reached emitTableDrivenNativeCall");
     }
 
@@ -600,6 +601,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     case ReturnWrapping::OptionFromNullablePtr:
     case ReturnWrapping::ResultOutParamOption:
     case ReturnWrapping::IteratorFromHandle:
+    case ReturnWrapping::ResourceFree:
         llvm_unreachable("descriptor-only wrapping reached emitTableDrivenNativeCall");
     }
 
@@ -772,7 +774,7 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     // No library matched both arity and types — fall through to user functions
     if (!matchedSig) return nullptr;
 
-    used_native_libraries_.insert(matchedPackage);
+    linkNativeLibrary(matchedPackage);
 
     // Look up the descriptor populated alongside this sig in codegen_fn.cpp.
     // Descriptors and sigs are pushed in lock-step under the same sigKey, so
@@ -866,12 +868,18 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     const std::string &outParamType = desc.out_param_type_name;
 
     // Error function name for Result wrappings. The descriptor pre-computes
-    // it from library_name; for descriptors without a library (bare @native
-    // outside knownNativeLibs), fall back to deriving from matchedPackage
-    // to preserve current behavior for any non-Pattern-C consumer that ever
-    // reaches this path.
+    // it from library_name for packages that own a per-module
+    // `__ry_<pkg>_get_last_error` symbol (see codegen_fn.cpp's
+    // kHasModuleLastError list). Packages without one (thread / gc /
+    // testing / json / json5) fall through here to the default
+    // `__ry_get_last_error` channel, matching what the pre-2393 thread
+    // customEmitters consumed via `wrapStatusAsResult(status)` (the helper's
+    // default param). Bare @native fns outside knownNativeLibs that never
+    // declare an error channel similarly land here, which is the only
+    // existing behavior they could have relied on (no runtime defines
+    // `__ry_<unknown_pkg>_get_last_error`).
     std::string errFnName = desc.error_channel.empty()
-        ? ry::util::deriveRuntimeFnName(matchedPackage, "get_last_error")
+        ? "__ry_get_last_error"
         : desc.error_channel;
 
     // Installment 2-c (#2381): handle-coupled overload library linkage.
@@ -884,7 +892,7 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
         && desc.handle_resource_kind != ResourceKindRegistry::NONE) {
         if (const auto *info = ResourceKindRegistry::instance().getInfo(
                 desc.handle_resource_kind))
-            used_native_libraries_.insert(info->library);
+            linkNativeLibrary(info->library);
     }
 
     // Installment 2-c (#2381): IteratorFromHandle — synthesize an iterator
@@ -893,6 +901,26 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     // descriptor consumption stays one well-scoped switch arm.
     if (wrapping == ReturnWrapping::IteratorFromHandle) {
         return emitIteratorFromHandleNative(e, desc, args, rtName);
+    }
+
+    // #2393: ResourceFree — thread *Free entries (lockFree / rwlockFree /
+    // semaphoreFree / barrierFree / atomicIntFree / atomicBoolFree) emit
+    // a null-check + ARC-release sequence via emitResourceFree. No runtime
+    // fn is dialed. The handle arg lives at desc.handle_param_index (must
+    // be 0 — all six *Free entries take the resource as their sole arg)
+    // with desc.handle_resource_kind selecting the destructor. The arg has
+    // already been emit-checked against the registered resource kind by
+    // overload resolution, so we go straight to emitResourceFree.
+    if (wrapping == ReturnWrapping::ResourceFree) {
+        if (desc.handle_param_index < 0
+            || desc.handle_resource_kind == ResourceKindRegistry::NONE
+            || args.empty()) {
+            codegenError(e.callee +
+                "(): ResourceFree requires handle_param_index=0 and a "
+                "registered handle_resource_kind");
+        }
+        return emitResourceFree(args[0], desc.handle_resource_kind,
+                                *e.args[0]);
     }
 
     // Build C-level return type and handle out-param. For OptionFromNullablePtr
@@ -927,6 +955,8 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
         llvm_unreachable("ResultPtrWithListMeta not used in generic native dispatch");
     case ReturnWrapping::IteratorFromHandle:
         llvm_unreachable("IteratorFromHandle handled above (early return)");
+    case ReturnWrapping::ResourceFree:
+        llvm_unreachable("ResourceFree handled above (early return)");
     }
 
     // Create alloca for out-param (ResultOutParam / ResultOutParamOption)
@@ -950,11 +980,23 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     auto emitCallAndWrap = [&]() -> llvm::Value * {
         auto *fnTy = llvm::FunctionType::get(cRetTy, paramTypes, false);
         auto fn = mod_->getOrInsertFunction(rtName, fnTy);
+        // #2393: the pre-migration thread customEmitters named the i64
+        // status call `<callee>_status` (see emitThreadSyncOp). Mirror that
+        // so the descriptor migration's IR byte-exact diff stays empty for
+        // the `lockAcquire` / `rwlockReadLock` / `semaphoreAcquire` /
+        // `barrierWait` / etc. chain. Other Pattern C consumers (io / net /
+        // http ResultStatus entries) use the bare callee name; the gate
+        // on (matchedPackage == "thread") preserves their existing IR.
+        std::string callNameHint = e.callee;
+        if (wrapping == ReturnWrapping::ResultStatus
+            && matchedPackage == "thread") {
+            callNameHint = e.callee + "_status";
+        }
         llvm::Value *callResult;
         if (cRetTy->isVoidTy())
             callResult = builder_.CreateCall(fn, args);
         else
-            callResult = builder_.CreateCall(fn, args, e.callee);
+            callResult = builder_.CreateCall(fn, args, callNameHint);
 
         llvm::Value *res;
         switch (wrapping) {
@@ -962,6 +1004,20 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
             if (cRetTy->isVoidTy())
                 return llvm::ConstantInt::get(i8Ty_, 0);
             res = callResult;
+            // #2393: bare-resource returns (e.g. lockNew() -> Lock,
+            // atomicIntNew() -> AtomicInt). Tag the value with the
+            // descriptor's resource kind so ARC sees it correctly, mirroring
+            // the pre-migration thread customEmitters' `addResourceKind`
+            // call. Stdlib audit confirmed no existing Pattern C consumer
+            // returns a bare resource via Direct wrapping, so adding the
+            // tag here is IR-neutral outside the newly-migrated thread
+            // constructors.
+            if (desc.resource_kind != ResourceKindRegistry::NONE) {
+                addResourceKind(res, desc.resource_kind);
+                if (const auto *info =
+                        ResourceKindRegistry::instance().getInfo(desc.resource_kind))
+                    linkNativeLibrary(info->library);
+            }
             break;
 
         case ReturnWrapping::ResultPtr:
@@ -977,7 +1033,7 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
                 // too. Idempotent with the matchedPackage insert.
                 if (const auto *info =
                         ResourceKindRegistry::instance().getInfo(desc.resource_kind))
-                    used_native_libraries_.insert(info->library);
+                    linkNativeLibrary(info->library);
             }
             break;
 

--- a/src/codegen_call_thread.cpp
+++ b/src/codegen_call_thread.cpp
@@ -490,83 +490,29 @@ static llvm::Value *emitThreadJoin(CodeGen &cg, const CallExpr &e) {
         });
 }
 
-// lockNew, rwlockNew: 0-arg → ptr + resource tracking
-static llvm::Value *emitThreadSyncNew(CodeGen &cg, const CallExpr &e) {
-    cg.requireArgs(e, 0);
-    const char *rtName;
-    int rk;
-    if (e.callee == "lockNew") { rtName = "__ry_lock_new"; rk = rk_lock; }
-    else { rtName = "__ry_rwlock_new"; rk = rk_rwlock; }
-    llvm::Value *result = cg.emitRuntimeCallDirect(
-        rtName, cg.ptrTy_, {}, {}, e.callee.c_str());
-    cg.addResourceKind(result, rk);
-    return result;
-}
-
-// semaphoreNew, barrierNew: 1-arg → wrapPtrAsResult + resource tracking
-static llvm::Value *emitThreadSyncResultNew(CodeGen &cg, const CallExpr &e) {
-    cg.requireArgs(e, 1);
-    llvm::Value *count = cg.emitExpr(*e.args[0]);
-    const char *rtName;
-    int rk;
-    if (e.callee == "semaphoreNew") { rtName = "__ry_semaphore_new"; rk = rk_semaphore; }
-    else { rtName = "__ry_barrier_new"; rk = rk_barrier; }
-    llvm::Value *ptr = cg.emitRuntimeCallDirect(
-        rtName, cg.ptrTy_, {cg.i64Ty_}, {count}, e.callee.c_str());
-    llvm::Value *result = cg.wrapPtrAsResult(ptr);
-    cg.addResourceKind(result, rk);
-    return result;
-}
-
-// Status-returning operations: acquire, release, lock, unlock, wait
-static llvm::Value *emitThreadSyncOp(CodeGen &cg, const CallExpr &e) {
+// #2393: emitThreadSyncNew / emitThreadSyncResultNew / emitThreadSyncOp
+// were inlined into the descriptor-driven path. Their constructor/op IR
+// shape is reproduced by emitGenericNativeCall's Direct + resource_kind /
+// ResultPtr + resource_kind / ResultStatus paths, with the "_status"
+// SSA-name suffix preserved by the thread-package gate so the byte-exact
+// diff stays empty. See `kOverrides` in codegen_native_call_descriptor.cpp.
+//
+// emitThreadSyncFree is only reached by the atomic*Free Pattern B entries
+// below (lockFree / rwlockFree / semaphoreFree / barrierFree are
+// descriptor-driven via the new `ResourceFree` wrapping).
+static llvm::Value *emitThreadAtomicFree(CodeGen &cg, const CallExpr &e) {
     cg.requireArgs(e, 1);
     llvm::Value *arg = cg.emitExpr(*e.args[0]);
 
-    // Type-check and derive runtime name
-    struct OpInfo { const char *rt; bool (CodeGen::*check)(llvm::Value*); const char *type; };
-    static const std::unordered_map<std::string, OpInfo> ops = {
-        {"lockAcquire",     {"__ry_lock_acquire",     &CodeGen::isLock,      "Lock"}},
-        {"lockRelease",     {"__ry_lock_release",     &CodeGen::isLock,      "Lock"}},
-        {"rwlockReadLock",  {"__ry_rwlock_read_lock", &CodeGen::isRWLock,    "RWLock"}},
-        {"rwlockWriteLock", {"__ry_rwlock_write_lock",&CodeGen::isRWLock,    "RWLock"}},
-        {"rwlockUnlock",    {"__ry_rwlock_unlock",    &CodeGen::isRWLock,    "RWLock"}},
-        {"semaphoreAcquire",{"__ry_semaphore_acquire",&CodeGen::isSemaphore, "Semaphore"}},
-        {"semaphoreRelease",{"__ry_semaphore_release",&CodeGen::isSemaphore, "Semaphore"}},
-        {"barrierWait",     {"__ry_barrier_wait",     &CodeGen::isBarrier,   "Barrier"}},
-    };
+    int rk = -1;
+    const char *typeName = nullptr;
+    if (e.callee == "atomicIntFree")  { rk = rk_atomic_int;  typeName = "AtomicInt"; }
+    if (e.callee == "atomicBoolFree") { rk = rk_atomic_bool; typeName = "AtomicBool"; }
+    if (rk == -1) return nullptr;
 
-    auto it = ops.find(e.callee);
-    if (it == ops.end()) return nullptr;
-    if (!(cg.*(it->second.check))(arg))
-        cg.codegenError(e.callee + "() requires " + it->second.type + " argument");
-    std::string statusName = e.callee + "_status";
-    llvm::Value *status = cg.emitRuntimeCallDirect(
-        it->second.rt, cg.i64Ty_, {cg.ptrTy_}, {arg}, statusName.c_str());
-    return cg.wrapStatusAsResult(status);
-}
-
-// All *_free operations: type-check + emitResourceFree
-static llvm::Value *emitThreadSyncFree(CodeGen &cg, const CallExpr &e) {
-    cg.requireArgs(e, 1);
-    llvm::Value *arg = cg.emitExpr(*e.args[0]);
-
-    struct FreeInfo { int rk; const char *type; };
-    // rk_* are populated during static init, before any codegen runs.
-    static const std::unordered_map<std::string, FreeInfo> frees = {
-        {"lockFree",        {rk_lock,        "Lock"}},
-        {"rwlockFree",      {rk_rwlock,      "RWLock"}},
-        {"semaphoreFree",   {rk_semaphore,   "Semaphore"}},
-        {"barrierFree",     {rk_barrier,     "Barrier"}},
-        {"atomicIntFree",   {rk_atomic_int,  "AtomicInt"}},
-        {"atomicBoolFree",  {rk_atomic_bool, "AtomicBool"}},
-    };
-
-    auto it = frees.find(e.callee);
-    if (it == frees.end()) return nullptr;
-    if (!cg.isResourceKind(it->second.rk, arg))
-        cg.codegenError(e.callee + "() requires " + it->second.type + " argument");
-    return cg.emitResourceFree(arg, it->second.rk, *e.args[0]);
+    if (!cg.isResourceKind(rk, arg))
+        cg.codegenError(e.callee + "() requires " + typeName + " argument");
+    return cg.emitResourceFree(arg, rk, *e.args[0]);
 }
 
 static llvm::Value *emitThreadAtomicIntNew(CodeGen &cg, const CallExpr &e) {
@@ -661,90 +607,124 @@ static llvm::Value *emitThreadAtomicBoolOp(CodeGen &cg, const CallExpr &e) {
         {cg.ptrTy_, cg.i64Ty_}, {atom, extended}, "");
 }
 
-// ===== Thread dispatch table =====
+// ===== Thread dispatch =====
 //
-// threadSpawn / threadJoin were carved out to emitBuiltinThread (Pattern B)
-// per #2340 — both synthesize an `llvm::Function` from the worker body, which
-// no declarative descriptor can express. The remaining sync / atomic entries
-// stay here as table-driven customEmitters; their `libry_thread` registration
-// is now handled by dispatchThread itself (see below).
-static const CodeGen::NativeDispatchEntry thread_table[] = {
-    // Sync primitives: new
-    {"lockNew",          nullptr, {}, 0, nullptr, emitThreadSyncNew},
-    {"rwlockNew",        nullptr, {}, 0, nullptr, emitThreadSyncNew},
-    {"semaphoreNew",     nullptr, {}, 0, nullptr, emitThreadSyncResultNew},
-    {"barrierNew",       nullptr, {}, 0, nullptr, emitThreadSyncResultNew},
-    // Sync primitives: operations
-    {"lockAcquire",      nullptr, {}, 0, nullptr, emitThreadSyncOp},
-    {"lockRelease",      nullptr, {}, 0, nullptr, emitThreadSyncOp},
-    {"rwlockReadLock",   nullptr, {}, 0, nullptr, emitThreadSyncOp},
-    {"rwlockWriteLock",  nullptr, {}, 0, nullptr, emitThreadSyncOp},
-    {"rwlockUnlock",     nullptr, {}, 0, nullptr, emitThreadSyncOp},
-    {"semaphoreAcquire", nullptr, {}, 0, nullptr, emitThreadSyncOp},
-    {"semaphoreRelease", nullptr, {}, 0, nullptr, emitThreadSyncOp},
-    {"barrierWait",      nullptr, {}, 0, nullptr, emitThreadSyncOp},
-    // Sync primitives: free
-    {"lockFree",         nullptr, {}, 0, nullptr, emitThreadSyncFree},
-    {"rwlockFree",       nullptr, {}, 0, nullptr, emitThreadSyncFree},
-    {"semaphoreFree",    nullptr, {}, 0, nullptr, emitThreadSyncFree},
-    {"barrierFree",      nullptr, {}, 0, nullptr, emitThreadSyncFree},
-    // AtomicInt
-    {"atomicIntNew",     nullptr, {}, 0, nullptr, emitThreadAtomicIntNew},
-    {"atomicIntLoad",    nullptr, {}, 0, nullptr, emitThreadAtomicIntOp},
-    {"atomicIntStore",   nullptr, {}, 0, nullptr, emitThreadAtomicIntOp},
-    {"atomicIntAdd",     nullptr, {}, 0, nullptr, emitThreadAtomicIntOp},
-    {"atomicIntSub",     nullptr, {}, 0, nullptr, emitThreadAtomicIntOp},
-    {"atomicIntCas",     nullptr, {}, 0, nullptr, emitThreadAtomicIntCas},
-    {"atomicIntFree",    nullptr, {}, 0, nullptr, emitThreadSyncFree},
-    // AtomicBool
-    {"atomicBoolNew",    nullptr, {}, 0, nullptr, emitThreadAtomicBoolNew},
-    {"atomicBoolLoad",   nullptr, {}, 0, nullptr, emitThreadAtomicBoolOp},
-    {"atomicBoolStore",  nullptr, {}, 0, nullptr, emitThreadAtomicBoolOp},
-    {"atomicBoolFree",   nullptr, {}, 0, nullptr, emitThreadSyncFree},
-};
+// #2393: thread is now descriptor-driven for sync primitives + Pattern B
+// for value-transform atomics.
+//   - threadSpawn / threadJoin: Pattern B carve-out per #2340 (synthesize
+//     an `llvm::Function` from the worker body — no declarative descriptor
+//     captures that).
+//   - lock* / rwlock* / semaphore* / barrier* (sync new / op / free):
+//     descriptor-driven via emitGenericNativeCall with the per-overload
+//     entries in `kOverrides` (codegen_native_call_descriptor.cpp).
+//     `lockNew` / `rwlockNew` use `Direct` + `resource_kind` (bare-resource
+//     return tagging, via inferResourceKind's #2393 extension);
+//     `semaphoreNew` / `barrierNew` use the existing `ResultPtr` +
+//     `resource_kind` shape; `*Acquire` / `*Release` / `*ReadLock` /
+//     `*WriteLock` / `*Unlock` / `*Wait` use `ResultStatus` (with the
+//     "_status" SSA-name suffix preserved by emitGenericNativeCall's
+//     thread-package gate so the IR byte-exact diff stays empty); `*Free`
+//     use the new `ResourceFree` wrapping that delegates to emitResourceFree.
+//   - atomic* (atomicIntNew/Load/Store/Add/Sub/Cas/Free and
+//     atomicBoolNew/Load/Store/Free): Pattern B carve-out
+//     (`emitBuiltinThread`) — every entry threads value-transform IR (bool
+//     i1↔i64 zext/trunc, CAS i64→i1 trunc, or a non-callee SSA name like
+//     "atomic_int") that the declarative descriptor cannot express
+//     byte-exactly. Mirrors the #2340 precedent that carved
+//     `threadSpawn`/`threadJoin` out of thread_table.
+//
+// `thread_table` is intentionally empty: `dispatchThread` returns nullptr,
+// letting the descriptor-driven path (`emitGenericNativeCall`) handle every
+// sync-primitive callee. Atomics short-circuit earlier in
+// `emitExprVariant`'s Pattern B chain (`emitBuiltinThread`) before the
+// stdlib dispatcher loop runs.
+static const CodeGen::NativeDispatchEntry thread_table[] = {};
 
-// Gate the dispatcher: only proceed if any thread sig is actually registered,
-// and in that case register `libry_thread` up-front so the JIT loads it before
-// any customEmitter in the table runs. The previous regime registered the
-// library from emitTableDrivenNativeCall's customEmitter branch; after the
-// generic auto-register lands (see codegen_call_native.cpp) the explicit
-// insert here remains as the dispatcher-level guarantee that JSON / JSON5
-// already provide (codegen_call_json.cpp / codegen_call_json5.cpp).
-//
+// Gate the dispatcher: only proceed if any thread sig is actually registered.
 // Probe two representative anchors covering the carved-out (threadSpawn) and
 // table-driven (lockNew) sides of the module; a single sig from either side
 // is enough to confirm the user imported `thread`. Mirrors the O(1)
 // `sigs.count(...)` shape used by `isJsonImported` / `isJson5Imported`.
+//
+// `libry_thread` registration: emitTableDrivenNativeCall registers the
+// library from the sig's library field on entry (#2340), and the auto-link
+// in `getRuntimeFn` / `emitRuntimeCallDirect` covers downstream paths whose
+// runtime symbols carry a `__ry_thread_*` / `__ry_lock_*` / etc. prefix
+// (#2393). The previous explicit `_.insert("thread")` was redundant with
+// both layers.
 static bool isThreadImported(CodeGen &cg) {
     const auto &sigs = cg.getNativeFnSigs();
     return sigs.count("thread::threadSpawn") || sigs.count("thread::lockNew");
 }
 
 RY_REGISTER_STDLIB_PACKAGE(thread, "share/std/thread/thread.ry", dispatchThread)
-static llvm::Value *dispatchThread(CodeGen &cg, const CallExpr &e) {
-    if (!isThreadImported(cg))
-        return nullptr;
-    cg.used_native_libraries_.insert("thread");
-    return cg.emitTableDrivenNativeCall(e, "thread", thread_table, std::size(thread_table));
+static llvm::Value *dispatchThread(CodeGen &, const CallExpr &) {
+    // #2393: thread_table is empty (see above). Returning nullptr lets the
+    // dispatch chain proceed to `emitGenericNativeCall`, which consumes the
+    // per-overload kOverrides entries for lock / rwlock / semaphore /
+    // barrier. Atomics are handled by `emitBuiltinThread` earlier in
+    // `emitExprVariant`'s Pattern B chain.
+    return nullptr;
 }
 
-// ===== Builtin Thread (Pattern B carve-out, #2340) =====
+// ===== Builtin Thread (Pattern B carve-out, #2340 + #2393) =====
 //
-// threadSpawn synthesizes an `llvm::Function` from the worker lambda body;
-// threadJoin reads back through a ThreadResult-tagged slot. Neither maps to a
-// declarative descriptor field. Sig gate mirrors emitBuiltinJson so a same-
-// named identifier bound to a variable / lambda still reaches the indirect-
-// call path when `thread` was not imported.
+// Pattern B entries:
+//   - threadSpawn / threadJoin (#2340): synthesize an `llvm::Function` from
+//     the worker lambda body / read back through a ThreadResult-tagged slot.
+//   - atomicIntNew / atomicBoolNew (#2393): use SSA names like "atomic_int"
+//     / "atomic_bool_ext" that don't match the descriptor's callee-derived
+//     naming, plus the AtomicBool path zexts i1→i64 before the runtime call.
+//   - atomicIntCas (#2393): truncates an i64 runtime result to i1, a value
+//     transform the descriptor's wrappings don't express.
+//   - atomicIntLoad/Store/Add/Sub, atomicBoolLoad/Store (#2393): mixed bool
+//     widening / value naming. Kept together for parity with the rest of
+//     the atomic surface.
+//   - atomicIntFree / atomicBoolFree (#2393): the *Free thread-sync entries
+//     (lockFree etc.) migrated to descriptor-driven ResourceFree, but the
+//     atomic ones stay here so they share `emitThreadAtomicFree`'s
+//     resource-kind type-check with the rest of the atomic family.
+//
+// Sig gate mirrors emitBuiltinJson so a same-named identifier bound to a
+// variable / lambda still reaches the indirect-call path when `thread` was
+// not imported. `libry_thread` registration is auto-derived from the
+// downstream `__ry_thread_*` / `__ry_atomic_*` calls these emitters issue
+// through `emitRuntimeCallDirect` (#2393, via the symbol→library auto-link).
 llvm::Value *CodeGen::emitBuiltinThread(const CallExpr &e) {
+    // threadSpawn / threadJoin — #2340 carve-out.
     if (e.callee == "threadSpawn" &&
         native_fn_sigs_.count("thread::threadSpawn")) {
-        used_native_libraries_.insert("thread");
         return emitBuiltinNativeOrMock(e, "thread", &emitThreadSpawn);
     }
     if (e.callee == "threadJoin" &&
         native_fn_sigs_.count("thread::threadJoin")) {
-        used_native_libraries_.insert("thread");
         return emitBuiltinNativeOrMock(e, "thread", &emitThreadJoin);
+    }
+    // Atomic family — #2393 carve-out.
+    if (e.callee == "atomicIntNew" &&
+        native_fn_sigs_.count("thread::atomicIntNew")) {
+        return emitBuiltinNativeOrMock(e, "thread", &emitThreadAtomicIntNew);
+    }
+    if (e.callee == "atomicBoolNew" &&
+        native_fn_sigs_.count("thread::atomicBoolNew")) {
+        return emitBuiltinNativeOrMock(e, "thread", &emitThreadAtomicBoolNew);
+    }
+    if (e.callee == "atomicIntCas" &&
+        native_fn_sigs_.count("thread::atomicIntCas")) {
+        return emitBuiltinNativeOrMock(e, "thread", &emitThreadAtomicIntCas);
+    }
+    if ((e.callee == "atomicIntLoad" || e.callee == "atomicIntStore"
+            || e.callee == "atomicIntAdd" || e.callee == "atomicIntSub")
+        && native_fn_sigs_.count("thread::" + e.callee)) {
+        return emitBuiltinNativeOrMock(e, "thread", &emitThreadAtomicIntOp);
+    }
+    if ((e.callee == "atomicBoolLoad" || e.callee == "atomicBoolStore")
+        && native_fn_sigs_.count("thread::" + e.callee)) {
+        return emitBuiltinNativeOrMock(e, "thread", &emitThreadAtomicBoolOp);
+    }
+    if ((e.callee == "atomicIntFree" || e.callee == "atomicBoolFree")
+        && native_fn_sigs_.count("thread::" + e.callee)) {
+        return emitBuiltinNativeOrMock(e, "thread", &emitThreadAtomicFree);
     }
     return nullptr;
 }

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -717,15 +717,23 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             // pre-computed values instead of re-inferring at dispatch.
             auto [wrapping, outParamType] = inferReturnWrapping(sig.returnTypeName);
 
-            // Error channel: __ry_<lib>_get_last_error when the descriptor
-            // resolves to a library; bare @native in unknown modules leaves
-            // it empty (the dispatch consumer falls back to deriving from
-            // matchedPackage for behavior-preservation symmetry). Using
-            // effectivePackage matches emitGenericNativeCall's matchedPackage
-            // exactly — both come from sig.library / sig.package via the
-            // same precedence ordering.
+            // Error channel: only set when the package owns a per-module
+            // `__ry_<pkg>_get_last_error` symbol (see DEFINE_LAST_ERROR in
+            // include/ry/runtime/core/error.hpp and the manual emitters in
+            // runtime/native/{io,http}.cpp). Packages without one fall
+            // through to the default `__ry_get_last_error` channel at
+            // dispatch consumption time. #2393 added thread / gc / testing /
+            // json / json5 to this fall-through set (their runtime libs
+            // never emitted DEFINE_LAST_ERROR(thread) etc., so deriving
+            // `__ry_thread_get_last_error` would resolve to an unloaded
+            // symbol at JIT time).
+            static const std::unordered_set<std::string> kHasModuleLastError = {
+                "base64", "convert", "filesystem", "io",
+                "net", "http", "path", "regex",
+            };
             std::string errCh;
-            if (!effectivePackage.empty())
+            if (!effectivePackage.empty()
+                && kHasModuleLastError.count(effectivePackage))
                 errCh = ry::util::deriveRuntimeFnName(effectivePackage,
                                                      "get_last_error");
 

--- a/src/codegen_native_call_descriptor.cpp
+++ b/src/codegen_native_call_descriptor.cpp
@@ -189,6 +189,85 @@ static const OverrideEntry kOverrides[] = {
     {"http", "httpClientResponseFree", {"HttpClientResponse"},
      "__ry_http_client_response_free", {}, "",
      CodeGenReturnWrapping::Direct, false},
+
+    // -------- thread: sync-primitive new (bare resource return) --------
+    // #2393: replaces emitThreadSyncNew (0-arg) custom emitters. The
+    // `Direct` wrapping + descriptor.resource_kind (populated via
+    // inferResourceKind's bare-return arm) drives the addResourceKind tag
+    // in emitGenericNativeCall's Direct path. exported_symbol overrides
+    // the convention-derived `__ry_thread_<callee>` (the runtime symbols
+    // predate the package prefix — they live under `__ry_lock_*` /
+    // `__ry_rwlock_*` directly).
+    {"thread", "lockNew",        {},
+     "__ry_lock_new", {}, "",
+     CodeGenReturnWrapping::Direct, false},
+    {"thread", "rwlockNew",      {},
+     "__ry_rwlock_new", {}, "",
+     CodeGenReturnWrapping::Direct, false},
+
+    // -------- thread: sync-primitive new (Result<resource> return) -----
+    // semaphoreNew / barrierNew take an int and return Result<resource,
+    // Error>. The descriptor's wrapping stays ResultPtr (auto-derived from
+    // inferReturnWrapping on `Result<Semaphore, Error>`) and resource_kind
+    // is auto-set via inferResourceKind's existing Result<T,Error> arm —
+    // the override carries only the runtime-symbol mapping (the convention-
+    // derived `__ry_thread_semaphoreNew` does not match the actual
+    // `__ry_semaphore_new`).
+    {"thread", "semaphoreNew",   {"int"},
+     "__ry_semaphore_new", {}, "",
+     CodeGenReturnWrapping::Direct, false},
+    {"thread", "barrierNew",     {"int"},
+     "__ry_barrier_new", {}, "",
+     CodeGenReturnWrapping::Direct, false},
+
+    // -------- thread: sync-primitive ops (Result<Unit, Error>) ---------
+    // Status-returning sync ops route through ResultStatus +
+    // wrapStatusAsResult. The default `__ry_get_last_error` channel (set
+    // via codegen_fn.cpp's kHasModuleLastError exclusion + the
+    // emitGenericNativeCall fallback) matches the pre-migration call to
+    // `wrapStatusAsResult(status)` with no explicit errFn arg.
+    {"thread", "lockAcquire",      {"Lock"},
+     "__ry_lock_acquire", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true},
+    {"thread", "lockRelease",      {"Lock"},
+     "__ry_lock_release", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true},
+    {"thread", "rwlockReadLock",   {"RWLock"},
+     "__ry_rwlock_read_lock", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true},
+    {"thread", "rwlockWriteLock",  {"RWLock"},
+     "__ry_rwlock_write_lock", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true},
+    {"thread", "rwlockUnlock",     {"RWLock"},
+     "__ry_rwlock_unlock", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true},
+    {"thread", "semaphoreAcquire", {"Semaphore"},
+     "__ry_semaphore_acquire", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true},
+    {"thread", "semaphoreRelease", {"Semaphore"},
+     "__ry_semaphore_release", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true},
+    {"thread", "barrierWait",      {"Barrier"},
+     "__ry_barrier_wait", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true},
+
+    // -------- thread: sync-primitive *Free (ResourceFree wrapping) ----
+    // The *Free entries don't dial a runtime fn — they emit emitResourceFree's
+    // null-check + ARC-release sequence. `exported_symbol` is unused by the
+    // ResourceFree path; the destructor lives in ResourceKindRegistry under
+    // the rk_<resource> kind, looked up via desc.handle_resource_kind.
+    {"thread", "lockFree",        {"Lock"},
+     "", {}, "",
+     CodeGenReturnWrapping::ResourceFree, true},
+    {"thread", "rwlockFree",      {"RWLock"},
+     "", {}, "",
+     CodeGenReturnWrapping::ResourceFree, true},
+    {"thread", "semaphoreFree",   {"Semaphore"},
+     "", {}, "",
+     CodeGenReturnWrapping::ResourceFree, true},
+    {"thread", "barrierFree",     {"Barrier"},
+     "", {}, "",
+     CodeGenReturnWrapping::ResourceFree, true},
 };
 
 bool paramListMatches(std::initializer_list<const char *> expected,
@@ -275,12 +354,25 @@ inferReturnWrapping(const std::string &returnType) {
 }
 
 int inferResourceKind(const std::string &returnType) {
-    // Only Result<T, Error> carriers are considered today. A bare resource
-    // return type (e.g. `fn open() -> File`) is not in stdlib use; gating
-    // on Result<...> keeps the inference's blast radius narrow.
+    // Two carriers populate `resource_kind`:
+    //
+    // (1) `Result<T, Error>` where `T` is a registered resource — the
+    //     wrapped Ok value is tagged after `wrapPtrAsResult` (the pre-2393
+    //     net/http/io constructor pattern).
+    //
+    // (2) #2393: bare resource return (e.g. `lockNew() -> Lock`,
+    //     `atomicIntNew() -> AtomicInt`). Used by thread constructors whose
+    //     runtime symbols return the resource pointer directly without a
+    //     Result wrapper. The Direct path in `emitGenericNativeCall` consumes
+    //     this to call `addResourceKind` after the call. Stdlib audit
+    //     (2026-06-25): only the thread package's *New entries hit this arm
+    //     — no other @native fn returns a bare resource type today, so the
+    //     extension is IR-neutral for existing Pattern C consumers.
+    auto &registry = ResourceKindRegistry::instance();
     std::string okType = extractResultOkType(returnType);
-    if (okType.empty()) return ResourceKindRegistry::NONE;
-    return ResourceKindRegistry::instance().lookupByTypeName(okType);
+    if (!okType.empty())
+        return registry.lookupByTypeName(okType);
+    return registry.lookupByTypeName(returnType);
 }
 
 // Installment 2-c (#2381): scan declared params for the first resource

--- a/tests/test_native_call_descriptor.cpp
+++ b/tests/test_native_call_descriptor.cpp
@@ -563,3 +563,142 @@ TEST(NativeCallDescriptor, ErrorChannelOverride_HttpResponseUsesPackageDefault) 
     EXPECT_EQ(info->typeName, "HttpResponse");
     EXPECT_STREQ(info->errorChannelLibrary, "http");
 }
+
+// =============================================================================
+// #2393: bare-resource return tagging via inferResourceKind, error-channel
+// allow-list (thread / gc / testing / json / json5 fall through to the default
+// `__ry_get_last_error`), and the new ResourceFree wrapping for thread *Free.
+// =============================================================================
+
+TEST(NativeCallDescriptor, InferResourceKind_BareReturnsAreNowTagged) {
+    // #2393 extended inferResourceKind to bare resource returns (in addition
+    // to the pilot's Result<T, Error> arm) so the thread package's *New
+    // constructors get auto-tagged. Stdlib audit confirmed no existing
+    // Pattern C consumer returns a bare resource type, so this is IR-neutral
+    // for io / net / http / base64 / path callers.
+    int rkLock = ResourceKindRegistry::instance().lookupByTypeName("Lock");
+    EXPECT_NE(rkLock, ResourceKindRegistry::NONE)
+        << "Lock must be registered (thread static init)";
+    EXPECT_EQ(inferResourceKind("Lock"), rkLock);
+
+    int rkAtomicInt = ResourceKindRegistry::instance().lookupByTypeName(
+        "AtomicInt");
+    EXPECT_NE(rkAtomicInt, ResourceKindRegistry::NONE);
+    EXPECT_EQ(inferResourceKind("AtomicInt"), rkAtomicInt);
+
+    // Result<T, Error> arm still works (regression).
+    int rkFile = ResourceKindRegistry::instance().lookupByTypeName("File");
+    EXPECT_NE(rkFile, ResourceKindRegistry::NONE);
+    EXPECT_EQ(inferResourceKind("Result<File, Error>"), rkFile);
+
+    // Non-resource returns stay NONE.
+    EXPECT_EQ(inferResourceKind("int"), ResourceKindRegistry::NONE);
+    EXPECT_EQ(inferResourceKind("str"), ResourceKindRegistry::NONE);
+    EXPECT_EQ(inferResourceKind("Result<int, Error>"),
+              ResourceKindRegistry::NONE);
+}
+
+TEST(NativeCallDescriptor, DescriptorStorage_LockNewBareResourceKind) {
+    // lockNew() -> Lock: the descriptor populates resource_kind via the
+    // bare-return arm. The Direct path in emitGenericNativeCall consumes
+    // this to call addResourceKind after the call, mirroring the pre-2393
+    // customEmitter emitThreadSyncNew.
+    std::string src =
+        "@native(\"thread\")\n"
+        "fn lockNew() -> Lock\n"
+        "print(\"setup only\")\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    const auto &descs = cg.getNativeCallDescriptors();
+    auto it = descs.find("thread::lockNew");
+    ASSERT_NE(it, descs.end());
+    ASSERT_EQ(it->second.size(), 1u);
+
+    const auto &desc = it->second[0];
+    EXPECT_EQ(desc.return_wrapping, CodeGenReturnWrapping::Direct);
+    EXPECT_NE(desc.resource_kind, ResourceKindRegistry::NONE);
+    const auto *info = ResourceKindRegistry::instance().getInfo(desc.resource_kind);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->typeName, "Lock");
+    // The override table provides the runtime symbol.
+    EXPECT_EQ(desc.exported_symbol, "__ry_lock_new");
+}
+
+TEST(NativeCallDescriptor, ErrorChannel_ThreadFallsThroughToDefault) {
+    // #2393: thread / gc / testing / json / json5 lack a per-module
+    // `__ry_<pkg>_get_last_error` runtime symbol, so codegen_fn.cpp's
+    // error_channel derivation skips them via the kHasModuleLastError
+    // allow-list. emitGenericNativeCall's fallback then uses the default
+    // `__ry_get_last_error` channel at dispatch time, matching what the
+    // pre-2393 customEmitter `wrapStatusAsResult(status)` consumed.
+    std::string src =
+        "@native(\"thread\")\n"
+        "fn lockAcquire(lock: Lock) -> Result<Unit, Error>\n"
+        "print(\"setup only\")\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    const auto &descs = cg.getNativeCallDescriptors();
+    auto it = descs.find("thread::lockAcquire");
+    ASSERT_NE(it, descs.end());
+    ASSERT_EQ(it->second.size(), 1u);
+
+    const auto &desc = it->second[0];
+    EXPECT_EQ(desc.return_wrapping, CodeGenReturnWrapping::ResultStatus);
+    EXPECT_TRUE(desc.error_channel.empty())
+        << "thread is not in kHasModuleLastError; channel must stay empty "
+           "so emitGenericNativeCall falls back to __ry_get_last_error";
+    EXPECT_EQ(desc.exported_symbol, "__ry_lock_acquire");
+}
+
+TEST(NativeCallDescriptor, Override_LockFreeIsResourceFree) {
+    // #2393: the thread sync *Free entries (lockFree / rwlockFree /
+    // semaphoreFree / barrierFree) use the new ResourceFree wrapping. No
+    // runtime fn is dialed; the destructor lives in ResourceKindRegistry
+    // and emitResourceFree handles the null-check + ARC-release.
+    auto ov = lookupNativeOverloadOverride("thread", "lockFree", {"Lock"});
+    ASSERT_TRUE(ov.has_value());
+    ASSERT_TRUE(ov->wrapping_overridden);
+    EXPECT_EQ(ov->wrapping_override, CodeGenReturnWrapping::ResourceFree);
+}
+
+TEST(NativeCallDescriptor, Testing_DescriptorPopulatesForMockNative) {
+    // #2393: testing's @native fns dispatch via Pattern C (no
+    // RY_REGISTER_STDLIB_PACKAGE for testing). Descriptor population mirrors
+    // any other library-tagged @native; the default error channel applies
+    // since testing has no `__ry_testing_get_last_error` runtime symbol.
+    std::string src =
+        "@native(\"testing\")\n"
+        "fn _mockGetCallCount(name: str) -> int\n"
+        "print(\"setup only\")\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    const auto &descs = cg.getNativeCallDescriptors();
+    auto it = descs.find("testing::_mockGetCallCount");
+    ASSERT_NE(it, descs.end());
+    ASSERT_EQ(it->second.size(), 1u);
+
+    const auto &desc = it->second[0];
+    EXPECT_EQ(desc.return_wrapping, CodeGenReturnWrapping::Direct);
+    ASSERT_TRUE(desc.library_name.has_value());
+    EXPECT_EQ(*desc.library_name, "testing");
+    EXPECT_TRUE(desc.error_channel.empty())
+        << "testing is not in kHasModuleLastError; channel must stay empty";
+}


### PR DESCRIPTION
## Summary

- Closes out #2299's three remaining pieces in one PR (per #2393's "no partial implementation" preamble): thread sync-primitive descriptor migration, `used_native_libraries_` consolidation via symbol→library reverse map, and `inferResourceKind` extension to bare-resource returns.
- thread `lock*` / `rwlock*` / `semaphore*` / `barrier*` (new / op / free) move to `emitGenericNativeCall` with per-overload `exported_symbol` overrides; new `ResourceFree` wrapping replaces the `*Free` custom emitters; thread atomics + `threadSpawn`/`threadJoin` stay Pattern B (value-transform, #2340 precedent).
- Manual `used_native_libraries_.insert(...)` is structurally banned (`rg` confirms 0 hits). Pattern B carve-outs (convert / io built-ins, `emitHttpListen`'s synthesized net+http calls, `emitBuiltinThread`'s atomics) auto-link via the symbol prefix table in `getRuntimeFn` / `emitRuntimeCallDirect`. Only the gc emit-boundary sites (`emitArcRelease` / `emitCowCheckSlot`) keep a `linkNativeLibrary("gc")` hand-call.

## Test plan

- [x] `./build-rust/ry_tests` — 3016 tests pass (32 NativeCallDescriptor + 137 EmitAbiGuard + …).
- [x] `./build-rust/ry test -p` — 220 spec files / 9 workers, 0 failures (`thread.test.ry`'s 31 tests pass).
- [x] `ctest -L filecheck` — 41 / 41 pass.
- [x] **IR byte-exact regression (criterion 6)**: pre vs post diff of `tests/spec/{thread,io_file_handle,net,http_client}.test.ry` IR dumps is EMPTY (after normalizing heap-allocated pointer addresses).
- [x] **`ResourceFree` execution coverage**: a standalone program exercising `lockFree` / `rwlockFree` / `semaphoreFree` / `barrierFree` runs clean; its pre vs post IR diff is also EMPTY.
- [x] `scripts/check-examples.sh` — 101 / 101 canonical examples pass.
- [x] Close criterion 2: `rg 'used_native_libraries_.*insert' src include tests` → 0 hits.
- [x] `docs/architecture/native-call-boundary.md` §"Pattern B carve-out" rewritten and descriptor field table updated.

Closes #2393