### PR TITLE
feat(testing): add calledWith / calledTimes / lastCalledWith matchers

### DIFF
--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -658,6 +658,95 @@ fn verifyCalledWithTests():
 - `int` argument literals are widened to `float` automatically when the parameter type is `float` (matching ordinary call-site coercion).
 - Returns `0` when no recorded call matches the supplied arguments.
 
+### calledWith(name, args...)
+
+Returns `bool`: `true` iff at least one recorded call to the mocked or spied function matches the supplied `args...` (as `int` for the count is conceptually `verifyCalledWith(name, args...) > 0`). Like `verifyCalledWith`, the function name must be a **string literal** and is resolved at compile time.
+
+```ry
+from ry.testing import it, describe, mock, spy, calledWith, expect
+
+fn compute(x: int) -> int:
+    return x * 2
+
+@describe("calledWith")
+fn calledWithTests():
+    @it("should return true when arg matches")
+    fn matchesArg():
+        spy("compute")
+        compute(5)
+        compute(7)
+        expect(calledWith("compute", 5)).toBeTrue()
+        expect(calledWith("compute", 7)).toBeTrue()
+        expect(calledWith("compute", 99)).toBeFalse()
+```
+
+- Requires `from testing import calledWith` (since v0.0.30, #2396)
+- Same compile-time validation rules as `verifyCalledWith`: function must exist, must be mocked or spied, and supplied `args...` must match the original function's parameter list by arity and type
+- Supported argument types are identical to `verifyCalledWith` (`int`, `float`, `bool`, `str`, `List<T>`, `Set<T>`, `Map<K, V>`, record / tuple, `fn(...) -> R`)
+- Returns `false` when no recorded call matches (including the "never called" case)
+- Overload semantics are identical to `verifyCalledWith`: bare-name on an overloaded function dispatches to the arity-matching overload (compile error on ambiguity); signature form (`"compute(int)"`) selects a specific overload
+
+### calledTimes(name, n)
+
+Returns `bool`: `true` iff the mocked or spied function has been called exactly `n` times.
+
+```ry
+from ry.testing import it, describe, spy, calledTimes, expect
+
+fn compute(x: int) -> int:
+    return x * 2
+
+@describe("calledTimes")
+fn calledTimesTests():
+    @it("should match exact count")
+    fn matchesCount():
+        spy("compute")
+        compute(1)
+        compute(2)
+        expect(calledTimes("compute", 2)).toBeTrue()
+        expect(calledTimes("compute", 0)).toBeFalse()
+
+    @it("should return true with zero count when never called")
+    fn matchesZero():
+        spy("compute")
+        expect(calledTimes("compute", 0)).toBeTrue()
+```
+
+- Requires `from testing import calledTimes` (since v0.0.30, #2396)
+- The first argument must be a **string literal** function name (same convention as `calledWith` / `verifyCalledWith`)
+- The function must exist and must be mocked or spied (compile error otherwise — catches stale or misspelled names that `verify(name)` silently treats as zero)
+- The second argument may be any `int` expression (literal, variable, or computed)
+- Overload semantics: bare-name aggregates counts across all overloads (matches `verify(bareName)` parity); signature form (`"compute(int)"`) counts only that overload
+- Equivalent to `verify(name) == n`, returned as `bool` so it composes with `expect(...).toBeTrue()` directly
+
+### lastCalledWith(name, args...)
+
+Returns `bool`: `true` iff the **most recent** recorded call to the mocked or spied function matches the supplied `args...`. Unlike `calledWith` (which scans the entire history), `lastCalledWith` checks only the latest call — useful for assertions on the final state of a retry loop or paginated request.
+
+```ry
+from ry.testing import it, describe, spy, lastCalledWith, expect
+
+fn compute(x: int) -> int:
+    return x * 2
+
+@describe("lastCalledWith")
+fn lastCalledWithTests():
+    @it("should match only the most recent call")
+    fn matchesLast():
+        spy("compute")
+        compute(1)
+        compute(2)
+        compute(3)
+        expect(lastCalledWith("compute", 3)).toBeTrue()
+        expect(lastCalledWith("compute", 1)).toBeFalse()
+        expect(lastCalledWith("compute", 2)).toBeFalse()
+```
+
+- Requires `from testing import lastCalledWith` (since v0.0.30, #2396)
+- Same compile-time validation rules and supported argument types as `verifyCalledWith` / `calledWith`
+- Returns `false` when there are no recorded calls
+- Overload semantics are identical to `verifyCalledWith`: bare-name on an overloaded function dispatches to the arity-matching overload (compile error on ambiguity); signature form selects a specific overload. "Last" always refers to the last call recorded against the resolved overload — there is no cross-overload aggregation
+
 ### spy(name)
 
 Records calls to a function without replacing its implementation. Unlike `mock`, the original function body still executes — `spy` only adds call-count and argument-recording instrumentation around it.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -680,7 +680,7 @@ fn calledWithTests():
         expect(calledWith("compute", 99)).toBeFalse()
 ```
 
-- Requires `from testing import calledWith` (since v0.0.30, #2396)
+- Requires `from ry.testing import calledWith` (since v0.0.30, #2396)
 - Same compile-time validation rules as `verifyCalledWith`: function must exist, must be mocked or spied, and supplied `args...` must match the original function's parameter list by arity and type
 - Supported argument types are identical to `verifyCalledWith` (`int`, `float`, `bool`, `str`, `List<T>`, `Set<T>`, `Map<K, V>`, record / tuple, `fn(...) -> R`)
 - Returns `false` when no recorded call matches (including the "never called" case)
@@ -712,7 +712,7 @@ fn calledTimesTests():
         expect(calledTimes("compute", 0)).toBeTrue()
 ```
 
-- Requires `from testing import calledTimes` (since v0.0.30, #2396)
+- Requires `from ry.testing import calledTimes` (since v0.0.30, #2396)
 - The first argument must be a **string literal** function name (same convention as `calledWith` / `verifyCalledWith`)
 - The function must exist and must be mocked or spied (compile error otherwise — catches stale or misspelled names that `verify(name)` silently treats as zero)
 - The second argument may be any `int` expression (literal, variable, or computed)
@@ -742,7 +742,7 @@ fn lastCalledWithTests():
         expect(lastCalledWith("compute", 2)).toBeFalse()
 ```
 
-- Requires `from testing import lastCalledWith` (since v0.0.30, #2396)
+- Requires `from ry.testing import lastCalledWith` (since v0.0.30, #2396)
 - Same compile-time validation rules and supported argument types as `verifyCalledWith` / `calledWith`
 - Returns `false` when there are no recorded calls
 - Overload semantics are identical to `verifyCalledWith`: bare-name on an overloaded function dispatches to the arity-matching overload (compile error on ambiguity); signature form selects a specific overload. "Last" always refers to the last call recorded against the resolved overload — there is no cross-overload aggregation

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1847,7 +1847,18 @@ public:
     void emitMockReturnValueOnceCall(CallStmt &s);
     void emitSpyCall(CallStmt &s);
     void emitFailCall(CallStmt &s);
+    // Mode for the shared called-matcher implementation (#2396). CountInt is
+    // the original verifyCalledWith semantics (i64 count). HasMatchingBool
+    // returns i1 from `count > 0` (calledWith). LastMatchesBool calls the
+    // last-call runtime helper and returns i1 (lastCalledWith).
+    enum class CalledMatcherMode { CountInt, HasMatchingBool, LastMatchesBool };
     llvm::Value *emitVerifyCalledWithCall(const CallExpr &e);
+    llvm::Value *emitCalledWithCall(const CallExpr &e);
+    llvm::Value *emitLastCalledWithCall(const CallExpr &e);
+    llvm::Value *emitCalledTimesCall(const CallExpr &e);
+    llvm::Value *emitCalledMatcherImpl(const CallExpr &e,
+                                        const std::string &intrinsicName,
+                                        CalledMatcherMode mode);
     void emitMockArgRecording(llvm::Value *nameStr,
                                const std::vector<llvm::Value *> &argVals,
                                OverloadEntry *matchedEntry);

--- a/include/ry/test_runtime.hpp
+++ b/include/ry/test_runtime.hpp
@@ -92,6 +92,15 @@ extern "C" {
     int64_t __ry_mock_count_matching_calls(const char *name, int64_t numArgs,
                                             const int64_t *kinds,
                                             const int64_t *values);
+    // #2396: returns 1 iff the most-recently-recorded call to `name` matches
+    // the expected (kinds, values) tuple (same comparison rules as
+    // __ry_mock_count_matching_calls). Returns 0 when there are no recorded
+    // calls or when the last call does not match. Consumes snapshot ownership
+    // for kinds 6/7/8/9/10/11 identically to __ry_mock_count_matching_calls,
+    // so callers do not need a separate free path.
+    int64_t __ry_mock_last_call_matches(const char *name, int64_t numArgs,
+                                         const int64_t *kinds,
+                                         const int64_t *values);
     void    __ry_mock_clear_all();
     void    __ry_mock_clear(const char *name);
     void    __ry_mock_reset(const char *name);

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -162,6 +162,14 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
     // Testing intrinsic: verifyCalledWith (#1677)
     if (e->callee == "verifyCalledWith")
         return emitVerifyCalledWithCall(*e);
+    // Testing matcher intrinsics: calledWith / calledTimes / lastCalledWith
+    // (#2396). bool-returning siblings of verifyCalledWith / verify.
+    if (e->callee == "calledWith")
+        return emitCalledWithCall(*e);
+    if (e->callee == "calledTimes")
+        return emitCalledTimesCall(*e);
+    if (e->callee == "lastCalledWith")
+        return emitLastCalledWithCall(*e);
 
     // Fast path: pre-emit args[0] once for callee names shared by multiple
     // dispatchers, then route through the same try-chain order to avoid

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -2531,20 +2531,46 @@ void CodeGen::emitMockArgRecording(llvm::Value *nameStr,
     }
 }
 
-// ===== Test: verifyCalledWith(name, args...) -> int =====
+// ===== Test: verifyCalledWith / calledWith / lastCalledWith =====
+//
+// Shared implementation (#2396). verifyCalledWith returns int (call count);
+// calledWith returns bool (count > 0); lastCalledWith returns bool (last
+// recorded call matches). All three share the same signature resolution,
+// argument validation, and per-arg recording IR — only the runtime helper
+// invoked at the end and the result transformation differ. Error messages
+// are parameterized via `iname` so users see the actual intrinsic name they
+// wrote, not a stale "verifyCalledWith" prefix.
 
 llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
+    return emitCalledMatcherImpl(e, "verifyCalledWith",
+                                  CalledMatcherMode::CountInt);
+}
+
+llvm::Value *CodeGen::emitCalledWithCall(const CallExpr &e) {
+    return emitCalledMatcherImpl(e, "calledWith",
+                                  CalledMatcherMode::HasMatchingBool);
+}
+
+llvm::Value *CodeGen::emitLastCalledWithCall(const CallExpr &e) {
+    return emitCalledMatcherImpl(e, "lastCalledWith",
+                                  CalledMatcherMode::LastMatchesBool);
+}
+
+llvm::Value *CodeGen::emitCalledMatcherImpl(const CallExpr &e,
+                                             const std::string &intrinsicName,
+                                             CalledMatcherMode mode) {
+    const std::string &iname = intrinsicName;
     if (!test_mode_)
-        codegenError("'verifyCalledWith' is only allowed in test mode (use 'ry test')");
-    if (!testing_intrinsics_imported_.count("verifyCalledWith"))
-        codegenError("'verifyCalledWith' requires 'from ry.testing import verifyCalledWith'");
+        codegenError("'" + iname + "' is only allowed in test mode (use 'ry test')");
+    if (!testing_intrinsics_imported_.count(iname))
+        codegenError("'" + iname + "' requires 'from ry.testing import " + iname + "'");
 
     if (e.args.empty())
-        codegenError("verifyCalledWith() requires at least 1 argument: function name");
+        codegenError(iname + "() requires at least 1 argument: function name");
 
     auto *strExpr = std::get_if<StringExpr>(&e.args[0]->data);
     if (!strExpr)
-        codegenError("verifyCalledWith() first argument must be a function name string literal");
+        codegenError(iname + "() first argument must be a function name string literal");
     const std::string &fnNameInput = strExpr->value;
 
     // Sig form vs bare. Bare-name on an overloaded function is matched
@@ -2564,11 +2590,11 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
         // still works since it goes through __ry_mock_count_matching_calls.
         auto nativeSigs = collectNativeSigsByBareName(bareName);
         if (!nativeSigs.empty())
-            codegenError("verifyCalledWith: argument recording for @native overloads "
+            codegenError(iname + ": argument recording for @native overloads "
                          "(e.g. math.digits) is not supported in v1; only count-based "
                          "verify(\"" + fnNameInput + "\") works (see "
                          "docs/reference/testing.md 'Native (@native) overloads' note)");
-        codegenError("verifyCalledWith: unknown function '" + fnNameInput + "'");
+        codegenError(iname + ": unknown function '" + fnNameInput + "'");
     }
 
     OverloadEntry *entryPtr = nullptr;
@@ -2589,7 +2615,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             if (eq) { entryPtr = &ov; break; }
         }
         if (!entryPtr) {
-            std::string msg = "verifyCalledWith: no overload of '" + bareName +
+            std::string msg = iname + ": no overload of '" + bareName +
                 "' matches signature '" + fnNameInput + "'. Available:";
             for (const auto &ov : *overloads)
                 msg += "\n  - " + buildCanonicalSig(bareName, ov.paramTypeNames);
@@ -2607,13 +2633,13 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             if (ov.paramTypes.size() == suppliedArgs) { match = &ov; ++matchCount; }
         }
         if (matchCount != 1) {
-            std::string msg = "verifyCalledWith: '" + bareName +
+            std::string msg = iname + ": '" + bareName +
                 "' is overloaded; ";
             msg += (matchCount == 0)
                 ? "no overload accepts " + std::to_string(suppliedArgs) + " argument(s)."
                 : "multiple overloads accept " + std::to_string(suppliedArgs) +
                   " argument(s).";
-            msg += " Use signature form: verifyCalledWith(\"" + bareName +
+            msg += " Use signature form: " + iname + "(\"" + bareName +
                 "(T1, T2)\", ...). Available:";
             for (const auto &ov : *overloads)
                 msg += "\n  - " + buildCanonicalSig(bareName, ov.paramTypeNames);
@@ -2626,11 +2652,11 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
     const std::string &fnName = bareName;
 
     if (!mocked_functions_.count(canonicalSig) && !spied_functions_.count(canonicalSig))
-        codegenError("verifyCalledWith: '" + fnName + "' is not mocked or spied");
+        codegenError(iname + ": '" + fnName + "' is not mocked or spied");
 
     const size_t expectedNumArgs = e.args.size() - 1;
     if (expectedNumArgs != entry.paramTypes.size())
-        codegenError("verifyCalledWith: expected " +
+        codegenError(iname + ": expected " +
                      std::to_string(entry.paramTypes.size()) +
                      " argument(s) for '" + fnName + "', got " +
                      std::to_string(expectedNumArgs));
@@ -2692,7 +2718,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             paramListInner = resolveTypeAlias(
                 declaredParamName.substr(5, declaredParamName.size() - 6));
             if (!isSupportedCollElemName(paramListInner)) {
-                std::string msg = "verifyCalledWith: parameter ";
+                std::string msg = iname + ": parameter ";
                 msg += std::to_string(i);
                 msg += " of '";
                 msg += fnName;
@@ -2706,7 +2732,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             paramSetInner = resolveTypeAlias(
                 declaredParamName.substr(4, declaredParamName.size() - 5));
             if (!isSupportedCollElemName(paramSetInner)) {
-                std::string msg = "verifyCalledWith: parameter ";
+                std::string msg = iname + ": parameter ";
                 msg += std::to_string(i);
                 msg += " of '";
                 msg += fnName;
@@ -2727,7 +2753,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             }
             if (!isSupportedCollElemName(paramMapKeyInner) ||
                 !isSupportedCollElemName(paramMapValInner)) {
-                std::string msg = "verifyCalledWith: parameter ";
+                std::string msg = iname + ": parameter ";
                 msg += std::to_string(i);
                 msg += " of '";
                 msg += fnName;
@@ -2748,7 +2774,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 else if (fldName == "bool") k = 3;
                 else if (fldName == "str") k = 4;
                 if (k == 0) {
-                    std::string msg = "verifyCalledWith: parameter ";
+                    std::string msg = iname + ": parameter ";
                     msg += std::to_string(i);
                     msg += " of '";
                     msg += fnName;
@@ -2768,7 +2794,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             // #1706: tuple params accepted iff every element is primitive or str.
             paramTupleElemNames = splitTupleSig(declaredParamName);
             if (paramTupleElemNames.empty()) {
-                std::string msg = "verifyCalledWith: parameter ";
+                std::string msg = iname + ": parameter ";
                 msg += std::to_string(i);
                 msg += " of '";
                 msg += fnName;
@@ -2785,7 +2811,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 else if (resolved == "bool") k = 3;
                 else if (resolved == "str") k = 4;
                 if (k == 0) {
-                    std::string msg = "verifyCalledWith: parameter ";
+                    std::string msg = iname + ": parameter ";
                     msg += std::to_string(i);
                     msg += " of '";
                     msg += fnName;
@@ -2812,7 +2838,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
         } else if (!declaredParamName.empty() &&
                    declaredParamName != "int" && declaredParamName != "float" &&
                    declaredParamName != "bool" && declaredParamName != "str") {
-            std::string msg = "verifyCalledWith: parameter ";
+            std::string msg = iname + ": parameter ";
             msg += std::to_string(i);
             msg += " of '";
             msg += fnName;
@@ -2841,13 +2867,13 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
         if (paramIsFn) {
             auto *fnInfo = lookupFnTypeInfo(argVal);
             if (!fnInfo) {
-                codegenError("verifyCalledWith: argument " +
+                codegenError(iname + ": argument " +
                              std::to_string(i + 1) +
                              " of '" + fnName +
                              "' is fn-typed but its FnTypeInfo could not be "
                              "recovered; pass a named lambda or function "
-                             "reference (e.g. `let f = (...) => ...; "
-                             "verifyCalledWith(\"...\", f)`)");
+                             "reference (e.g. `let f = (...) => ...; " +
+                             iname + "(\"...\", f)`)");
             }
 
             // #1715: enforce exact signature match between the recorded fn
@@ -2885,7 +2911,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 }
                 actualSig += ") -> ";
                 actualSig += fnInfo->returnTypeName;
-                std::string msg = "verifyCalledWith: argument ";
+                std::string msg = iname + ": argument ";
                 msg += std::to_string(i + 1);
                 msg += " of '";
                 msg += fnName;
@@ -2905,7 +2931,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 argVal = builder_.CreateSIToFP(argVal, f64Ty_, "vcw_int2f");
                 argTy = f64Ty_;
             } else {
-                codegenError("verifyCalledWith: argument " + std::to_string(i + 1) +
+                codegenError(iname + ": argument " + std::to_string(i + 1) +
                              " type does not match '" + fnName + "' parameter " +
                              std::to_string(i));
             }
@@ -2931,7 +2957,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 return " has an unsupported type";
             };
             if (paramIsList && !argIsList) {
-                std::string msg = "verifyCalledWith: argument ";
+                std::string msg = iname + ": argument ";
                 msg += std::to_string(i + 1);
                 msg += argIsSet || argIsMap ? otherShapeStr() : " is not a List";
                 msg += " but parameter ";
@@ -2944,7 +2970,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 codegenError(msg);
             }
             if (!paramIsList && !paramIsSet && !paramIsMap && argIsList) {
-                std::string msg = "verifyCalledWith: argument ";
+                std::string msg = iname + ": argument ";
                 msg += std::to_string(i + 1);
                 msg += " is a List but parameter ";
                 msg += std::to_string(i);
@@ -2956,7 +2982,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 codegenError(msg);
             }
             if (paramIsSet && !argIsSet) {
-                std::string msg = "verifyCalledWith: argument ";
+                std::string msg = iname + ": argument ";
                 msg += std::to_string(i + 1);
                 msg += argIsList || argIsMap ? otherShapeStr() : " is not a Set";
                 msg += " but parameter ";
@@ -2969,7 +2995,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 codegenError(msg);
             }
             if (!paramIsSet && !paramIsList && !paramIsMap && argIsSet) {
-                std::string msg = "verifyCalledWith: argument ";
+                std::string msg = iname + ": argument ";
                 msg += std::to_string(i + 1);
                 msg += " is a Set but parameter ";
                 msg += std::to_string(i);
@@ -2981,7 +3007,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 codegenError(msg);
             }
             if (paramIsMap && !argIsMap) {
-                std::string msg = "verifyCalledWith: argument ";
+                std::string msg = iname + ": argument ";
                 msg += std::to_string(i + 1);
                 msg += argIsList || argIsSet ? otherShapeStr() : " is not a Map";
                 msg += " but parameter ";
@@ -2994,7 +3020,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 codegenError(msg);
             }
             if (!paramIsSet && !paramIsList && !paramIsMap && argIsMap) {
-                std::string msg = "verifyCalledWith: argument ";
+                std::string msg = iname + ": argument ";
                 msg += std::to_string(i + 1);
                 msg += " is a Map but parameter ";
                 msg += std::to_string(i);
@@ -3018,7 +3044,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 }
                 std::string argElemResolved = resolveTypeAlias(argElemName);
                 if (argElemResolved != paramListInner) {
-                    std::string msg = "verifyCalledWith: argument ";
+                    std::string msg = iname + ": argument ";
                     msg += std::to_string(i + 1);
                     msg += " is List<";
                     msg += argElemName;
@@ -3050,7 +3076,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 }
                 std::string argElemResolved = resolveTypeAlias(argElemName);
                 if (argElemResolved != paramSetInner) {
-                    std::string msg = "verifyCalledWith: argument ";
+                    std::string msg = iname + ": argument ";
                     msg += std::to_string(i + 1);
                     msg += " is Set<";
                     msg += argElemName;
@@ -3083,7 +3109,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 std::string argValResolved = resolveTypeAlias(argValName);
                 if (argKeyResolved != paramMapKeyInner ||
                     argValResolved != paramMapValInner) {
-                    std::string msg = "verifyCalledWith: argument ";
+                    std::string msg = iname + ": argument ";
                     msg += std::to_string(i + 1);
                     msg += " is Map<";
                     msg += argKeyName;
@@ -3113,7 +3139,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                     std::string argName =
                         argSt->hasName() ? argSt->getName().str()
                                           : std::string("<anonymous>");
-                    std::string msg = "verifyCalledWith: argument ";
+                    std::string msg = iname + ": argument ";
                     msg += std::to_string(i + 1);
                     msg += " is record '";
                     msg += argName;
@@ -3129,7 +3155,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             } else if (paramIsTuple) {
                 if (!isTupleStructType(argSt) ||
                     argSt->getNumElements() != paramTupleKinds.size()) {
-                    std::string msg = "verifyCalledWith: argument ";
+                    std::string msg = iname + ": argument ";
                     msg += std::to_string(i + 1);
                     msg += " has shape mismatch for tuple parameter ";
                     msg += std::to_string(i);
@@ -3156,7 +3182,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 if (!argTupleSig.empty())
                     argElemNames = splitTupleSig(argTupleSig);
                 if (argElemNames.size() != paramTupleElemNames.size()) {
-                    std::string msg = "verifyCalledWith: argument ";
+                    std::string msg = iname + ": argument ";
                     msg += std::to_string(i + 1);
                     msg += " is a tuple whose element types could not be "
                            "recovered from metadata; only literal tuple "
@@ -3176,7 +3202,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                     std::string paramElemResolved =
                         resolveTypeAlias(paramTupleElemNames[k]);
                     if (argElemResolved != paramElemResolved) {
-                        std::string msg = "verifyCalledWith: argument ";
+                        std::string msg = iname + ": argument ";
                         msg += std::to_string(i + 1);
                         msg += " element ";
                         msg += std::to_string(k);
@@ -3195,7 +3221,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                     }
                 }
             } else {
-                std::string msg = "verifyCalledWith: argument ";
+                std::string msg = iname + ": argument ";
                 msg += std::to_string(i + 1);
                 msg += " has struct type but parameter ";
                 msg += std::to_string(i);
@@ -3420,7 +3446,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             kind = 4;
             valI64 = builder_.CreatePtrToInt(argVal, i64Ty_, "vcw_p2i");
         } else {
-            codegenError("verifyCalledWith: argument " + std::to_string(i + 1) +
+            codegenError(iname + ": argument " + std::to_string(i + 1) +
                          " has unsupported type; only int, float, bool, str, "
                          "List<T>, Set<T>, Map<K, V>, record types whose fields "
                          "are primitives or str, and tuple types whose elements "
@@ -3441,10 +3467,177 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
         builder_.CreateStore(valI64, valGEP);
     }
 
+    // #2396: dispatch on mode. CountInt / HasMatchingBool share
+    // __ry_mock_count_matching_calls (the bool form just compares count > 0).
+    // LastMatchesBool uses a dedicated runtime helper that returns 1 iff the
+    // most-recent recorded call matches; 0 means no calls or last call didn't
+    // match. Both helpers consume snapshot ownership for collection-shaped
+    // expected args identically, so the recording IR is unchanged.
+    if (mode == CalledMatcherMode::LastMatchesBool) {
+        llvm::FunctionCallee lastFn = getRuntimeFn(
+            "__ry_mock_last_call_matches", i64Ty_,
+            {ptrTy_, i64Ty_, ptrTy_, ptrTy_});
+        llvm::Value *res = builder_.CreateCall(
+            lastFn, {nameStr, numArgsConst, kindsArr, valuesArr}, "vcw_last");
+        return builder_.CreateICmpNE(
+            res, llvm::ConstantInt::get(i64Ty_, 0), "vcw_last_b");
+    }
     llvm::FunctionCallee countFn =
         getRuntimeFn("__ry_mock_count_matching_calls", i64Ty_, {ptrTy_, i64Ty_, ptrTy_, ptrTy_});
-    return builder_.CreateCall(countFn, {nameStr, numArgsConst, kindsArr, valuesArr},
-                                "vcw_count");
+    llvm::Value *count = builder_.CreateCall(
+        countFn, {nameStr, numArgsConst, kindsArr, valuesArr}, "vcw_count");
+    if (mode == CalledMatcherMode::HasMatchingBool)
+        return builder_.CreateICmpNE(
+            count, llvm::ConstantInt::get(i64Ty_, 0), "vcw_has");
+    return count;
+}
+
+// ===== Test: calledTimes(name, n) -> bool =====
+//
+// #2396: bool form of `verify(name) == n`. Validates the function exists and
+// has been mocked or spied (matches verifyCalledWith's compile-time gate).
+// For overloaded functions, bare-name accepts aggregate count semantics —
+// __ry_mock_get_call_count's bare-name index path sums calls across all
+// overloads, so no sig-form requirement is enforced (unlike verifyCalledWith
+// which requires arity disambiguation). The expected count is any int
+// expression (literal or variable).
+llvm::Value *CodeGen::emitCalledTimesCall(const CallExpr &e) {
+    const std::string iname = "calledTimes";
+    if (!test_mode_)
+        codegenError("'" + iname + "' is only allowed in test mode (use 'ry test')");
+    if (!testing_intrinsics_imported_.count(iname))
+        codegenError("'" + iname + "' requires 'from ry.testing import " + iname + "'");
+
+    if (e.args.size() != 2)
+        codegenError(iname + "() requires exactly 2 arguments: function name and expected count");
+
+    auto *strExpr = std::get_if<StringExpr>(&e.args[0]->data);
+    if (!strExpr)
+        codegenError(iname + "() first argument must be a function name string literal");
+    const std::string &fnNameInput = strExpr->value;
+
+    // Parse sig form if present. Bare name is allowed on overloaded fns and
+    // aggregates the count at runtime.
+    std::string bareName;
+    std::vector<std::string> sigParamTypes;
+    const bool isSigForm = parseSigString(fnNameInput, bareName, sigParamTypes);
+    if (!isSigForm) bareName = fnNameInput;
+
+    auto *overloads = findFunction(bareName);
+    auto nativeSigs = collectNativeSigsByBareName(bareName);
+    const bool isNative = (!overloads || overloads->empty()) && !nativeSigs.empty();
+    if ((!overloads || overloads->empty()) && nativeSigs.empty())
+        codegenError(iname + ": unknown function '" + fnNameInput + "'");
+
+    auto sigParamNames = [](const NativeFnSignature *sig) {
+        std::vector<std::string> out;
+        out.reserve(sig->params.size());
+        for (const auto &p : sig->params) out.push_back(p.typeName);
+        return out;
+    };
+
+    // Resolve to canonical sig (or use the bare name for aggregate runtime path).
+    std::string runtimeName = bareName;
+    if (isSigForm) {
+        std::vector<std::string> wantNorm;
+        wantNorm.reserve(sigParamTypes.size());
+        for (const auto &p : sigParamTypes)
+            wantNorm.push_back(resolveTypeAlias(ry::util::trimTypeNameSpaces(p)));
+        bool found = false;
+        if (overloads) {
+            for (auto &ov : *overloads) {
+                if (ov.paramTypeNames.size() != wantNorm.size()) continue;
+                bool eq = true;
+                for (size_t i = 0; i < wantNorm.size(); ++i) {
+                    if (resolveTypeAlias(ry::util::trimTypeNameSpaces(ov.paramTypeNames[i]))
+                            != wantNorm[i]) {
+                        eq = false; break;
+                    }
+                }
+                if (eq) {
+                    runtimeName = buildCanonicalSig(bareName, ov.paramTypeNames);
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if (!found && isNative) {
+            // For @native overloads, accept any sig form whose normalized
+            // param types match a registered native sig.
+            for (const auto *nsig : nativeSigs) {
+                auto paramNames = sigParamNames(nsig);
+                if (paramNames.size() != wantNorm.size()) continue;
+                bool eq = true;
+                for (size_t i = 0; i < wantNorm.size(); ++i) {
+                    if (resolveTypeAlias(ry::util::trimTypeNameSpaces(paramNames[i]))
+                            != wantNorm[i]) {
+                        eq = false; break;
+                    }
+                }
+                if (eq) {
+                    runtimeName = buildCanonicalSig(bareName, paramNames);
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if (!found)
+            codegenError(iname + ": no overload of '" + bareName +
+                         "' matches signature '" + fnNameInput + "'");
+    } else if (overloads && overloads->size() == 1) {
+        // Single overload — use canonical sig so the runtime checks the exact
+        // entry without falling back to bare-name aggregation. Behaviourally
+        // identical for the single-overload case but mirrors verifyCalledWith's
+        // canonicalization.
+        runtimeName = buildCanonicalSig(bareName, (*overloads)[0].paramTypeNames);
+    } else if (isNative && nativeSigs.size() == 1) {
+        runtimeName = buildCanonicalSig(bareName, sigParamNames(nativeSigs[0]));
+    }
+    // For bare-name on multi-overload, runtimeName stays as the bare name and
+    // __ry_mock_get_call_count aggregates via the bare-name index.
+
+    // Compile-time mocked/spied gate. For bare-name multi-overload, require
+    // that ANY overload is mocked or spied (matches verify(bareName) parity
+    // — if none are mocked, the user has a typo or stale name).
+    bool anyMockedOrSpied = false;
+    if (isSigForm ||
+        (overloads && overloads->size() == 1) ||
+        (isNative && nativeSigs.size() == 1)) {
+        anyMockedOrSpied = mocked_functions_.count(runtimeName) > 0 ||
+                            spied_functions_.count(runtimeName) > 0;
+    } else if (overloads) {
+        for (auto &ov : *overloads) {
+            std::string sig = buildCanonicalSig(bareName, ov.paramTypeNames);
+            if (mocked_functions_.count(sig) > 0 || spied_functions_.count(sig) > 0) {
+                anyMockedOrSpied = true;
+                break;
+            }
+        }
+    } else if (isNative) {
+        for (const auto *nsig : nativeSigs) {
+            std::string sig = buildCanonicalSig(bareName, sigParamNames(nsig));
+            if (mocked_functions_.count(sig) > 0 || spied_functions_.count(sig) > 0) {
+                anyMockedOrSpied = true;
+                break;
+            }
+        }
+    }
+    if (!anyMockedOrSpied)
+        codegenError(iname + ": '" + bareName + "' is not mocked or spied");
+
+    // Evaluate the expected-count expression and require int.
+    llvm::Value *expectedVal = emitExpr(*e.args[1]);
+    if (expectedVal->getType() != i64Ty_)
+        codegenError(iname + "() second argument must be int");
+
+    // Cache the global string for the runtime name.
+    auto &nameStr = mock_name_strings_[runtimeName];
+    if (!nameStr) nameStr = cachedGlobalString(runtimeName, ".mock." + runtimeName);
+
+    llvm::FunctionCallee getCountFn =
+        getRuntimeFn("__ry_mock_get_call_count", i64Ty_, {ptrTy_});
+    llvm::Value *actual = builder_.CreateCall(getCountFn, {nameStr}, "ct_count");
+    return builder_.CreateICmpEQ(actual, expectedVal, "ct_eq");
 }
 
 // ===== Test: ExpectStmt =====

--- a/src/module/module_loader.cpp
+++ b/src/module/module_loader.cpp
@@ -182,7 +182,8 @@ static std::string makeImportError(int line, const std::string &detail) {
 // through the same standard mechanism and is NOT a compiler intrinsic.
 static const std::unordered_set<std::string> &testingIntrinsics() {
     static const std::unordered_set<std::string> kSet = {
-        "expect", "mock", "mockReturnValueOnce", "spy", "fail", "verifyCalledWith"};
+        "expect", "mock", "mockReturnValueOnce", "spy", "fail",
+        "verifyCalledWith", "calledWith", "calledTimes", "lastCalledWith"};
     return kSet;
 }
 

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -1348,6 +1348,69 @@ int64_t __ry_mock_count_matching_calls(const char *name, int64_t numArgs,
     return matched;
 }
 
+// #2396: returns 1 iff the most-recently-recorded call across all entries
+// resolved for `name` matches (kinds, values). Aggregation across overloads
+// mirrors __ry_mock_count_matching_calls — when a bare name maps to multiple
+// canonical-sig entries (bare-name index), the entry's last call is compared
+// against the expected args. If multiple entries are present and at least one
+// has a last call that matches, we return 1; we do NOT track a global
+// timestamp across entries because individual entry ordering is sufficient
+// for the verifyCalledWith-style use case (the user supplies a name and
+// expects "the last invocation of THAT thing"). Snapshot ownership is
+// transferred identically to __ry_mock_count_matching_calls.
+int64_t __ry_mock_last_call_matches(const char *name, int64_t numArgs,
+                                     const int64_t *kinds,
+                                     const int64_t *values) {
+    std::vector<MockEntry *> entries;
+    auto exactIt = g_mock_registry.find(name);
+    if (exactIt != g_mock_registry.end()) {
+        entries.push_back(&exactIt->second);
+    } else {
+        auto idxIt = g_mock_name_index.find(name);
+        if (idxIt != g_mock_name_index.end()) {
+            for (const auto &sig : idxIt->second) {
+                auto sigIt = g_mock_registry.find(sig);
+                if (sigIt != g_mock_registry.end())
+                    entries.push_back(&sigIt->second);
+            }
+        }
+    }
+    int64_t result = 0;
+    for (MockEntry *entry : entries) {
+        if (entry->calls.empty()) continue;
+        const auto &last = entry->calls.back();
+        if (static_cast<int64_t>(last.args.size()) != numArgs) continue;
+        bool ok = true;
+        for (int64_t i = 0; i < numArgs; ++i) {
+            if (!mockArgEqual(last.args[static_cast<size_t>(i)],
+                              kinds[i], values[i])) {
+                ok = false;
+                break;
+            }
+        }
+        if (ok) { result = 1; break; }
+    }
+    for (int64_t i = 0; i < numArgs; ++i) {
+        if (kinds[i] == 6 || kinds[i] == 7) {
+            freeMockListSnapshot(
+                reinterpret_cast<MockListSnapshot *>(values[i]));
+        } else if (kinds[i] == 8) {
+            freeMockMapSnapshot(
+                reinterpret_cast<MockMapSnapshot *>(values[i]));
+        } else if (kinds[i] == 9) {
+            freeMockRecordSnapshot(
+                reinterpret_cast<MockRecordSnapshot *>(values[i]));
+        } else if (kinds[i] == 10) {
+            freeMockTupleSnapshot(
+                reinterpret_cast<MockTupleSnapshot *>(values[i]));
+        } else if (kinds[i] == 11) {
+            freeMockFnSnapshot(
+                reinterpret_cast<MockFnSnapshot *>(values[i]));
+        }
+    }
+    return result;
+}
+
 void __ry_mock_clear_all() {
     for (auto &kv : g_mock_registry) {
         auto &entry = kv.second;

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -1348,16 +1348,21 @@ int64_t __ry_mock_count_matching_calls(const char *name, int64_t numArgs,
     return matched;
 }
 
-// #2396: returns 1 iff the most-recently-recorded call across all entries
-// resolved for `name` matches (kinds, values). Aggregation across overloads
-// mirrors __ry_mock_count_matching_calls — when a bare name maps to multiple
-// canonical-sig entries (bare-name index), the entry's last call is compared
-// against the expected args. If multiple entries are present and at least one
-// has a last call that matches, we return 1; we do NOT track a global
-// timestamp across entries because individual entry ordering is sufficient
-// for the verifyCalledWith-style use case (the user supplies a name and
-// expects "the last invocation of THAT thing"). Snapshot ownership is
-// transferred identically to __ry_mock_count_matching_calls.
+// #2396: returns 1 iff the last recorded call to `name` matches
+// (kinds, values). The codegen path always pins `name` to the canonical
+// signature of the resolved overload (emitCalledMatcherImpl in
+// codegen_test.cpp dispatches bare-name on overloaded fns by arity at
+// compile time — compile error on ambiguity), so the exact-name lookup
+// below always hits a single entry in practice; the bare-name index
+// fallback is structurally unreachable from `lastCalledWith` and kept only
+// for shape-symmetry with __ry_mock_count_matching_calls. If a future
+// caller invokes this helper with an unresolved bare name across multiple
+// overload entries, the current "any entry's calls.back() matches" branch
+// would not be a true global-last across overloads — adding a global
+// sequence counter on MockCallRecord would be the correct generalization,
+// but is deferred until such a caller actually exists. Snapshot ownership
+// for kinds 6-11 is transferred identically to
+// __ry_mock_count_matching_calls so the path is leak-free regardless.
 int64_t __ry_mock_last_call_matches(const char *name, int64_t numArgs,
                                      const int64_t *kinds,
                                      const int64_t *values) {

--- a/tests/spec/called_with.test.ry
+++ b/tests/spec/called_with.test.ry
@@ -1,0 +1,312 @@
+from ry.testing import it, describe, expect, spy, mock, mockClear, mockReset, mockResetAll
+from ry.testing import calledWith, calledTimes, lastCalledWith
+
+# Real implementations for spy-based scenarios.
+fn compute(x: int) -> int:
+  return x * 3
+
+fn greet(name: str) -> str:
+  return "hello " + name
+
+fn flagToInt(b: bool) -> int:
+  if b:
+    return 1
+  return 0
+
+fn floatDouble(x: float) -> float:
+  return x * 2.0
+
+fn sumList(xs: List<int>) -> int:
+  total: int = 0
+  for x in xs:
+    total = total + x
+  return total
+
+fn countStrSet(xs: Set<str>) -> int:
+  return len(xs)
+
+fn sumMapValues(m: Map<str, int>) -> int:
+  total: int = 0
+  for k, v in m:
+    total = total + v
+  return total
+
+@describe("calledWith")
+fn calledWithTests():
+  @it("should return true when at least one call matches int argument")
+  fn t1():
+    spy("compute")
+    compute(7)
+    compute(7)
+    compute(8)
+    expect(calledWith("compute", 7)).toBeTrue()
+    expect(calledWith("compute", 8)).toBeTrue()
+    expect(calledWith("compute", 999)).toBeFalse()
+
+  @it("should return true when str argument matches")
+  fn t2():
+    spy("greet")
+    greet("alice")
+    expect(calledWith("greet", "alice")).toBeTrue()
+    expect(calledWith("greet", "bob")).toBeFalse()
+
+  @it("should return true when bool argument matches")
+  fn t3():
+    spy("flagToInt")
+    flagToInt(true)
+    expect(calledWith("flagToInt", true)).toBeTrue()
+    expect(calledWith("flagToInt", false)).toBeFalse()
+
+  @it("should return true when float argument matches")
+  fn t4():
+    spy("floatDouble")
+    floatDouble(1.5)
+    expect(calledWith("floatDouble", 1.5)).toBeTrue()
+    expect(calledWith("floatDouble", 3.0)).toBeFalse()
+
+  @it("should match List<int> argument by deep snapshot")
+  fn t5():
+    spy("sumList")
+    sumList([1, 2, 3])
+    expect(calledWith("sumList", [1, 2, 3])).toBeTrue()
+    expect(calledWith("sumList", [1, 2])).toBeFalse()
+
+  @it("should match Set<str> argument unordered")
+  fn t6():
+    spy("countStrSet")
+    countStrSet({"a", "b"})
+    expect(calledWith("countStrSet", {"b", "a"})).toBeTrue()
+    expect(calledWith("countStrSet", {"c"})).toBeFalse()
+
+  @it("should match Map<str, int> argument unordered")
+  fn t7():
+    spy("sumMapValues")
+    m1: Map<str, int> = {"a": 1, "b": 2}
+    sumMapValues(m1)
+    expect(calledWith("sumMapValues", {"b": 2, "a": 1})).toBeTrue()
+    expect(calledWith("sumMapValues", {"x": 9})).toBeFalse()
+
+  @it("should return false when no calls recorded")
+  fn t8():
+    spy("compute")
+    expect(calledWith("compute", 1)).toBeFalse()
+
+  @it("should work with mock as well as spy")
+  fn t9():
+    mock(compute, (x: int) => 999)
+    compute(5)
+    expect(calledWith("compute", 5)).toBeTrue()
+    expect(calledWith("compute", 6)).toBeFalse()
+
+@describe("calledTimes")
+fn calledTimesTests():
+  @it("should return true when call count matches")
+  fn t1():
+    spy("compute")
+    compute(1)
+    compute(2)
+    expect(calledTimes("compute", 2)).toBeTrue()
+    expect(calledTimes("compute", 0)).toBeFalse()
+    expect(calledTimes("compute", 3)).toBeFalse()
+
+  @it("should return true with zero count when never called")
+  fn t2():
+    spy("compute")
+    expect(calledTimes("compute", 0)).toBeTrue()
+
+  @it("should accept an int variable as the expected count")
+  fn t3():
+    spy("compute")
+    compute(1)
+    compute(2)
+    compute(3)
+    expected: int = 3
+    expect(calledTimes("compute", expected)).toBeTrue()
+
+  @it("should reset count after mockClear")
+  fn t4():
+    spy("compute")
+    compute(1)
+    compute(2)
+    expect(calledTimes("compute", 2)).toBeTrue()
+    mockClear("compute")
+    expect(calledTimes("compute", 0)).toBeTrue()
+
+@describe("lastCalledWith")
+fn lastCalledWithTests():
+  @it("should match only the most recent call")
+  fn t1():
+    spy("compute")
+    compute(1)
+    compute(2)
+    compute(3)
+    expect(lastCalledWith("compute", 3)).toBeTrue()
+    expect(lastCalledWith("compute", 1)).toBeFalse()
+    expect(lastCalledWith("compute", 2)).toBeFalse()
+
+  @it("should return false when no calls recorded")
+  fn t2():
+    spy("compute")
+    expect(lastCalledWith("compute", 1)).toBeFalse()
+
+  @it("should match str argument on last call")
+  fn t3():
+    spy("greet")
+    greet("alice")
+    greet("bob")
+    expect(lastCalledWith("greet", "bob")).toBeTrue()
+    expect(lastCalledWith("greet", "alice")).toBeFalse()
+
+  @it("should match List<int> argument on last call")
+  fn t4():
+    spy("sumList")
+    sumList([1, 2, 3])
+    sumList([4, 5])
+    expect(lastCalledWith("sumList", [4, 5])).toBeTrue()
+    expect(lastCalledWith("sumList", [1, 2, 3])).toBeFalse()
+
+  @it("should match Set<str> argument on last call unordered")
+  fn t5():
+    spy("countStrSet")
+    countStrSet({"a", "b"})
+    countStrSet({"x", "y", "z"})
+    expect(lastCalledWith("countStrSet", {"z", "y", "x"})).toBeTrue()
+    expect(lastCalledWith("countStrSet", {"a", "b"})).toBeFalse()
+
+  @it("should match Map<str, int> argument on last call unordered")
+  fn t6():
+    spy("sumMapValues")
+    sumMapValues({"a": 1})
+    sumMapValues({"b": 2, "c": 3})
+    expect(lastCalledWith("sumMapValues", {"c": 3, "b": 2})).toBeTrue()
+    expect(lastCalledWith("sumMapValues", {"a": 1})).toBeFalse()
+
+  @it("should reset after mockClear and observe no last call")
+  fn t7():
+    spy("compute")
+    compute(7)
+    expect(lastCalledWith("compute", 7)).toBeTrue()
+    mockClear("compute")
+    expect(lastCalledWith("compute", 7)).toBeFalse()
+
+  @it("should work with mock as well as spy")
+  fn t8():
+    mock(compute, (x: int) => 999)
+    compute(5)
+    compute(6)
+    expect(lastCalledWith("compute", 6)).toBeTrue()
+    expect(lastCalledWith("compute", 5)).toBeFalse()
+
+@describe("matcher interop with mockReset / mockResetAll")
+fn matcherInteropTests():
+  @it("should observe zero state after mockReset")
+  fn t1():
+    spy("compute")
+    compute(1)
+    expect(calledTimes("compute", 1)).toBeTrue()
+    expect(calledWith("compute", 1)).toBeTrue()
+    mockReset("compute")
+    expect(calledTimes("compute", 0)).toBeTrue()
+    expect(calledWith("compute", 1)).toBeFalse()
+    expect(lastCalledWith("compute", 1)).toBeFalse()
+
+  @it("should observe zero state after mockResetAll")
+  fn t2():
+    spy("compute")
+    spy("greet")
+    compute(1)
+    greet("alice")
+    mockResetAll()
+    expect(calledTimes("compute", 0)).toBeTrue()
+    expect(calledTimes("greet", 0)).toBeTrue()
+    expect(calledWith("compute", 1)).toBeFalse()
+    expect(calledWith("greet", "alice")).toBeFalse()
+
+# Overloaded function for overload-form tests.
+fn addNum(a: int, b: int) -> int:
+  return a + b
+
+fn addNum(a: float, b: float) -> float:
+  return a + b
+
+# Belt-and-suspenders: record / tuple / fn / zero-arg coverage. The arg-recording
+# IR is shared with verifyCalledWith (already covered for these shapes), so this
+# section locks in that the new matcher dispatch routes through the same path.
+
+record Point:
+  x: int
+  y: int
+
+fn takesPoint(p: Point) -> int:
+  return p.x + p.y
+
+fn takesPair(t: (int, str)) -> int:
+  return t.0
+
+fn takesFn(f: fn(int) -> int) -> int:
+  return f(0)
+
+fn noArgs() -> int:
+  return 42
+
+@describe("matchers cover record / tuple / fn / zero-arg")
+fn extraShapeTests():
+  @it("calledWith on record argument")
+  fn t1():
+    spy("takesPoint")
+    takesPoint(Point(1, 2))
+    expect(calledWith("takesPoint", Point(1, 2))).toBeTrue()
+    expect(calledWith("takesPoint", Point(9, 9))).toBeFalse()
+    expect(lastCalledWith("takesPoint", Point(1, 2))).toBeTrue()
+
+  @it("calledWith on tuple argument")
+  fn t2():
+    spy("takesPair")
+    takesPair((1, "a"))
+    expect(calledWith("takesPair", (1, "a"))).toBeTrue()
+    expect(calledWith("takesPair", (2, "b"))).toBeFalse()
+    expect(lastCalledWith("takesPair", (1, "a"))).toBeTrue()
+
+  @it("calledWith on fn argument (pointer equality)")
+  fn t3():
+    spy("takesFn")
+    lam = (x: int) => x + 1
+    takesFn(lam)
+    expect(calledWith("takesFn", lam)).toBeTrue()
+    expect(lastCalledWith("takesFn", lam)).toBeTrue()
+
+  @it("calledWith on zero-arg function")
+  fn t4():
+    spy("noArgs")
+    noArgs()
+    noArgs()
+    expect(calledWith("noArgs")).toBeTrue()
+    expect(calledTimes("noArgs", 2)).toBeTrue()
+    expect(lastCalledWith("noArgs")).toBeTrue()
+
+@describe("matchers on overloaded functions (signature form)")
+fn overloadedMatcherTests():
+  @it("should target int overload only with signature form")
+  fn t1():
+    spy("addNum(int, int)")
+    addNum(2, 3)
+    addNum(5, 7)
+    expect(calledWith("addNum(int, int)", 2, 3)).toBeTrue()
+    expect(calledWith("addNum(int, int)", 5, 7)).toBeTrue()
+    expect(calledWith("addNum(int, int)", 99, 99)).toBeFalse()
+
+  @it("should count only int overload calls with signature form")
+  fn t2():
+    spy("addNum(int, int)")
+    addNum(1, 1)
+    addNum(2, 2)
+    expect(calledTimes("addNum(int, int)", 2)).toBeTrue()
+    expect(calledTimes("addNum(int, int)", 1)).toBeFalse()
+
+  @it("should pick most recent call by overload with lastCalledWith")
+  fn t3():
+    spy("addNum(int, int)")
+    addNum(1, 2)
+    addNum(3, 4)
+    expect(lastCalledWith("addNum(int, int)", 3, 4)).toBeTrue()
+    expect(lastCalledWith("addNum(int, int)", 1, 2)).toBeFalse()

--- a/tests/spec/called_with.test.ry
+++ b/tests/spec/called_with.test.ry
@@ -221,6 +221,8 @@ fn matcherInteropTests():
     expect(calledTimes("greet", 0)).toBeTrue()
     expect(calledWith("compute", 1)).toBeFalse()
     expect(calledWith("greet", "alice")).toBeFalse()
+    expect(lastCalledWith("compute", 1)).toBeFalse()
+    expect(lastCalledWith("greet", "alice")).toBeFalse()
 
 # Overloaded function for overload-form tests.
 fn addNum(a: int, b: int) -> int:

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1902,9 +1902,12 @@ TEST_F(ImportTest, FromTestingWildcardRecordsAllIntrinsics) {
     // #1677 adds `verifyCalledWith` as an intrinsic.
     // #1683 adds `spy` as an intrinsic.
     // #1681 adds `mockReturnValueOnce` as an intrinsic.
+    // #2396 adds `calledWith`, `calledTimes`, `lastCalledWith` as bool-form
+    // matcher intrinsics.
     std::unordered_set<std::string> expected = {
-        "expect", "mock", "mockReturnValueOnce", "spy", "fail", "verifyCalledWith"};
-    EXPECT_EQ(intrinsics.size(), 6u);
+        "expect", "mock", "mockReturnValueOnce", "spy", "fail",
+        "verifyCalledWith", "calledWith", "calledTimes", "lastCalledWith"};
+    EXPECT_EQ(intrinsics.size(), 9u);
     EXPECT_EQ(intrinsics, expected);
 }
 
@@ -1973,9 +1976,12 @@ TEST_F(ImportTest, CodeGenReceivesAllTestingIntrinsicsForWildcard) {
     // #1677 adds `verifyCalledWith` as an intrinsic.
     // #1683 adds `spy` as an intrinsic.
     // #1681 adds `mockReturnValueOnce` as an intrinsic.
+    // #2396 adds `calledWith`, `calledTimes`, `lastCalledWith` as bool-form
+    // matcher intrinsics.
     std::unordered_set<std::string> expected = {
-        "expect", "mock", "mockReturnValueOnce", "spy", "fail", "verifyCalledWith"};
-    EXPECT_EQ(intrinsics.size(), 6u);
+        "expect", "mock", "mockReturnValueOnce", "spy", "fail",
+        "verifyCalledWith", "calledWith", "calledTimes", "lastCalledWith"};
+    EXPECT_EQ(intrinsics.size(), 9u);
     EXPECT_EQ(intrinsics, expected);
 }
 


### PR DESCRIPTION
## Summary

Adds three bool-returning matcher intrinsics that mirror `verifyCalledWith` (which returns int):

- `calledWith(name, args...)` — true iff at least one recorded call matches.
- `calledTimes(name, n)` — true iff the call count equals `n`.
- `lastCalledWith(name, args...)` — true iff the most recent recorded call matches; backed by a new `__ry_mock_last_call_matches` runtime helper.

All three share `verifyCalledWith`'s compile-time validation (function exists, mocked or spied, arg arity/type) and lifecycle (it-end auto-clear, `mockClear` / `mockReset` / `mockResetAll`). The arg-recording IR is reused via a new `emitCalledMatcherImpl` helper; only the runtime call and result transformation vary by mode.

## Scope notes

The issue body was updated before implementation (per the issue's own re-planning rule) to reflect:

- snake_case names (`called_with` / `called_times` / `last_called_with`) → camelCase to align with existing `verifyCalledWith` / `mockResetAll` / `toEq`.
- `spy.calls` / `mock.calls` property accessor: dropped as out of scope. Ry has no property access on function values, and the recorded buffer uses opaque kind-tagged ints — exposing it as a typed `List<tuple<paramTypes>>` would require a per-overload typed deserializer. The matchers fully cover argument-level assertions (the recording itself already exists internally).

## Test plan

- [x] `./build-rust/ry_tests`: 3016/3016 pass (incl. updated `ImportTest` intrinsic-set expectations).
- [x] `./build-rust/ry test -p tests/spec/`: 220 test files, 0 failure (new `tests/spec/called_with.test.ry` adds 30 cases covering int/float/bool/str/List/Set/Map/record/tuple/fn/zero-arg + overload sig form + `mockReset` / `mockResetAll` interop).
- [x] `tests/spec/spy.test.ry` + `tests/spec/mock.test.ry`: no regression (refactor is behavior-preserving).
- [x] `bash scripts/check-examples.sh`: 102/102 pass.
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh`: clean.
- [x] Negative tests verified: unknown function name, wrong arg type, not-mocked-or-spied each produce a compile error prefixed with the intrinsic the user actually wrote.

Closes #2396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new mock-testing matchers for checking whether a function was called, how many times it was called, and whether the last call matched expected arguments.
  * Expanded testing import support so the new matcher APIs are available alongside existing testing helpers.

* **Bug Fixes**
  * Improved matching behavior across overloads and argument types, including clearer handling when no calls exist or no match is found.
  * Added broader test coverage for spies, mocks, state resets, and composite values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->