### PR TITLE
fix(tree-sitter): resolve tuple / generic / numeric / lambda expected-fail buckets (#2394)

### DIFF
--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -137,7 +137,7 @@ entry, or is explicitly marked as covered by the smoke fixture only.
 | Top-level rule | Corpus file |
 |---|---|
 | `function_declaration` | `functions.txt`, `decorators.txt` |
-| `record_declaration`, `record_invariant` | `records.txt` |
+| `record_declaration`, `record_invariant`, `record_declaration` w/ `parent` (subtyping, #2394) | `records.txt` |
 | `enum_declaration`, `variant_payload` (named / unnamed) | `enums.txt` |
 | `type_alias_declaration` | `type_aliases.txt` |
 | `import_statement`, `qualified_import_statement` | `imports.txt` |
@@ -151,20 +151,23 @@ entry, or is explicitly marked as covered by the smoke fixture only.
 | `f_string` | `f_strings.txt` |
 | `regex_literal` | `regex.txt` |
 | `_indent` / `_dedent` / `_newline` edge cases | `indent.txt` |
-| `lambda_expression` | `lambdas.txt` |
-| literals (`integer_literal`, `float_literal`, `string_literal`, `block_string_literal`, `boolean_literal`, `none_literal`, `list_literal`, `map_literal`, `set_literal`, `tuple_literal`) | `literals.txt` |
-| `binary_expression`, `unary_expression`, `call_expression`, `index_expression`, `field_access` | `expressions.txt` |
+| `lambda_expression` (single-param / parens / block-body), block-form `if_expression` body (#2394) | `lambdas.txt` |
+| literals (`integer_literal`, `float_literal`, `string_literal`, `block_string_literal`, `boolean_literal`, `none_literal`, `list_literal`, `map_literal`, `set_literal`, `tuple_literal`); leading-dot / suffix / underscore numeric forms (#2394) | `literals.txt` |
+| `binary_expression`, `unary_expression`, `call_expression`, `index_expression`, `field_access` (incl. numeric tuple-member access `t.0`, #2394), `generic_constructor` (`Foo<T>::Variant`, #2394), single-line `if_expression` (#2394) | `expressions.txt` |
 | `directive_def_declaration` | `decorators.txt` (※1) |
-| **smoke-only** (corpus 化不能 / 既知 grammar gap) | `tuple_destructure_statement`, top-level `@<decorator> NAME: T = ...` (`expected-fail.txt` 該当) |
+| `tuple_destructure_statement` (incl. decorated `@const (a, b) = ...`, #2394), `generic_parameters` with `type_parameter` bounds (#2394) | `statements.txt`, `functions.txt` |
+| **smoke-only** (corpus 化不能 / 既知 grammar gap) | top-level `@<decorator> NAME: T = ...` (`expected-fail.txt` 該当)、nested block-body lambda (`mid = () -> int: leaf = () -> int: …` 二重ネスト時に内側 DEDENT 後の outer `_simple_statement` 用 NEWLINE が emit されない問題 — scanner 側の別 issue として継続) |
 
 Scope of the matrix is the rules that can appear as a direct child of
 `source_file` (declarations, top-level statements, imports). The
 following rules surface only inside another corpus entry's expression
 or type and are validated indirectly when that parent entry is parsed:
 
-- `cast_expression`, `unwrap_expression`, `update_expression`,
-  `if_expression` — expression-interior; appear inside `_expression`
-  but never at top level.
+- `cast_expression`, `unwrap_expression`, `update_expression` —
+  expression-interior; appear inside `_expression` but never at top
+  level. (`if_expression` single-line is now covered directly in
+  `expressions.txt` via #2394's "if expression with identifier
+  condition" entry.)
 - `weak_type` — type-interior; only meaningful inside `_primary_type`.
 - `contract_clause` — appears only inside `function_body` after the
   introducing `:`. Indirectly exercised via `functions.txt` if a

--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -14,39 +14,16 @@
 #   - Nested f-strings: e.g. `f"a={f"b={42}"}"`。tests/spec/ には該当する spec が
 #     存在しないため file path 登録は無し。spec が追加されたら追記する。
 
-# === Tuple member access (`.0`, `.1`, ..., `.N`) ===
-tests/spec/arc_set_map_tuple_2226.test.ry  # triage(#2382): persistent — shares the tuple member-access (`.0`, `.1`) gap with the rest of this bucket
-tests/spec/collections.test.ry
-tests/spec/combinatorial/collection_element_tuple_access.test.ry
-tests/spec/combinatorial/collection_element_tuple_iterate.test.ry
-tests/spec/combinatorial/fn_argument.test.ry
-tests/spec/combinatorial/fn_return.test.ry
-tests/spec/combinatorial/match_types.test.ry
-tests/spec/combinatorial/nested_types.test.ry
-tests/spec/combinatorial/syntax_combinations.test.ry
-tests/spec/generic_infer_container.test.ry
-tests/spec/tuple_destructure_assign_parens.test.ry
-tests/spec/tuple_nested_generic_2264.test.ry  # triage(#2382): persistent — shares the tuple member-access (`.0`, `.1`) gap with the rest of this bucket
-tests/spec/tuple_single_element.test.ry
-tests/spec/types.test.ry
-
-# === Generic type syntax variants (`<T: Bound>`, `<T>::Variant` turbofish) ===
-tests/spec/enum_generic_param_type.test.ry
-tests/spec/generic_bounds.test.ry
-
-# === Lambda body with block expressions (`=> if ... :`, `=> if ... else ...`) ===
+# === Lambda body with nested block-body lambdas (DEDENT/NEWLINE) ===
+# `mid = () -> int: <indent> leaf = () -> int: <indent> stmt <dedent> stmt
+# <dedent>` の二重ネストで、内側 lambda の DEDENT 後に外側 `_simple_statement`
+# 用 NEWLINE が emit されない問題 (#2394 で部分解析 — block-form if-expr /
+# turbofish / `<T: Bound>` 等は本 PR で解消、本ケースは scanner.c で
+# NEWLINE-then-DEDENT 列に揃える別問題として継続)。
 tests/spec/nested_fn_return_fn.test.ry
-tests/spec/option_branch_merge_none.test.ry
-tests/spec/option_lambda_if.test.ry
-tests/spec/result_lambda_if.test.ry
-
-# === Numeric literal forms (leading dot, type suffix, underscore separator) ===
-tests/spec/leading_dot_float.test.ry
-tests/spec/numeric_literal_suffix.test.ry
-tests/spec/numeric_underscore_separator.test.ry
 
 # === Async / decorator / operator-overload / untyped-param declarations ===
-tests/spec/any.test.ry
+tests/spec/arc_iolist.test.ry
 tests/spec/concurrency.test.ry
 tests/spec/concurrency_stress.test.ry
 tests/spec/functions.test.ry
@@ -57,12 +34,10 @@ tests/spec/net.test.ry
 tests/spec/top_level_bindings.test.ry
 
 # === Other surface coverage gaps ===
-# (relative imports, trailing commas, records, case unification / arm bindings,
-#  ARC iolist patterns, Result type inference, enum with discriminant value)
-tests/spec/arc_iolist.test.ry
+# (relative imports, case unification / arm bindings, ARC iolist patterns,
+#  records, enum with discriminant value)
 tests/spec/case_unification.test.ry
 tests/spec/nul_safety_http.test.ry
-tests/spec/record_subtyping.test.ry
 tests/spec/records.test.ry
 tests/spec/relative_import/mymath/mymath.test.ry
 tests/spec/relative_import/relative_import.test.ry
@@ -75,20 +50,8 @@ tests/spec/braced_import/braced_import.test.ry
 # import with alias`); the failure is the leading `.` in `module_path` — the
 # same relative import grammar gap above.
 tests/spec/import_alias/import_alias.test.ry
-tests/spec/result_type_inference.test.ry
 tests/spec/trailing_commas.test.ry
 tests/spec/type_of.test.ry
-
-# === Housekeeping: pre-existing gaps not registered by earlier PRs ===
-# Discovered during #1722 self-verification; the parent PRs introduced these
-# fixtures but did not update expected-fail.txt. Each is an independent grammar
-# gap unrelated to braced selective import.
-#   - arc_tuple_*.ry, collection_meta_propagation.ry, mock.test.ry: feature-
-#     specific syntax surfaces not yet covered by editor/tree-sitter/grammar.js
-tests/spec/arc_tuple_index_assign.test.ry
-tests/spec/arc_tuple_ownership.test.ry
-tests/spec/collection_meta_propagation.test.ry
-tests/spec/mock.test.ry
 
 # === #2115: multiline UFCS chain (`obj\n.iter()...`) ===
 # The C++ parser supports multiline UFCS chains (continuation lines starting

--- a/editor/tree-sitter/grammar.js
+++ b/editor/tree-sitter/grammar.js
@@ -98,6 +98,12 @@ export default grammar({
     // start a lambda param list, a tuple type, or a parenthesized expr). (#1906)
     [$.named_type, $.qualified_identifier],
     [$.named_type, $.qualified_identifier, $.lambda_param],
+    // `f[Foo<T>::Variant, ...]` — bracket contents can look like either a
+    // type list (named_type with `::` chain + type args) OR an expression
+    // list (generic_constructor primary expression). Resolved at the
+    // closing `]` based on the next token (`(args)` → expression, no `(`
+    // → type list).
+    [$.named_type, $.generic_constructor],
   ],
 
   rules: {
@@ -184,8 +190,14 @@ export default grammar({
     decorator: $ => seq(
       '@',
       field('name', $.identifier),
+      // `token.immediate('(')` requires no whitespace between the
+      // decorator name and the `(`. This mirrors the C++ parser's
+      // `looksLikeParenthesizedTupleDestructure` lookahead — `@const(...)`
+      // is decorator-with-args, while `@const (a, b) = expr` is the
+      // decorator followed by a parenthesized tuple-destructure statement
+      // (#1189; see src/parser/parser.cpp:387-393).
       optional(seq(
-        '(',
+        alias(token.immediate('('), '('),
         optional($.decorator_arguments),
         ')',
       )),
@@ -245,8 +257,13 @@ export default grammar({
 
     generic_parameters: $ => seq(
       '<',
-      sep1($.identifier, ','),
+      sep1($.type_parameter, ','),
       '>',
+    ),
+
+    type_parameter: $ => seq(
+      field('name', $.identifier),
+      optional(seq(':', field('bound', $.identifier))),
     ),
 
     // Live-editing tolerance (#1623): the INDENT body is optional so that
@@ -290,6 +307,7 @@ export default grammar({
       'record',
       field('name', $.identifier),
       optional(field('generics', $.generic_parameters)),
+      optional(seq('<', field('parent', $.identifier))),
       ':',
       $._indent,
       repeat($._record_member),
@@ -407,7 +425,11 @@ export default grammar({
     )),
 
     type_arguments: $ => seq(
-      '<',
+      // `token.immediate('<')` keeps `Foo<T>` from colliding with the
+      // comparison operator `a < b` — type args must directly follow the
+      // identifier with no intervening whitespace. Mirrors the C++
+      // parser's `couldBeGenericEnum` lookahead and the EBNF spec.
+      alias(token.immediate('<'), '<'),
       sep1($._type, ','),
       '>',
     ),
@@ -486,18 +508,28 @@ export default grammar({
       field('right', $._expression),
     )),
 
-    /* `name: Type = value` — implicit-binding form (no `let` keyword) */
+    /* `name: Type = value` — implicit-binding form (no `let` keyword).
+     * The value slot accepts either a regular expression or a block-form
+     * `if_statement` / `case_statement`. The block-form admission lets
+     * `x: T = if cond:\n  (e1)\nelse:\n  (e2)` parse cleanly (Ry's
+     * IfBlockExpr / CaseBlockExpr surfaces — see #1154). */
     typed_binding_statement: $ => seq(
       field('name', $.identifier),
       ':',
       field('type', $._type),
       '=',
-      field('value', $._expression),
+      field('value', choice($._expression, $.if_statement, $.case_statement)),
     ),
 
-    /* Both forms: `(a, b) = expr`  and  `a, b = expr` */
+    /* Both forms: `(a, b) = expr`  and  `a, b = expr`
+     * Leading decorators (`@const (a, b) = expr`, etc.) are allowed on the
+     * parenthesized form so directives like `@const` can attach to a
+     * tuple-destructure binding (#1189 — see src/parser/parser.cpp:387-393).
+     * The decorator sits on the same line as the `(` so the inter-decorator
+     * NEWLINE seen in `_declaration` is intentionally NOT required here. */
     tuple_destructure_statement: $ => choice(
       seq(
+        repeat($.decorator),
         '(',
         sep1($.identifier, ','),
         ')',
@@ -566,13 +598,13 @@ export default grammar({
     // expected interpretation.
     if_statement: $ => prec.right(seq(
       'if',
-      field('condition', $._expression),
+      field('condition', $._conditional_expression),
       ':',
       optional(field('consequence', $.block)),
       repeat(seq(
         'else',
         'if',
-        field('alt_condition', $._expression),
+        field('alt_condition', $._conditional_expression),
         ':',
         optional(field('alt_consequence', $.block)),
       )),
@@ -740,6 +772,22 @@ export default grammar({
       repeat(seq('::', $.identifier)),
     )),
 
+    /* `Foo<T, U>::Variant` — explicit-type-args constructor for generic
+     * enums / records. Requires `::IDENT` after the type-arguments closing
+     * `>` so the parser does not mistake the leading `<` for a comparison
+     * operator. Mirrors src/parser/parser_expr.cpp:634 `couldBeGenericEnum`.
+     * The pair conflicts with `qualified_identifier` (both start with
+     * `identifier`); the conflict declaration in `conflicts:` tells GLR
+     * to keep both interpretations alive until the lookahead beyond IDENT
+     * (`<type>::IDENT` vs comparison `<expr>`) disambiguates. */
+    generic_constructor: $ => seq(
+      $.identifier,
+      $.type_arguments,
+      '::',
+      $.identifier,
+      repeat(seq('::', $.identifier)),
+    ),
+
     range_pattern: $ => seq(
       $.literal_pattern,
       '..',
@@ -791,12 +839,28 @@ export default grammar({
       optional(seq('=', field('default', $._expression))),
     ),
 
-    _lambda_body: $ => choice($._expression, $.block),
+    /* Lambda body can be:
+     *   - any expression (`x => x + 1`, `() => 42`)
+     *   - an indented block (`(x) -> int: <indent> stmts <dedent>`)
+     *   - an `if_statement` so the Ry IfBlockExpr form (`=> if cond: …
+     *     else: …`) parses cleanly inside a lambda. The C++ parser models
+     *     this as `IfBlockExpr`; surface-syntactically it shares the
+     *     `if_statement` shape, so we reuse that rule rather than carry a
+     *     second copy of the block grammar (#1154). */
+    _lambda_body: $ => choice($._expression, $.block, $.if_statement),
 
-    /* if-expression: `if cond => then else else_expr` (single-line sugar) */
+    /* if-expression: `if cond => then else else_expr` (single-line sugar).
+     * The condition uses `_conditional_expression` rather than the broader
+     * `_expression` because `_expression` includes the bare-paren
+     * single-param lambda (`x => body`), and the parser would otherwise
+     * commit to `cond => body` as a lambda before noticing the surrounding
+     * `if … else …` shape. The C++ parser narrows the same way (`parseIf`
+     * calls `parseConditional` for the condition). The block form
+     * (`if cond:\n  expr\nelse:\n  expr`) is reached via `if_statement`
+     * appearing in `_lambda_body` — see the `_lambda_body` rule. */
     if_expression: $ => prec.right(PREC.conditional, seq(
       'if',
-      field('condition', $._expression),
+      field('condition', $._conditional_expression),
       '=>',
       field('consequence', $._expression),
       'else',
@@ -832,13 +896,20 @@ export default grammar({
       $._postfix_expression,
     ),
 
+    /* Binary expression operands use `_conditional_expression`, not the
+     * broader `_expression`. `_expression` reaches `lambda_expression` /
+     * `bare_lambda` / `if_expression` / `case_expression`, none of which
+     * make sense as a sub-expression of an arithmetic / comparison / etc.
+     * operator at the surface level — wrapping is required (`(x => x+1)
+     * ?? defaultFn`). Narrowing here also keeps the LR table for if /
+     * lambda disambiguation from leaking through binary expressions. */
     binary_expression: $ => choice(
       prec.right(PREC.coalesce,
-        seq(field('left', $._expression), field('operator', '??'),  field('right', $._expression))),
+        seq(field('left', $._conditional_expression), field('operator', '??'),  field('right', $._conditional_expression))),
       prec.left(PREC.or,
-        seq(field('left', $._expression), field('operator', 'or'),  field('right', $._expression))),
+        seq(field('left', $._conditional_expression), field('operator', 'or'),  field('right', $._conditional_expression))),
       prec.left(PREC.and,
-        seq(field('left', $._expression), field('operator', 'and'), field('right', $._expression))),
+        seq(field('left', $._conditional_expression), field('operator', 'and'), field('right', $._conditional_expression))),
       ...[
         ['==', PREC.comparison],
         ['!=', PREC.comparison],
@@ -860,16 +931,16 @@ export default grammar({
         ['//', PREC.multiplicative],
         ['%',  PREC.multiplicative],
       ].map(([op, p]) => prec.left(p,
-        seq(field('left', $._expression), field('operator', op), field('right', $._expression)),
+        seq(field('left', $._conditional_expression), field('operator', op), field('right', $._conditional_expression)),
       )),
       // 'in' / 'not in' membership test
       prec.left(PREC.comparison,
-        seq(field('left', $._expression),
+        seq(field('left', $._conditional_expression),
             field('operator', choice('in', seq('not', 'in'))),
-            field('right', $._expression))),
+            field('right', $._conditional_expression))),
       // power is right-associative
       prec.right(PREC.power,
-        seq(field('left', $._expression), field('operator', '**'), field('right', $._expression))),
+        seq(field('left', $._conditional_expression), field('operator', '**'), field('right', $._conditional_expression))),
     ),
 
     unary_expression: $ => prec.right(PREC.unary, seq(
@@ -910,7 +981,7 @@ export default grammar({
     field_access: $ => prec(PREC.postfix, seq(
       field('object', $._postfix_expression),
       '.',
-      field('field', $.identifier),
+      field('field', choice($.identifier, $.integer_literal)),
     )),
 
     unwrap_expression: $ => prec(PREC.postfix, seq(
@@ -939,6 +1010,7 @@ export default grammar({
     /* ------- Primary ------- */
     _primary_expression: $ => choice(
       $._literal,
+      $.generic_constructor,
       $.qualified_identifier,
       $._parenthesized,
       $.tuple_literal,
@@ -953,8 +1025,8 @@ export default grammar({
     tuple_literal: $ => choice(
       // 1-tuple `(e,)`
       seq('(', $._expression, ',', ')'),
-      // n-tuple `(e1, e2, ...)`  (n >= 2)
-      seq('(', $._expression, ',', sep1($._expression, ','), ')'),
+      // n-tuple `(e1, e2, ...)`  (n >= 2), optional trailing comma
+      seq('(', $._expression, ',', sep1($._expression, ','), optional(','), ')'),
     ),
 
     // Multi-line brace tolerance (#1727): see import_list note above.
@@ -1024,13 +1096,24 @@ export default grammar({
       optional(choice('i8','i16','i32','i64','u8','u16','u32','u64')),
     )),
 
-    /* ------- Float ------- */
+    /* ------- Float -------
+     * Four shapes (with optional `f32` / `f64` suffix):
+     *   N.M[eE±N]     digits, dot, digits, optional exponent
+     *   NeE±N         digits, exponent (no dot)
+     *   .M[eE±N]      leading-dot float (`.5`, `.5e2`) — context-aware
+     *                 lexing keeps it out of postfix `.` positions where
+     *                 only `'.' IDENT|INTEGER` is valid (tuple/field
+     *                 access). See lexer.cpp:483-498's prev_kind_ guard
+     *                 for the same disambiguation in the C++ parser.
+     *   N f32|f64     bare digits with float suffix (`42f32`) — forces
+     *                 float interpretation even without dot or exponent. */
     float_literal: $ => token(seq(
       choice(
-        seq(/[0-9][0-9_]*/, '.', /[0-9][0-9_]*/, optional(/[eE][+-]?[0-9][0-9_]*/)),
-        seq(/[0-9][0-9_]*/, /[eE][+-]?[0-9][0-9_]*/),
+        seq(/[0-9][0-9_]*/, '.', /[0-9][0-9_]*/, optional(/[eE][+-]?[0-9][0-9_]*/), optional(choice('f32', 'f64'))),
+        seq(/[0-9][0-9_]*/, /[eE][+-]?[0-9][0-9_]*/, optional(choice('f32', 'f64'))),
+        seq('.', /[0-9][0-9_]*/, optional(/[eE][+-]?[0-9][0-9_]*/), optional(choice('f32', 'f64'))),
+        seq(/[0-9][0-9_]*/, choice('f32', 'f64')),
       ),
-      optional(choice('f32', 'f64')),
     )),
 
     /* ------- String -------

--- a/editor/tree-sitter/queries/highlights.scm
+++ b/editor/tree-sitter/queries/highlights.scm
@@ -163,7 +163,8 @@
 
 ; ---------- Identifiers ----------
 ; Generic parameter names introduce types.
-(generic_parameters (identifier) @type)
+(type_parameter name: (identifier) @type)
+(type_parameter bound: (identifier) @type)
 
 ; Bindings and fallback identifiers as variables (after more-specific rules above).
 (binding_pattern (identifier) @variable)

--- a/editor/tree-sitter/test/corpus/expressions.txt
+++ b/editor/tree-sitter/test/corpus/expressions.txt
@@ -277,3 +277,96 @@ x = load[Map<str, List<Foo>>](text)
         (argument
           value: (qualified_identifier
             (identifier)))))))
+
+==================
+tuple member access via integer literal (#2394)
+==================
+
+x = t.0
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (field_access
+      object: (qualified_identifier
+        (identifier))
+      field: (integer_literal))))
+
+==================
+chained tuple member access (#2394)
+==================
+
+x = t.0.1
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (field_access
+      object: (field_access
+        object: (qualified_identifier
+          (identifier))
+        field: (integer_literal))
+      field: (integer_literal))))
+
+==================
+generic constructor call with explicit type args (#2394)
+==================
+
+x = MyOpt<int>::MySome(42)
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (generic_constructor
+        (identifier)
+        (type_arguments
+          (union_type
+            (primitive_type)))
+        (identifier))
+      arguments: (argument_list
+        (argument
+          value: (integer_literal))))))
+
+==================
+generic constructor without call (#2394)
+==================
+
+x = MyOpt<int>::MyNone
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (generic_constructor
+      (identifier)
+      (type_arguments
+        (union_type
+          (primitive_type)))
+      (identifier))))
+
+==================
+if expression with identifier condition (#2394)
+==================
+
+x = if cond => a else b
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (if_expression
+      condition: (qualified_identifier
+        (identifier))
+      consequence: (qualified_identifier
+        (identifier))
+      alternative: (qualified_identifier
+        (identifier)))))

--- a/editor/tree-sitter/test/corpus/functions.txt
+++ b/editor/tree-sitter/test/corpus/functions.txt
@@ -117,7 +117,8 @@ fn identity<T>(x: T) -> T:
     name: (function_name
       (identifier))
     generics: (generic_parameters
-      (identifier))
+      (type_parameter
+        name: (identifier)))
     parameters: (parameter_list
       (parameter
         name: (identifier)
@@ -176,3 +177,74 @@ fn factorial(n: int) -> int:
                   left: (qualified_identifier
                     (identifier))
                   right: (integer_literal))))))))))
+
+==================
+generic fn with type parameter bound (#2394)
+==================
+
+fn getName<T: Animal>(a: T) -> str:
+    return a.name
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    generics: (generic_parameters
+      (type_parameter
+        name: (identifier)
+        bound: (identifier)))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (named_type
+            (identifier)))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (return_statement
+        value: (field_access
+          object: (qualified_identifier
+            (identifier))
+          field: (identifier))))))
+
+==================
+generic fn with mixed bounded and unbounded type params (#2394)
+==================
+
+fn pair<T: Animal, U>(a: T, b: U) -> str:
+    return a.name
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    generics: (generic_parameters
+      (type_parameter
+        name: (identifier)
+        bound: (identifier))
+      (type_parameter
+        name: (identifier)))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (named_type
+            (identifier))))
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (named_type
+            (identifier)))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (return_statement
+        value: (field_access
+          object: (qualified_identifier
+            (identifier))
+          field: (identifier))))))

--- a/editor/tree-sitter/test/corpus/lambdas.txt
+++ b/editor/tree-sitter/test/corpus/lambdas.txt
@@ -133,3 +133,43 @@ c = filter(xs, (x) => x > 0)
               left: (qualified_identifier
                 (identifier))
               right: (integer_literal))))))))
+
+==================
+lambda with block-form if-expression body (#2394)
+==================
+
+f = (x: int) => if x > 0:
+  Some(x)
+else:
+  None()
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (lambda_expression
+      parameters: (lambda_params
+        (lambda_param
+          name: (identifier)
+          type: (union_type
+            (primitive_type))))
+      body: (if_statement
+        condition: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (integer_literal))
+        consequence: (block
+          (expression_statement
+            (call_expression
+              function: (qualified_identifier
+                (identifier))
+              arguments: (argument_list
+                (argument
+                  value: (qualified_identifier
+                    (identifier)))))))
+        alternative: (block
+          (expression_statement
+            (call_expression
+              function: (qualified_identifier
+                (identifier)))))))))

--- a/editor/tree-sitter/test/corpus/literals.txt
+++ b/editor/tree-sitter/test/corpus/literals.txt
@@ -305,3 +305,83 @@ fn foo():
         (call_expression
           function: (qualified_identifier
             (identifier)))))))
+
+==================
+leading-dot float literal (#2394)
+==================
+
+x = .5
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (float_literal)))
+
+==================
+integer literal with float suffix (#2394)
+==================
+
+x = 42f32
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (float_literal)))
+
+==================
+integer literal with integer suffix (#2394)
+==================
+
+x = 42i32
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (integer_literal)))
+
+==================
+underscore separator in decimal literal (#2394)
+==================
+
+x = 1_000_000
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (integer_literal)))
+
+==================
+hex literal with underscore and suffix (#2394)
+==================
+
+x = 0xFF_FFu16
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (integer_literal)))
+
+==================
+tuple literal with trailing comma in multi-element form (#2394)
+==================
+
+x = (1, 2,)
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (tuple_literal
+      (integer_literal)
+      (integer_literal))))

--- a/editor/tree-sitter/test/corpus/records.txt
+++ b/editor/tree-sitter/test/corpus/records.txt
@@ -105,3 +105,21 @@ record Pos:
         left: (qualified_identifier
           (identifier))
         right: (integer_literal)))))
+
+==================
+record declaration with parent type (record subtyping, #2394)
+==================
+
+record Dog < Animal:
+  breed: str
+
+---
+
+(source_file
+  (record_declaration
+    name: (identifier)
+    parent: (identifier)
+    (record_field
+      name: (identifier)
+      type: (union_type
+        (primitive_type)))))

--- a/editor/tree-sitter/test/corpus/statements.txt
+++ b/editor/tree-sitter/test/corpus/statements.txt
@@ -103,3 +103,26 @@ fn t():
           (identifier))
         matcher: (identifier)
         (integer_literal)))))
+
+==================
+decorated tuple destructure binding (#2394)
+==================
+
+fn foo():
+  @const (a, b) = (1, 2)
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (tuple_destructure_statement
+        (decorator
+          name: (identifier))
+        (identifier)
+        (identifier)
+        value: (tuple_literal
+          (integer_literal)
+          (integer_literal))))))


### PR DESCRIPTION
## Summary

#2394 が指定する 4 バケットのうち以下を grammar.js / scanner.c 周辺の修正で解消した:

- **Tuple member access** (`t.0`, `t.0.1` 等の数値メンバアクセス) — 14/14 files pass
- **Generic type syntax variants** (`<T: Bound>`, `Foo<int>::Variant` turbofish) — 2/2 files pass
- **Lambda body block expressions** (`=> if cond:` 等のブロック形 lambda 本体) — **3/4 files pass**
- **Numeric literal forms** (`.5`, `42f32`, `1_000_000` 等) — 3/3 files pass

baseline 49 SKIP のうち 29 ファイル (4 バケット該当 22 + 既存の他バケット 7) が新たに pass し、smoke pass=170→199 / corpus 119→135 (16 件追加)。

## Scope expansion (issue 本文の合意済み)

bucket 1/2/4 を完全クリアするのに加え、files に内在する隣接 gap も実装範囲に含めた:
- tuple n-tuple の trailing comma (`(1, 2,)`)
- record subtyping (`record A < B:`)
- `@const (a, b) = expr` の decorator-on-statement
- if-expression condition と lambda 単パラ形の disambiguation (`if a => b else c`)
- block-form if-expression body (`x: T = if cond: ... else: ...`)

これら無しでは bucket 内の対応ファイルが clean pass しないため、issue 既定の「Out of scope 宣言禁止」「partial 実装禁止」に合わせた最小拡張。

## Remaining gap

`tests/spec/nested_fn_return_fn.test.ry` — 二重ネスト block-body lambda の DEDENT 後に outer `_simple_statement` 用 NEWLINE が emit されない構造的問題。同形式の nested case-block でも再現することを確認 (discriminating test 済) — lambda 固有でなく一般「block-tailed non-final simple_statement in nested block」の問題。scanner.c に NEWLINE-before-DEDENT を入れる試行は pass 199→23 まで regress、grammar の `_statement` 緩和は LR conflict 多発。expected-fail.txt に「scanner 側の別問題として継続」とコメント付きで残置。

## Test plan

- [x] `editor/tree-sitter/check.sh` smoke: pass=199 / skip=20 / warn=0 / fail=0
- [x] `editor/tree-sitter/check.sh` corpus: 135/135 (success 100.00%)
- [x] `scripts/check-prompt-refs.sh`: clean
- [x] `scripts/check-examples.sh`: 102/102 passed
- [x] `ry.so` 再ビルド完了
- [ ] CI 緑確認

Closes #2394