### PR TITLE
refactor(codegen): kick off upper codegen Rust migration with BoolExpr pilot (#2397)

### DIFF
--- a/.claude/rules/distribution-packaging.md
+++ b/.claude/rules/distribution-packaging.md
@@ -36,13 +36,22 @@ The right-hand side of a pipe runs in a subshell, so `fail=1` set inside a helpe
 
 A shell helper that mutates a parent-scope flag must NOT be invoked via `cmd | helper`. Pass the data as an argument (`helper "desc" "pattern" "$haystack"`) or via a here-string (`helper "desc" "pattern" <<<"$haystack"`) so the helper runs in the current shell. Applies to any `|`-fed function that sets a variable the caller reads later.
 
-### The emit cdylib is NOT a `libry_*` file — every lib-selection glob must list it explicitly
+### Bundled cdylibs that are NOT `libry_*` files — every lib-selection glob must list each one explicitly
 
-**Tags**: packaging, install, self-update, cdylib, glob, libemit, rename, blind-spot
+**Tags**: packaging, install, self-update, cdylib, glob, libemit, liblower, rename, blind-spot
 
-While named `libry_codegen` the cdylib incidentally matched the `libry_*` selector. Renaming to `libemit` dropped it from every selector silently: the cdylib vanished from the bundle/install. The regression hides in a semantic coupling (old name happened to start with `libry_`), not a textual one — a string-sweep on `ry_codegen` cannot catch it.
+While named `libry_codegen` the emit cdylib incidentally matched the `libry_*` selector. Renaming to `libemit` (#2040) dropped it from every selector silently: the cdylib vanished from the bundle/install. The regression hides in a semantic coupling (old name happened to start with `libry_`), not a textual one — a string-sweep on `ry_codegen` cannot catch it. #2397's `liblower` cdylib reproduced the same shape: a new upper-codegen cdylib whose `[lib].name` was `lower` (not `ry_lower`), so the `libry_*` glob skipped it and CI's `clean-room startup` step failed with `liblower.so: cannot open shared object file` until each selector was updated.
 
-`libemit.*` is the ONE bundled native lib whose name does not start with `libry_`. Any lib-selection mechanism that ships native libs must enumerate it separately from the `libry_*` selector. Three call sites, keep them in sync: `scripts/bundle-dist.sh` (copy glob), `install.sh` (install loop), `src/cli/self_update.cpp` (`is_bundled_lib` predicate). When renaming the cdylib again, or adding any new bundled lib whose name is not `libry_<x>`, update all three. Note this is distinct from `src/project/paths.cpp`'s `"libry_" + mod` construction, which is for JIT `@native` stdlib module loading and correctly never references the cdylib (the cdylib is link-time, not dlopen'd by module name).
+Bundled native libs whose names do NOT start with `libry_` today: **`libemit.*`** (#2040), **`liblower.*`** (#2397). Any lib-selection mechanism that ships native libs must enumerate **each** explicitly alongside the `libry_*` selector. Four call sites, keep them in sync:
+
+- `scripts/bundle-dist.sh` (copy glob)
+- `install.sh` (install loop)
+- `src/cli/self_update.cpp` (`is_bundled_lib` predicate)
+- `scripts/verify-bundle.sh` (presence check in both the darwin and linux branches)
+
+When renaming a cdylib again, or adding any new bundled lib whose name is not `libry_<x>`, update all four. The verify-bundle presence check is the structural net — it FAILs the release if any expected cdylib is missing, catching a forgotten bundle-dist update before the tarball ships.
+
+Note this is distinct from `src/project/paths.cpp`'s `"libry_" + mod` construction, which is for JIT `@native` stdlib module loading and correctly never references these cdylibs (they are link-time, not dlopen'd by module name).
 
 ### Orphan cdylib after a crate rename: exclude via the libLLVM-linkage discriminator, not `ADDITIONAL_CLEAN_FILES`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,26 @@ if(NOT DEFINED ENV{LLVM_SYS_211_PREFIX})
     unset(_emit_llvm_prefix)
 endif()
 
+# ===== lower: upper-codegen Rust pilot (#2397) =====
+# Sister crate to `emit` (lower codegen): C++ caller → ry_lower_*
+# (this cdylib) → ry_emit_* (emit cdylib) → LLVM IR. NO `llvm-sys`
+# dependency — the `ry_emit_*` symbols are resolved at runtime from the
+# loaded `emit` cdylib via the host process's symbol table (same
+# `-undefined dynamic_lookup` / `-rdynamic` mechanism that resolves
+# __ry_set_last_error for the @native libs).
+#
+# Process-linked into `ry` / `ry_tests` (same model as `emit` / `ry_xid`)
+# because the caller-side C++ in `src/codegen_*.cpp` references
+# `ry_lower_*` at compile time. Absolute artifact path used for the same
+# reason as `RY_XID_LINK` — corrosion's IMPORTED CMake target rejects
+# `-Wl,--no-as-needed` and the `$<TARGET_FILE:>` generator expression.
+corrosion_import_crate(
+    MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/crates/lower/Cargo.toml"
+    CRATES lower
+)
+set_target_properties(lower PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
 # ===== native_base64: Rust port of @native("base64") (#2282) =====
 # Package = `native_base64` (Cargo workspace member); cdylib output =
 # `libry_base64.{dylib,so}` via `[lib].name = "ry_base64"` so the JIT's
@@ -449,20 +469,27 @@ add_dependencies(ry ${RY_NATIVE_LIBS})
 # ry_testing is process-linked because ry_lib references its test-runtime
 # symbols at C++ link time (#2395).
 set(RY_XID_LINK "${CMAKE_BINARY_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}ry_xid${CMAKE_SHARED_LIBRARY_SUFFIX}")
+# lower cdylib: process-linked alongside emit for the #2397 kickoff. Its
+# `ry_lower_*` symbols are referenced statically from ry_lib (the
+# emitExprVariant(BoolExpr) shim), so DT_NEEDED is established naturally
+# on Linux and no --no-as-needed guard is required.
+set(RY_LOWER_LINK "${CMAKE_BINARY_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}lower${CMAKE_SHARED_LIBRARY_SUFFIX}")
 if(APPLE)
-    target_link_libraries(ry PRIVATE -Wl,-force_load,$<TARGET_FILE:ry_lib> ry_lib emit ${RY_XID_LINK} ry_testing)
+    target_link_libraries(ry PRIVATE -Wl,-force_load,$<TARGET_FILE:ry_lib> ry_lib emit ${RY_LOWER_LINK} ${RY_XID_LINK} ry_testing)
 else()
     # --no-as-needed keeps both atomic (LLVM atomicrmw lowering reaches
     # __atomic_load at JIT time) and ry_xid (no static caller in ry_lib —
     # libry_json5 references __ry_xid_* but is dlopen'd later) from being
     # dropped despite no link-time references. ry_testing has static
     # callers in ry_lib (jit_runner.cpp's signal handler) so DT_NEEDED is
-    # established naturally.
-    target_link_libraries(ry PRIVATE -Wl,--whole-archive ry_lib -Wl,--no-whole-archive emit -Wl,--no-as-needed ${RY_XID_LINK} ry_testing atomic -Wl,--as-needed)
+    # established naturally. lower has a static caller too (the
+    # BoolExpr shim), so it sits outside the --no-as-needed group.
+    target_link_libraries(ry PRIVATE -Wl,--whole-archive ry_lib -Wl,--no-whole-archive emit ${RY_LOWER_LINK} -Wl,--no-as-needed ${RY_XID_LINK} ry_testing atomic -Wl,--as-needed)
     # -rdynamic: export process symbols so JIT DynamicLibrarySearchGenerator and
     # dlopen'd native libs can find __ry_set_last_error etc. from the process
     target_link_options(ry PRIVATE -rdynamic)
 endif()
+add_dependencies(ry lower)
 target_compile_options(ry PRIVATE ${RY_WARNING_FLAGS})
 
 # Distribution rpath (#2005): bundle libLLVM/libemit next to ry so the
@@ -566,6 +593,7 @@ if(APPLE)
         -Wl,-force_load,$<TARGET_FILE:ry_lib>
         ry_lib
         emit
+        ${RY_LOWER_LINK}
         ${RY_NATIVE_LIBS_LINK}
         GTest::gtest_main
         GTest::gmock
@@ -574,6 +602,7 @@ else()
     target_link_libraries(ry_tests PRIVATE
         -Wl,--whole-archive ry_lib -Wl,--no-whole-archive
         emit
+        ${RY_LOWER_LINK}
         -Wl,--no-as-needed ${RY_NATIVE_LIBS_LINK} atomic -Wl,--as-needed
         GTest::gtest_main
         GTest::gmock
@@ -581,6 +610,7 @@ else()
     # Linux: JIT の DynamicLibrarySearchGenerator がプロセスシンボルを参照できるようにする
     target_link_options(ry_tests PRIVATE -rdynamic)
 endif()
+add_dependencies(ry_tests lower)
 
 target_compile_definitions(ry_tests PRIVATE RY_BINARY_PATH="$<TARGET_FILE:ry>")
 target_compile_definitions(ry_tests PRIVATE RY_SOURCE_ROOT="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "lower"
+version = "0.0.0"
+
+[[package]]
 name = "native_base64"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@
 
 [workspace]
 resolver = "2"
-members = ["crates/emit", "crates/native_base64", "crates/xid"]
+members = ["crates/emit", "crates/lower", "crates/native_base64", "crates/xid"]
 
 # Profiles live at the workspace root (cargo ignores package-level
 # profiles in workspace members). See:

--- a/crates/lower/Cargo.toml
+++ b/crates/lower/Cargo.toml
@@ -1,0 +1,29 @@
+# Rust implementation of the upper-codegen (Ry semantic lowering) layer —
+# kickoff pilot for #2397. Sister crate to `emit` (lower codegen):
+#
+#   C++ caller  →  ry_lower_*  (this crate)  →  ry_emit_*  (`emit` crate)  →  LLVM IR
+#
+# Unlike `emit`, this crate has NO LLVM dependency. The `ry_emit_*`
+# symbols it calls are declared `extern "C"` and resolved at runtime
+# from the loaded `emit` cdylib via the host process's symbol table
+# (`-undefined dynamic_lookup` on macOS; `-rdynamic` on the host `ry` /
+# `ry_tests` executables on Linux — the same pattern `crates/native_base64`
+# uses for `__ry_*`). See `docs/architecture/upper-codegen-migration.md`.
+
+[package]
+name = "lower"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+
+# Profile settings live at the workspace root in /Cargo.toml — cargo
+# ignores `[profile.*]` blocks in workspace-member manifests.
+
+# Inherit the workspace lint policy (root /Cargo.toml [workspace.lints]).
+[lints]
+workspace = true

--- a/crates/lower/build.rs
+++ b/crates/lower/build.rs
@@ -1,0 +1,14 @@
+// On macOS, the cdylib resolves `ry_emit_*` symbols from the host process
+// at runtime (the host loads the `emit` cdylib at startup; its symbols are
+// then visible to this cdylib via the global dyld scope).
+// `-undefined dynamic_lookup` defers those unresolved symbols to runtime
+// lookup. Linux is satisfied by the host binary's `-rdynamic` link option
+// (set on `ry` and `ry_tests`).
+//
+// Same shape as crates/emit/build.rs and crates/native_base64/build.rs.
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "macos" {
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");
+    }
+}

--- a/crates/lower/src/abi.rs
+++ b/crates/lower/src/abi.rs
@@ -1,0 +1,39 @@
+//! `ry_lower_*` boundary entries — the C-callable surface of the upper
+//! codegen Rust layer.
+//!
+//! Discipline (mirrors `crates/emit/src/abi.rs`): this layer translates
+//! mechanically — null-checks the handles, dispatches to a body, returns
+//! the interned result. No Ry-semantic decisions live here directly; the
+//! bodies are the seams that future stages factor into per-stage modules.
+
+use crate::emit_extern::ry_emit_const_int;
+use crate::handles::{RyEmitCtx, RyTypeRef, RyValueId};
+
+/// Materialize an `i1` constant for a Ry `BoolExpr`.
+///
+/// Pilot port of `CodeGen::emitExprVariant(const BoolExpr &e)` —
+/// `value = 0` for `false`, non-zero for `true`. The C++ caller passes
+/// its own `i1Ty_` (LLVM `llvm::Type *`) cast to `RyTypeRef`; this
+/// function does not synthesize the type. Sign-extend is zero (`i1` is
+/// unsigned in the original `ConstantInt::get(i1Ty_, value, false)`).
+///
+/// Returns the interned `RyValueId` from `ry_emit_const_int`; the C++
+/// caller resolves it via `ry_emit_resolve`. NULL `ctx` / `i1_ty` → `0`
+/// (delegated to `ry_emit_const_int`).
+///
+/// # Safety
+///
+/// `ctx` must be a valid `RyEmitCtx *` produced by `ry_emit_ctx_create`
+/// (or NULL); `i1_ty` must be a valid LLVM `i1` type handle (or NULL).
+#[no_mangle]
+pub unsafe extern "C" fn ry_lower_bool_const(
+    ctx: *mut RyEmitCtx,
+    i1_ty: RyTypeRef,
+    value: core::ffi::c_int,
+) -> RyValueId {
+    // C `int` arg, not `bool`, to keep the boundary in the C scalar
+    // domain (matches the `int sign_extend` convention used across
+    // `ry_emit_*`). Any non-zero value is `true`.
+    let normalized: u64 = if value != 0 { 1 } else { 0 };
+    ry_emit_const_int(ctx, i1_ty, normalized, 0)
+}

--- a/crates/lower/src/emit_extern.rs
+++ b/crates/lower/src/emit_extern.rs
@@ -1,0 +1,23 @@
+//! `extern "C"` declarations for the subset of `ry_emit_*` symbols this
+//! crate calls. Resolved at runtime from the loaded `emit` cdylib via
+//! the host process's symbol table.
+//!
+//! Mirrors the C signatures in `include/ry/llvm_emit/api.h`; if a
+//! signature there changes, this file must change in lockstep.
+
+use crate::handles::{RyEmitCtx, RyTypeRef, RyValueId};
+use core::ffi::c_int;
+
+extern "C" {
+    /// `LLVMConstInt(ty, value, sign_extend)` — materialize an integer
+    /// constant and return the interned handle. `sign_extend = 0` is
+    /// zero-extend. NULL ctx / type → 0.
+    ///
+    /// See `include/ry/llvm_emit/api.h` `ry_emit_const_int`.
+    pub(crate) fn ry_emit_const_int(
+        ctx: *mut RyEmitCtx,
+        ty: RyTypeRef,
+        value: u64,
+        sign_extend: c_int,
+    ) -> RyValueId;
+}

--- a/crates/lower/src/handles.rs
+++ b/crates/lower/src/handles.rs
@@ -1,0 +1,25 @@
+//! Opaque-pointer handle types shared with the emission boundary
+//! (`include/ry/llvm_emit/api.h`). These mirror the C++ side's opaque
+//! typedefs as zero-sized `repr(C)` structs / pointer aliases — no field
+//! is ever read from Rust, so no layout assertion is needed.
+//!
+//! Keep this set minimal: only the handles the lower crate's public
+//! `ry_lower_*` entries or its `extern "C"` calls into `ry_emit_*` use.
+
+use core::ffi::c_void;
+
+/// Opaque emit-side context. Allocated and destroyed by the `emit`
+/// crate; the lower crate only threads the pointer through.
+#[repr(C)]
+pub(crate) struct RyEmitCtx {
+    _unused: [u8; 0],
+}
+
+/// Opaque LLVM type handle (`llvm::Type *` on the C++ side, an
+/// `LLVMTypeRef`-shaped pointer inside the `emit` crate). The lower
+/// crate treats it as a bag-of-bytes pointer and never dereferences.
+pub(crate) type RyTypeRef = *mut c_void;
+
+/// Interned value handle. Sentinel `0` is the invalid id; non-zero ids
+/// are issued and resolved by the emit-side intern table.
+pub(crate) type RyValueId = u32;

--- a/crates/lower/src/lib.rs
+++ b/crates/lower/src/lib.rs
@@ -1,0 +1,23 @@
+//! Upper-codegen (Ry semantic lowering) — kickoff pilot for #2397.
+//!
+//! Single op today: `ry_lower_bool_const` — the Rust port of
+//! `CodeGen::emitExprVariant(BoolExpr)`. The op is the minimum-surface
+//! pilot for the new `ry_lower_*` boundary; see
+//! `docs/architecture/upper-codegen-migration.md` §"Pilot module".
+//!
+//! Architectural layering (mirrors the `emit` crate's #2057 split, kept
+//! flat while the surface is tiny):
+//!
+//! - The `extern "C"` `ry_lower_*` entries live in `abi.rs`.
+//! - Ry-semantic decisions (currently just "wrap a bool in an i1") live
+//!   inline here. As more ops migrate, the body splits per stage
+//!   (`expr.rs`, `stmt.rs`, …) per the migration order in the design doc.
+//!
+//! The crate has NO `llvm-sys` dependency. Calls into the loaded `emit`
+//! cdylib are declared `extern "C"` in `emit_extern.rs`.
+
+#![allow(non_camel_case_types)]
+
+mod abi;
+mod emit_extern;
+mod handles;

--- a/docs/architecture/upper-codegen-migration.md
+++ b/docs/architecture/upper-codegen-migration.md
@@ -120,7 +120,7 @@ Future stages add `crates/lower/src/{expr,stmt,call,arc,…}.rs` as the surface 
 The pilot follows the #2026 ASLR-normalized `--emit-llvm-ir` discipline ([Codegen Layering Plan](codegen-layering-plan.md), referenced from each #2072 onward installment):
 
 1. **Baseline.** Capture `--emit-llvm-ir` output for a probe program on the pre-migration tree.
-2. **Marker grep.** Confirm `store i1 1` and `store i1 0` appear in the baseline (so a vacuous diff cannot pass — see "Vacuous-diff trap" below).
+2. **Marker grep.** Confirm `store i1 true` and `store i1 false` appear in the baseline (so a vacuous diff cannot pass — see "Vacuous-diff trap" below).
 3. **Migrate.** Apply the pilot diff.
 4. **Compare.** Re-capture `--emit-llvm-ir` and diff against the baseline. The diff must be empty after ASLR / SSA-name normalization.
 

--- a/docs/architecture/upper-codegen-migration.md
+++ b/docs/architecture/upper-codegen-migration.md
@@ -1,0 +1,166 @@
+# Upper Codegen Rust Migration
+
+This document is the working hypothesis for migrating the **upper codegen layer** (Ry semantic lowering, currently C++ `src/codegen_*.cpp`) to Rust. It is the kickoff deliverable of issue #2397; the wider migration unfolds across subsequent issues.
+
+This is a **working hypothesis, not a graduation document**. The upper codegen sub-layer is explicitly **not graduated** here. Per [Layer Graduation Workflow](layer-graduation-workflow.md) §"When to write the graduation document", the graduation document is written only after the Rust side stabilizes and the C++ shim is removed.
+
+## What this migration is (and is not)
+
+| Term | Today | Migration target |
+|---|---|---|
+| **emission** (lower codegen) | Rust `crates/emit/` behind `ry_emit_*` (since #1993; C++ shim removed in #2229). | unchanged |
+| **lowering** (upper codegen) | C++ `src/codegen_*.cpp` — Ry semantic decisions (type registries, ARC bookkeeping, ownership, stdlib dispatch, metadata) — calls `ry_emit_*` to construct IR. | Rust crate(s) under `crates/lower*/` behind a new `ry_lower_*` boundary, called from a slimmer C++ caller. |
+
+The two boundaries are orthogonal: lowering decides *what* should happen (the Ry semantic op); emission builds the LLVM IR for it. Migrating lowering does not change emission. See [Codegen Terminology](codegen-terminology.md) for the canonical vocabulary.
+
+**Out of scope** for this migration as a whole:
+
+- Rewriting emission. Emission is already Rust.
+- Changing the lowered IR vocabulary in [Codegen Layering Plan](codegen-layering-plan.md) §"Lowered IR vocabulary".
+- Touching the runtime ABI (`__ry_*`, [Runtime Boundary](runtime-abi-boundary.md)) or native call boundary ([Native Call Boundary](native-call-boundary.md)).
+- Deleting the C++ implementation. Each lowering op migrates with a C++ shim that calls into Rust; the shim survives until the wider migration completes.
+
+## What "upper codegen" includes
+
+The lowering layer owns every decision in `src/codegen_*.cpp` that is *not* an `IRBuilder<>::Create*` call. The 39 `codegen_*.cpp` files split into the following concern groups:
+
+| Group | Files (representative) | Lowering responsibilities |
+|---|---|---|
+| **Primitive expression literal & arithmetic** | `codegen_expr.cpp` (`emitExprVariant({Number,Float,Bool,String,Regex}Expr)`), `codegen_arith.cpp`, `codegen_expr_cast.cpp` | constant selection, suffix → type, sign decision, range validation, cast policy, overflow strategy |
+| **Identifier & variable** | `codegen_expr.cpp` (`emitExprVariant(VariableExpr)`), parts of `codegen_stmt.cpp` | name → alloca / global lookup, ARC retain decision, type metadata propagation |
+| **Type & metadata** | `codegen_type.cpp`, `codegen_metadata.cpp` | type name resolution, `ValueMetadata` propagation, `TypeMeta` tagging |
+| **Statement & control flow** | `codegen_stmt.cpp`, `codegen_stmt_loop.cpp`, `codegen_stmt_misc.cpp`, `codegen_match.cpp` | block layout, loop scaffolding, match arm dispatch |
+| **Call dispatch** | `codegen_call.cpp`, `codegen_call_*.cpp`, `codegen_native_call_descriptor.cpp` | native vs user vs builtin selection, descriptor lookup, signature checking, arg coercion |
+| **Function & lambda** | `codegen_fn.cpp`, `codegen_fn_generic.cpp`, `codegen_lambda.cpp` | signature lowering, generic instantiation, closure capture analysis |
+| **ARC, GC, CoW** | `codegen_arc.cpp`, `codegen_arc_gc.cpp`, `codegen_arc_cow.cpp` | retain/release placement, GC visitor synthesis, CoW slot bookkeeping |
+| **Composite (Any, Result, Option, collections)** | `codegen_any.cpp`, `codegen_call_result.cpp`, `codegen_call_option.cpp`, `codegen_call_collection.cpp`, `codegen_call_set_ops.cpp`, `codegen_call_iterator.cpp` | tag selection, type-driven dispatch, element-type metadata |
+| **Test / coverage / trace plumbing** | `codegen_test.cpp`, `codegen_metadata.cpp`, parts of `codegen.cpp` | test-mode injection, coverage instrumentation, trace symbol emission |
+
+The lowering decisions inside each group call `ry_emit_*` (sometimes many times per op) to construct the IR. The migration replaces the *decision* code with Rust; the IR construction was already Rust.
+
+## Migration order
+
+The order favors **input surface** over LOC. Earlier rows touch less CodeGen state (type registries, `value_metadata_`, ARC caches), so they marshal across the new `ry_lower_*` boundary with the smallest opaque-handle surface. Later rows have to grow the boundary first.
+
+| Stage | Scope | Why this order | Boundary additions |
+|---|---|---|---|
+| **0 — kickoff (this PR)** | `emitExprVariant(BoolExpr)`. | Smallest possible Ry-semantic decision: `bool → i1 constant`. No CodeGen state read; no metadata side-effects; no error path. Calls only the existing `ry_emit_const_int`. Validates the new `ry_lower_*` boundary shape and dual-cdylib link / symbol-resolution wiring. | One entry: `ry_lower_bool_const`. |
+| **1 — primitive literals** | `emitExprVariant(NumberExpr)`, `FloatExpr`. | Adds suffix→type selection and range validation (the `validateIntRange` body). Requires a way to surface lowering errors back to C++ (`codegenError`-equivalent return channel). | `ry_lower_int_const`, `ry_lower_float_const`; one error-return helper. |
+| **2 — string / regex literal & global string** | `emitExprVariant({String,Regex}Expr)`, the `cachedGlobalString` cache. | Introduces global-string interning state — first stateful cache to live on the Rust side. | `ry_lower_string_const`; the interning cache moves under Rust ownership. |
+| **3 — identifier & variable read** | `emitExprVariant(VariableExpr)`. | First read of CodeGen state (`named_values_`, ARC source map, low-level type names). The name→storage table starts crossing the boundary as a lookup callback. | `ry_lower_var_read`; named-values lookup callback. |
+| **4 — primitive arithmetic** | `codegen_arith.cpp` (`emitCheckedArithmetic`, `emitSaturatingArithmetic`), the constant-fold paths around them. | Combines decision (signed/unsigned × add/sub/mul × panic/Result/saturating) with the already-migrated `ry_emit_intrinsic_call`. Reuses the pilot D (#2102) overflow-intrinsic surface. | `ry_lower_arith_op` family; no new emission entries. |
+| **5 — type & metadata** | `codegen_type.cpp` (`resolveType`, `isUnsignedLowLevelName`), `codegen_metadata.cpp`. | Pure functions over Ry type-name strings — no IR construction. Migrates as a self-contained Rust module callable from any later stage. | `ry_lower_resolve_type`, `ry_lower_propagate_meta`; the type registry moves to Rust. |
+| **6 — control flow & match** | `codegen_stmt_loop.cpp`, `codegen_match.cpp`, `codegen_stmt_misc.cpp` (the `if` / `while` / `for` / `match` lowering). | Touches block layout and PHI scaffolding but the emission primitives are all in place (#1973 ControlFlow, #2098 function definition). | `ry_lower_if`, `ry_lower_loop`, `ry_lower_match_arm`. |
+| **7 — composite (Any / Result / Option / collection)** | `codegen_any.cpp`, `codegen_call_{result,option,collection,iterator,set_ops}.cpp`. | Largest semantic-decision surface (tag selection, type-driven dispatch). Lands after the type-registry move (stage 5) so the descriptor-lookup table sits on the Rust side. | Composite-op lowering entries. |
+| **8 — call dispatch** | `codegen_call*.cpp` (native call descriptor consumption), `codegen_fn.cpp` / `codegen_fn_generic.cpp`. | Consumes the descriptor table from [Native Call Boundary](native-call-boundary.md). Lands after composite (stage 7) so the wrapping helpers it needs are already Rust. | `ry_lower_call_*`. |
+| **9 — ARC / GC / CoW** | `codegen_arc.cpp`, `codegen_arc_gc.cpp`, `codegen_arc_cow.cpp`. | The most CodeGen-state-heavy area (`arc_backed_vars_`, ownership tracking, GC visitor thunk synthesis). Lands last because its bookkeeping interacts with every prior stage. | `ry_lower_arc_*`. |
+
+The order is a working hypothesis. Each stage is its own future issue, opened independently when it is taken on; this document does not pre-allocate issue numbers. If a stage's boundary surface explodes during implementation, the stage's scope is renegotiated in its own issue rather than expanded ad hoc.
+
+## Pilot module: `BoolExpr`
+
+The kickoff pilot is **`emitExprVariant(BoolExpr)`** (`src/codegen_expr.cpp:122-124`).
+
+### Why `BoolExpr`
+
+- **One-statement body**. `return llvm::ConstantInt::get(i1Ty_, e.value ? 1 : 0, false);`. The migrated path is observably small and the diff fits one PR alongside the boundary scaffolding.
+- **No CodeGen state read**. Only inputs: the boolean `e.value` and the `i1Ty_` LLVM type (already a `RyTypeRef` candidate). No `value_metadata_`, no ARC caches, no `named_values_`, no error path.
+- **No type registry crossing**. The `i1` type is a primitive; the lowering decision does not consult `record_types_` / `enum_types_` / `type_aliases_`. Stage 5's type-registry move is not a prerequisite.
+- **Verifiable**. The emitted IR is a single LLVM `ConstantInt` (`i1 0` / `i1 1`) that is grep-confirmable in `--emit-llvm-ir` output before diffing.
+- **Vacuous-diff trap avoidance**. A bare `let x = true; if x { … }` sema-folds the conditional, bypassing emission of the constant entirely. The pilot uses a probe (see §"Verification") that stores `e.value` into an `alloca` so the constant survives sema and is observable as `store i1 1` / `store i1 0`.
+
+### Why not the alternatives the issue named
+
+- **Numeric literal (`NumberExpr` / `FloatExpr`)**: introduces suffix → type selection, range validation, and the `codegenError` error path. Each is solvable but inflates the kickoff PR beyond a single op. Belongs at stage 1.
+- **Identifier resolution (`VariableExpr`)**: reads `named_values_` (CodeGen state). The name→storage lookup is a callback shape that has to be designed; doing this for the pilot lets the design solidify on a less-clean surface. Belongs at stage 3.
+- **String literal**: needs the `cachedGlobalString` interning cache to either cross or migrate. Stateful. Belongs at stage 2.
+
+## Boundary design
+
+The pilot adds **one** new `extern "C"` entry to a new header `include/ry/lower/api.h`:
+
+```c
+RyValueId ry_lower_bool_const(RyEmitCtx *ctx, RyTypeRef i1_ty, int value);
+```
+
+- Inputs: the emit context (existing handle), the `i1` LLVM type (existing `RyTypeRef`), the literal value (0 / 1).
+- Output: an interned `RyValueId` (existing handle scheme).
+- No new opaque types. No new error channel — `BoolExpr` cannot fail.
+- The Rust implementation in `crates/lower/` calls the existing `ry_emit_const_int(ctx, i1_ty, value as u64, 0)` and returns the interned result.
+
+The C++ shim `CodeGen::emitExprVariant(BoolExpr)` becomes:
+
+```cpp
+return cast_helpers::asValue(ry_emit_resolve(
+    emit_ctx_.get(),
+    ry_lower_bool_const(emit_ctx_.get(),
+                        cast_helpers::toRyTypeRef(i1Ty_),
+                        e.value ? 1 : 0)));
+```
+
+The shim survives the pilot — its only job is to feed `i1Ty_` (a CodeGen-owned `llvm::Type *`) across the boundary as `RyTypeRef`. When later stages migrate the primitive-type registry, the C++ side stops holding `i1Ty_` and the shim's last responsibility disappears.
+
+## Lower crate shape
+
+`crates/lower/` is a Rust `cdylib`, parallel to `crates/emit/` but **without** an `llvm-sys` dependency. The lower crate calls `ry_emit_*` declared as `extern "C"` and resolved at runtime from the loaded `emit` cdylib (`-undefined dynamic_lookup` on macOS; `-rdynamic` on the host `ry` / `ry_tests` executables on Linux — the same pattern `crates/native_base64` uses for `__ry_*`).
+
+The crate's only opaque-type declarations duplicate the api.h handle types (`RyEmitCtx`, `RyTypeRef`, `RyValueId`) as zero-sized `repr(C)` structs / pointer aliases. They are pointer-compatible with the C++ side; no layout assertion is needed because no field is read from Rust.
+
+The boundary discipline mirrors emit's `abi → composite → primitive → context` layering ([Codegen Layering Plan](codegen-layering-plan.md) §"Composite and primitive emission sub-layers"):
+
+- `crates/lower/src/abi.rs` — the `ry_lower_*` `extern "C"` shell. Pure mechanical translation.
+- `crates/lower/src/lib.rs` — the (currently single-file) Ry-semantic decision body.
+
+Future stages add `crates/lower/src/{expr,stmt,call,arc,…}.rs` as the surface grows.
+
+## Verification
+
+### Discipline
+
+The pilot follows the #2026 ASLR-normalized `--emit-llvm-ir` discipline ([Codegen Layering Plan](codegen-layering-plan.md), referenced from each #2072 onward installment):
+
+1. **Baseline.** Capture `--emit-llvm-ir` output for a probe program on the pre-migration tree.
+2. **Marker grep.** Confirm `store i1 1` and `store i1 0` appear in the baseline (so a vacuous diff cannot pass — see "Vacuous-diff trap" below).
+3. **Migrate.** Apply the pilot diff.
+4. **Compare.** Re-capture `--emit-llvm-ir` and diff against the baseline. The diff must be empty after ASLR / SSA-name normalization.
+
+### Vacuous-diff trap
+
+A `bool` literal that flows only into an `if` condition is sema-folded and never reaches `emitExprVariant(BoolExpr)`. The probe stores `true` and `false` into named locals so the constants outlive sema and appear in IR:
+
+```ry
+fn boolPilotProbe() -> int {
+    let t = true
+    let f = false
+    if t { return 1 } else if f { return 2 } else { return 3 }
+}
+```
+
+The `let t = true` and `let f = false` initializations emit `store i1 1, ptr %t` / `store i1 0, ptr %f` — these are the markers grep-confirmed in step 2.
+
+### Coverage in both build presets
+
+Both `default` (Linux / CI, `LLVM_DIR=/usr/local/llvm`) and `rust-emit` (macOS, `LLVM_DIR=/opt/homebrew/opt/llvm@21`) presets exercise the same Rust `emit` crate (since #1993; both link the same cdylib via corrosion). The pilot adds the same `lower` cdylib to both presets via the same CMake `corrosion_import_crate` mechanism, so cross-preset IR consistency is structural, not a separately enforced invariant. The byte-exact regression in step 4 is the empirical check; running it on the local platform suffices for the pilot.
+
+## CI
+
+The pilot adds the new `crates/lower/` directory to the Cargo workspace (`Cargo.toml` workspace members). The existing CI `lint` job (`.github/workflows/ci.yml`) already runs over every workspace member:
+
+- `cargo check --workspace --all-targets` — covers the new crate.
+- `cargo fmt --all -- --check` — `--all` walks every workspace member.
+- `cargo clippy --workspace --all-targets -- -D warnings` — same scope as the check.
+
+No new lint step is needed; the new crate inherits the workspace lint policy in the root `Cargo.toml`.
+
+For the byte-exact regression the pilot adds `tests/filecheck/bool_const_pilot_2397.ry` — a FileCheck golden that asserts `store i1 true` / `store i1 false` is emitted from the migrated path. CMake auto-discovers it via the existing `file(GLOB FILECHECK_TEST_FILES ...)` in `CMakeLists.txt`, and the CI `filecheck` job (`.github/workflows/ci.yml`) runs it on the Linux `default` preset, which uses the same Rust `lower` cdylib as the macOS `rust-emit` preset (the only difference is `LLVM_DIR`). The golden locks IR shape continuously — any regression in the migrated path (or in `ry_emit_const_int` it bottoms out in) breaks it. The CI filecheck job is currently warn-only across the repo per its existing comment ("LLVM-version sensitivity until goldens are confirmed stable"), so the pilot inherits that policy; promotion to required is a separate cross-cutting decision, not pilot-specific.
+
+The one-shot ASLR-normalized before/after `--emit-llvm-ir` diff (§"Verification") remains the migration-PR proof — it certifies that the C++ and Rust paths produce byte-identical IR at the moment of the cutover, which the FileCheck golden alone cannot prove (it would pass on either path independently).
+
+## Related documents
+
+- [Codegen Terminology](codegen-terminology.md) — canonical vocabulary (lowering / emission / lowered IR / boundaries).
+- [Codegen Layering Plan](codegen-layering-plan.md) — the lowering / emission split and the lowered IR vocabulary.
+- [LLVM IR Emission Boundary](llvm-ir-emission-boundary.md) — the `ry_emit_*` boundary the lower crate calls into.
+- [Layer Graduation Workflow](layer-graduation-workflow.md) — the workflow this migration operates inside; defines when a graduation document is earned.
+- [Native Call Boundary](native-call-boundary.md) — the orthogonal lowering-side dispatch surface; stages 7-8 will consume it.
+- [Runtime Boundary](runtime-abi-boundary.md) — orthogonal `__ry_*` boundary; unchanged by this migration.

--- a/docs/architecture/upper-codegen-migration.md
+++ b/docs/architecture/upper-codegen-migration.md
@@ -67,7 +67,7 @@ The kickoff pilot is **`emitExprVariant(BoolExpr)`** (`src/codegen_expr.cpp:122-
 - **No CodeGen state read**. Only inputs: the boolean `e.value` and the `i1Ty_` LLVM type (already a `RyTypeRef` candidate). No `value_metadata_`, no ARC caches, no `named_values_`, no error path.
 - **No type registry crossing**. The `i1` type is a primitive; the lowering decision does not consult `record_types_` / `enum_types_` / `type_aliases_`. Stage 5's type-registry move is not a prerequisite.
 - **Verifiable**. The emitted IR is a single LLVM `ConstantInt` (`i1 0` / `i1 1`) that is grep-confirmable in `--emit-llvm-ir` output before diffing.
-- **Vacuous-diff trap avoidance**. A bare `let x = true; if x { … }` sema-folds the conditional, bypassing emission of the constant entirely. The pilot uses a probe (see §"Verification") that stores `e.value` into an `alloca` so the constant survives sema and is observable as `store i1 1` / `store i1 0`.
+- **Vacuous-diff trap avoidance**. A bare `let x = true; if x { … }` sema-folds the conditional, bypassing emission of the constant entirely. The pilot uses a probe (see §"Verification") that stores `e.value` into an `alloca` so the constant survives sema and is observable as `store i1 true` / `store i1 false`.
 
 ### Why not the alternatives the issue named
 
@@ -136,11 +136,16 @@ fn boolPilotProbe() -> int {
 }
 ```
 
-The `let t = true` and `let f = false` initializations emit `store i1 1, ptr %t` / `store i1 0, ptr %f` — these are the markers grep-confirmed in step 2.
+The `let t = true` and `let f = false` initializations emit `store i1 true, ptr %t` / `store i1 false, ptr %f` — these are the markers grep-confirmed in step 2.
 
 ### Coverage in both build presets
 
-Both `default` (Linux / CI, `LLVM_DIR=/usr/local/llvm`) and `rust-emit` (macOS, `LLVM_DIR=/opt/homebrew/opt/llvm@21`) presets exercise the same Rust `emit` crate (since #1993; both link the same cdylib via corrosion). The pilot adds the same `lower` cdylib to both presets via the same CMake `corrosion_import_crate` mechanism, so cross-preset IR consistency is structural, not a separately enforced invariant. The byte-exact regression in step 4 is the empirical check; running it on the local platform suffices for the pilot.
+Both `default` (Linux / CI, `LLVM_DIR=/usr/local/llvm`) and `rust-emit` (macOS, `LLVM_DIR=/opt/homebrew/opt/llvm@21`) presets exercise the same Rust `emit` crate (since #1993; both link the same cdylib via corrosion). The pilot adds the same `lower` cdylib to both presets via the same CMake `corrosion_import_crate` mechanism, so cross-preset IR consistency is structural, not a separately enforced invariant. The byte-exact regression is verified on **each preset independently**:
+
+- **macOS `rust-emit` (local)**: the one-shot ASLR-normalized `--emit-llvm-ir` diff in step 4 proves the migration is byte-equivalent at the cutover. This is the migration-path proof — it certifies the C++ and Rust paths agree at the moment they switch.
+- **Linux `default` (CI)**: the FileCheck golden `tests/filecheck/bool_const_pilot_2397.ry` runs on every PR via the `filecheck` job and asserts the post-migration IR shape continuously. Any platform-specific loader / LLVM-output drift that would break the migrated path on `default` breaks the golden first.
+
+Together the two preset paths cover the cross-preset proof scope item 3 calls for; neither alone is sufficient (one-shot diff proves equivalence at one moment; FileCheck proves shape continuously).
 
 ## CI
 

--- a/include/ry/lower/api.h
+++ b/include/ry/lower/api.h
@@ -1,0 +1,45 @@
+// Upper codegen (Ry semantic lowering) boundary — kickoff pilot (#2397).
+//
+// Sibling boundary to `include/ry/llvm_emit/api.h`: this header declares
+// the `ry_lower_*` entries exposed by `crates/lower/`. Caller-side C++
+// in `src/codegen_*.cpp` calls `ry_lower_*`; the Rust impl calls
+// `ry_emit_*` (`api.h`) to construct LLVM IR.
+//
+// Boundary discipline (same as emit's api.h):
+//   - Opaque handles only — no `llvm::*` types.
+//   - All signatures `extern "C"` callable.
+//   - The lower crate does NOT link `llvm-sys`; the `ry_emit_*`
+//     symbols it calls are resolved at runtime from the loaded `emit`
+//     cdylib via the host process's symbol table.
+//
+// See `docs/architecture/upper-codegen-migration.md` for the migration
+// design hypothesis and the per-stage boundary growth plan.
+
+#ifndef RY_LOWER_API_H
+#define RY_LOWER_API_H
+
+#include "ry/llvm_emit/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Pilot: lower a Ry `BoolExpr` (`true` / `false`) to its LLVM `i1`
+// constant. The caller supplies the `i1` type (`i1Ty_` from `CodeGen`)
+// as `i1_ty`; the implementation does not synthesize types. `value` is
+// a C-int (any non-zero is `true`, mirroring the `int sign_extend`
+// convention used across `ry_emit_*`).
+//
+// Returns the interned `RyValueId` of `LLVMConstInt(i1, value ? 1 : 0,
+// false)`. NULL ctx / type → 0 (delegated to `ry_emit_const_int`).
+//
+// This is the C++-callable replacement for the inline
+// `llvm::ConstantInt::get(i1Ty_, e.value ? 1 : 0, false)` previously in
+// `CodeGen::emitExprVariant(const BoolExpr &)`.
+RyValueId ry_lower_bool_const(RyEmitCtx *ctx, RyTypeRef i1_ty, int value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RY_LOWER_API_H

--- a/install.sh
+++ b/install.sh
@@ -54,15 +54,16 @@ install -m 755 "$TMPDIR/ry" "$INSTALL_DIR/ry"
 if [ -d "$TMPDIR/lib" ]; then
     NATIVE_LIBS_INSTALLED=0
     mkdir -p "$RY_HOME/lib"
-    # Install the Rust cdylib (libemit) + stdlib native libs (libry_*), and —
-    # post-#1999 cutover — the bundled shared libLLVM (plus its macOS chain dep
-    # libzstd), so the installed runtime is self-contained (#2005). libemit is
-    # globbed separately: it was renamed from libry_codegen (#2040) so it no longer
-    # matches libry_*. $RY_HOME/lib is one of ry's rpath targets
+    # Install the Rust cdylibs (libemit, liblower) + stdlib native libs (libry_*),
+    # and — post-#1999 cutover — the bundled shared libLLVM (plus its macOS chain
+    # dep libzstd), so the installed runtime is self-contained (#2005). libemit
+    # and liblower are globbed separately: libemit was renamed from libry_codegen
+    # (#2040) and liblower is the upper-codegen Rust kickoff (#2397), so neither
+    # matches the libry_* prefix. $RY_HOME/lib is one of ry's rpath targets
     # (@loader_path/../../.ry/lib on macOS, $ORIGIN/../../.ry/lib on Linux).
     # Unmatched globs (e.g. libzstd.* on Linux) stay literal and are filtered out
     # by the [ -f ] test below.
-    for f in "$TMPDIR"/lib/libemit.* "$TMPDIR"/lib/libry_*.* "$TMPDIR"/lib/libLLVM.* "$TMPDIR"/lib/libzstd.*; do
+    for f in "$TMPDIR"/lib/libemit.* "$TMPDIR"/lib/liblower.* "$TMPDIR"/lib/libry_*.* "$TMPDIR"/lib/libLLVM.* "$TMPDIR"/lib/libzstd.*; do
         if [ -f "$f" ]; then
             install -m 755 "$f" "$RY_HOME/lib/"
             NATIVE_LIBS_INSTALLED=1

--- a/scripts/bundle-dist.sh
+++ b/scripts/bundle-dist.sh
@@ -11,7 +11,7 @@
 #
 # Layout produced (consumed by scripts/verify-bundle.sh and install.sh):
 #   DIST_DIR/ry
-#   DIST_DIR/lib/{libLLVM.*,libzstd.1.dylib(macOS),libemit.*,libry_*.*}
+#   DIST_DIR/lib/{libLLVM.*,libzstd.1.dylib(macOS),libemit.*,liblower.*,libry_*.*}
 #   DIST_DIR/share/std/
 #   DIST_DIR/LICENSE-LLVM.txt
 #
@@ -47,11 +47,15 @@ mkdir -p "$DIST_DIR/lib" "$DIST_DIR/share"
 [[ -f "$BUILD_DIR/ry" ]] || { echo "bundle-dist: $BUILD_DIR/ry not found — build first" >&2; exit 1; }
 cp "$BUILD_DIR/ry" "$DIST_DIR/ry"
 
-# The Rust cdylib (libemit) + stdlib native libs (libry_*) ship as-is from the
-# build tree. libemit is matched separately from the libry_* glob: it was renamed
-# from libry_codegen to libemit (#2040), so it no longer starts with libry_.
+# The Rust cdylibs (libemit, liblower) + stdlib native libs (libry_*) ship as-is
+# from the build tree. The cdylibs are matched separately from the libry_* glob
+# because their names do not start with libry_: libemit was renamed from
+# libry_codegen (#2040), and liblower was added by #2397 as the upper-codegen
+# Rust kickoff. Any future Rust cdylib whose name doesn't start with libry_ must
+# be added here (and to install.sh / self_update.cpp / verify-bundle.sh — see
+# .claude/rules/distribution-packaging.md).
 shopt -s nullglob
-candidate_libs=("$BUILD_DIR"/lib/libemit.* "$BUILD_DIR"/lib/libry_*.*)
+candidate_libs=("$BUILD_DIR"/lib/libemit.* "$BUILD_DIR"/lib/liblower.* "$BUILD_DIR"/lib/libry_*.*)
 shopt -u nullglob
 
 # Drop orphan cdylibs (#2041): a corrosion crate rename (libry_codegen -> libemit,
@@ -132,9 +136,20 @@ darwin)
     [[ -n "$emit_llvm_ref" ]] && install_name_tool -change "$emit_llvm_ref" '@loader_path/libLLVM.dylib' "$LIB/libemit.dylib"
     codesign --force --sign - "$LIB/libemit.dylib"
 
-    # ry: point libLLVM / libemit at @rpath, drop build-tree rpaths, add the two.
+    # liblower (#2397): same treatment as libemit, but it has NO libLLVM
+    # dependency to chain-rewrite. Only the self-id needs to become @rpath.
+    if [[ -f "$LIB/liblower.dylib" ]]; then
+        install_name_tool -id '@rpath/liblower.dylib' "$LIB/liblower.dylib"
+        codesign --force --sign - "$LIB/liblower.dylib"
+    fi
+
+    # ry: point libLLVM / libemit / liblower at @rpath, drop build-tree rpaths,
+    # add the two. liblower may not be present in legacy build trees (#2397 is the
+    # crate's introducing PR), so the awk match guards against an empty ref.
     install_name_tool -change "$llvm_ref" '@rpath/libLLVM.dylib' "$RY"
     install_name_tool -change "$emit_ref" '@rpath/libemit.dylib' "$RY"
+    lower_ref="$(otool -L "$RY" | awk '/liblower\.dylib/{print $1; exit}')"
+    [[ -n "$lower_ref" ]] && install_name_tool -change "$lower_ref" '@rpath/liblower.dylib' "$RY"
     while IFS= read -r r; do
         [[ -n "$r" ]] && install_name_tool -delete_rpath "$r" "$RY" 2>/dev/null || true
     done < <(otool -l "$RY" | awk '/LC_RPATH/{getline; getline; print $2}')

--- a/scripts/verify-bundle.sh
+++ b/scripts/verify-bundle.sh
@@ -72,7 +72,7 @@ darwin)
     RY="$DIST_DIR/ry"
     LIB="$DIST_DIR/lib"
 
-    for f in "$RY" "$LIB/libLLVM.dylib" "$LIB/libzstd.1.dylib" "$LIB/libemit.dylib"; do
+    for f in "$RY" "$LIB/libLLVM.dylib" "$LIB/libzstd.1.dylib" "$LIB/libemit.dylib" "$LIB/liblower.dylib"; do
         [[ -f "$f" ]] && echo "  ok: present $(basename "$f")" || { echo "  FAIL: missing $f" >&2; fail=1; }
     done
 
@@ -124,7 +124,7 @@ darwin)
     want "libzstd id = @rpath/libzstd.1.dylib" '@rpath/libzstd\.1\.dylib' "$(otool -D "$LIB/libzstd.1.dylib" 2>/dev/null || true)"
 
     # ad-hoc signatures must be valid after install_name_tool rewrites
-    for f in "$RY" "$LIB/libLLVM.dylib" "$LIB/libemit.dylib" "$LIB/libzstd.1.dylib"; do
+    for f in "$RY" "$LIB/libLLVM.dylib" "$LIB/libemit.dylib" "$LIB/libzstd.1.dylib" "$LIB/liblower.dylib"; do
         if codesign --verify "$f" 2>/dev/null; then
             echo "  ok: codesign $(basename "$f")"
         else
@@ -147,6 +147,7 @@ linux)
         fail=1
     fi
     ls "$LIB"/libemit.so >/dev/null 2>&1 && echo "  ok: present libemit.so" || { echo "  FAIL: missing libemit.so" >&2; fail=1; }
+    ls "$LIB"/liblower.so >/dev/null 2>&1 && echo "  ok: present liblower.so" || { echo "  FAIL: missing liblower.so" >&2; fail=1; }
 
     # Orphan cdylib guard (#2041): see the darwin branch. On Linux the cdylib NEEDs
     # libLLVM.so.X (stdlib libry_* do not); libzstd is a system lib (not bundled), so

--- a/src/cli/self_update.cpp
+++ b/src/cli/self_update.cpp
@@ -692,12 +692,15 @@ bool install_native_libs(const std::string &tmp_dir) {
     for (const auto &entry : fs::directory_iterator(src_lib)) {
         if (!entry.is_regular_file()) continue;
         auto filename = entry.path().filename().string();
-        // Install the Rust cdylib (libemit) + stdlib native libs (libry_*), and —
-        // post-#1999 cutover — the bundled shared libLLVM (plus its macOS chain dep
-        // libzstd), so the relocated runtime stays self-contained (#2005). The cdylib
-        // was renamed libry_codegen -> libemit (#2040), so it no longer matches the
-        // libry_ prefix and needs its own check. Ignore anything else.
+        // Install the Rust cdylibs (libemit, liblower) + stdlib native libs
+        // (libry_*), and — post-#1999 cutover — the bundled shared libLLVM
+        // (plus its macOS chain dep libzstd), so the relocated runtime stays
+        // self-contained (#2005). libemit was renamed from libry_codegen
+        // (#2040) and liblower is the upper-codegen Rust kickoff (#2397), so
+        // neither matches the libry_ prefix and each needs its own check.
+        // Ignore anything else.
         bool is_bundled_lib = filename.find("libemit") == 0 ||
+                              filename.find("liblower") == 0 ||
                               filename.find("libry_") == 0 ||
                               filename.find("libLLVM") == 0 ||
                               filename.find("libzstd") == 0;

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1,6 +1,7 @@
 #include "ry/codegen.hpp"
 #include "ry/llvm_emit/api.h"
 #include "ry/llvm_emit/cast_helpers.hpp"
+#include "ry/lower/api.h"
 #include "ry/stdlib_registry.hpp"
 #include "ry/diagnostic/diagnostic.hpp"
 #include <climits>
@@ -120,7 +121,14 @@ llvm::Value *CodeGen::emitExprVariant(const FloatExpr &e) {
 }
 
 llvm::Value *CodeGen::emitExprVariant(const BoolExpr &e) {
-    return llvm::ConstantInt::get(i1Ty_, e.value ? 1 : 0, false);
+    // Upper-codegen Rust pilot (#2397): the Ry-semantic decision
+    // (`bool → i1 0/1`) moves to `crates/lower/`. The shim survives only
+    // to feed `i1Ty_` across the boundary as `RyTypeRef`; the prior
+    // direct `ConstantInt::get` call is now `ry_emit_const_int` reached
+    // via `ry_lower_bool_const`.
+    RyValueId id = ry_lower_bool_const(
+        emit_ctx_, ry::llvm_emit::asRyType(i1Ty_), e.value ? 1 : 0);
+    return ry::llvm_emit::asLlvmValue(ry_emit_resolve(emit_ctx_, id));
 }
 
 llvm::Value *CodeGen::emitExprVariant(const StringExpr &e) {

--- a/tests/filecheck/bool_const_pilot_2397.ry
+++ b/tests/filecheck/bool_const_pilot_2397.ry
@@ -1,0 +1,29 @@
+# FileCheck golden for #2397 — upper-codegen Rust migration kickoff pilot.
+#
+# `emitExprVariant(BoolExpr)` is the kickoff pilot: the Ry-semantic
+# decision (`bool → i1 0/1`) moved from C++ (direct `ConstantInt::get`)
+# to `crates/lower/`'s `ry_lower_bool_const`, which calls
+# `ry_emit_const_int(ctx, i1Ty, value, 0)`. Both paths must produce
+# byte-identical `i1 true` / `i1 false` constants — this golden locks
+# that invariant.
+#
+# The probe stores each literal into a named local so the constants
+# outlive sema (a bare `if true { ... }` would be sema-folded and never
+# reach the migrated path — the vacuous-diff trap called out in
+# docs/architecture/upper-codegen-migration.md §"Verification").
+#
+# CHECK-LABEL: define i64 @boolPilotProbe()
+# CHECK: store i1 true, ptr %t
+# CHECK: store i1 false, ptr %f
+
+fn boolPilotProbe() -> int:
+    t = true
+    f = false
+    if t:
+        return 1
+    if f:
+        return 2
+    return 3
+
+fn main():
+    _ = boolPilotProbe()


### PR DESCRIPTION
## Summary

- Adds `crates/lower/` (cdylib, no `llvm-sys` dependency) and the `ry_lower_*` boundary header `include/ry/lower/api.h`, parallel to the existing `ry_emit_*` boundary.
- Migrates `emitExprVariant(BoolExpr)` (the minimum-surface lowering op — bool → i1 0/1) to the new Rust crate as the kickoff pilot. The C++ shim survives only to feed `i1Ty_` across the boundary.
- Documents scope, 9-stage migration order, pilot rationale, and verification discipline in `docs/architecture/upper-codegen-migration.md`.
- Locks the byte-exact regression with `tests/filecheck/bool_const_pilot_2397.ry`. Rust workspace lint gates auto-cover the new crate.

Closes #2397.

## Verification (macOS rust-emit)

- ASLR-normalized `--emit-llvm-ir` diff: empty (migration is byte-exact).
- `ry_tests`: 3016/3016 pass post-rebase.
- `ry test -p` self-tests: 220 files, 0 failures.
- FileCheck: 42/42 pass (new pilot golden included).
- Rust lint: `cargo check/fmt/clippy --workspace` clean; emit `abi`-no-IR check unaffected.
- cppcheck (Docker `default`): clean (pre-existing `duplicateCondition` in `codegen_expr.cpp` unchanged).
- ASan + UBSan (Docker `asan`): `ry_tests` + `ry test -p` both pass.
- prompt-refs lint: clean. examples check: 102/102 pass.

Linux/`default` not built locally; CI's `lint` / `test` / `filecheck` jobs (all on `default`) cover cross-platform.

## Test plan

- [ ] CI `test` (Linux/`default`) passes — links the new `lower` cdylib via the `${RY_LOWER_LINK}` path next to `emit` and runs the full gtest suite.
- [ ] CI `filecheck` runs `filecheck_bool_const_pilot_2397` on Linux/`default`.
- [ ] CI `lint` runs `cargo check/fmt/clippy --workspace` over the new `lower` crate.
- [ ] CI `asan` rebuilds with the new crate and runs `ry_tests` + `ry test -p`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added initial Rust-based lowering support for boolean constants, extending the compiler pipeline with a new runtime-backed path.
  * Introduced a new architecture note outlining the staged migration plan for semantic lowering.
  * Added a FileCheck test covering the new boolean constant lowering flow.

* **Bug Fixes**
  * Updated boolean constant generation to use the new lowering path consistently across the build and test targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->