### PR TITLE
refactor(app/main): give SessionTraceGuard ownership of its started flag

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -65,21 +65,22 @@ int main(int argc, char *argv[]) {
     bool emit_llvm_ir = false;
     ry::cli::parseGlobalFlags(argc, argv, trace_enabled, trace_out, emit_llvm_ir);
     ry::configureTrace(trace_enabled, trace_out);
-    bool sessionStarted = false;
-    if (ry::traceEnabled()) {
-        ry::emitTraceEvent("session.start", "session", nullptr,
-                           {ry::TraceField("argv0", argc > 0 && argv[0] ? argv[0] : "ry")});
-        sessionStarted = true;
-    }
+    const char *argv0 = (argc > 0 && argv[0]) ? argv[0] : "ry";
     struct SessionTraceGuard {
-        bool &started;
-        explicit SessionTraceGuard(bool &s) : started(s) {}
+        bool started = false;
+        void start(const char *argv0) {
+            if (started || !ry::traceEnabled()) return;
+            ry::emitTraceEvent("session.start", "session", nullptr,
+                               {ry::TraceField("argv0", argv0)});
+            started = true;
+        }
         ~SessionTraceGuard() {
             if (started && ry::traceEnabled()) {
                 ry::emitTraceEvent("session.end", "session");
             }
         }
-    } sessionTraceGuard(sessionStarted);
+    } sessionTraceGuard;
+    sessionTraceGuard.start(argv0);
 
     // Help flag handling: -h/--help takes priority over other options
     if (argc >= 2) {
@@ -262,18 +263,7 @@ int main(int argc, char *argv[]) {
         }
         if (trace_enabled) {
             ry::configureTrace(true, test_trace_out);
-            if (ry::traceEnabled() && !sessionStarted) {
-                ry::emitTraceEvent("session.start", "session", nullptr,
-                                   {ry::TraceField("argv0", argc > 0 && argv[0] ? argv[0] : "ry")});
-                // SessionTraceGuard (declared above) captures sessionStarted
-                // by reference and reads it in its destructor to emit
-                // session.end. The clang analyzer does not model the
-                // ref-capturing destructor read, producing a false-positive
-                // dead-store warning. Suppressed locally; surfaced by #2319's
-                // CLI / header changes triggering re-analysis of this TU.
-                [[clang::suppress]]
-                sessionStarted = true;
-            }
+            sessionTraceGuard.start(argv0);
         }
         // -p semantics finalisation (#2234): `-p` absent → 1 worker (uniform with
         // the no-`-p` default sequential semantics). `-p` alone keeps parallel_workers

--- a/tests/test_trace.cpp
+++ b/tests/test_trace.cpp
@@ -169,6 +169,18 @@ TEST_F(TraceModeTest, TraceCanBeRedirectedToFile) {
     EXPECT_NE(trace.find("\"event\":\"exec.end\""), std::string::npos);
 }
 
+// #2399: session.end is emitted only on non-JIT exit paths because
+// finalizeAfterPossibleJit() short-circuits via _exit() once the JIT
+// initialised, bypassing the SessionTraceGuard destructor. `ry --trace
+// --version` returns normally before any LLVM init, so the destructor
+// runs and both session.start and session.end appear.
+TEST_F(TraceModeTest, NonJitPathEmitsSessionStartAndEnd) {
+    auto result = runRy({"--trace", "--version"});
+    EXPECT_EQ(result.exit_code, 0);
+    EXPECT_NE(result.err.find("\"event\":\"session.start\""), std::string::npos);
+    EXPECT_NE(result.err.find("\"event\":\"session.end\""), std::string::npos);
+}
+
 // #2234: multi-file `--trace` is no longer aggregated across subprocesses;
 // the runner warns and disables it. The pre-#2234 "falls back to sequential"
 // path is gone — every multi-file invocation goes through subprocess fan-out.


### PR DESCRIPTION
## Summary

- Move `sessionStarted` out of `main()`'s local scope and into `SessionTraceGuard` as a member; expose `start(argv0)` so both startup and `ry test --trace` go through one idempotent entry point. Eliminates the `[[clang::suppress]]` and its 6-line comment that PR #2360 added to work around scan-build's inability to model the ref-captured destructor read.
- Add `NonJitPathEmitsSessionStartAndEnd` test (`ry --trace --version`). The existing trace tests all hit `finalizeAfterPossibleJit()`'s `_exit(rc)` shortcut, so the guard destructor never ran and `session.end` had zero coverage — a regression in the destructor would have gone undetected.

## Test plan

- [x] `./build-rust/ry_tests --gtest_filter='TraceModeTest.*'` — 5/5 pass (incl. new detector test).
- [x] `./.claude/skills/pre-commit-checklist/run-tests.sh` — `ry_tests` 3017/3017 + `ry test -p` 221 files / 0 failures.
- [x] `./.claude/skills/pre-commit-checklist/run-asan.sh --clean` — exit 0, 0 sanitizer errors.

## Skipped checks

- **scan-build**: retired by 5630f1fe; close criterion #3 (no scan-build warning at the site) is not mechanically verifiable. Refactor still applies because the `[[clang::suppress]]` annotation and the awkward ref-capture pattern were the substantive defect.
- **docs / changelog**: pure refactor + test, no user-visible behavior change.
- **rust lint / prompt-refs / examples / tree-sitter / fuzz / export-run-logs**: no relevant files changed.

## Side finding (out of scope)

Multi-file `ry test --trace <dir>` emits `session.start` then `warnAndDisableMultiFileFlags` calls `configureTrace(false, "")`, so the destructor's `traceEnabled()` gate suppresses `session.end`. Pre-existing and unchanged by this refactor.

Closes #2399