### PR TITLE
chore(ci): bake jq into ry-ci image and drop inline install (#2401)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,21 +204,7 @@ jobs:
         # the LoRA-source examples and current language semantics.
         run: bash scripts/check-examples.sh
       - name: 'Test (export-run-logs JSONL schema, #2300)'
-        # `jq` is not in `ry-ci:llvm-21` (gcc:14-trixie base); install a
-        # prebuilt binary inline, verified against the project's published
-        # sha256sum.txt (https://github.com/jqlang/jq/tree/master/sig) so an
-        # upstream compromise or MITM cannot poison this step. Long-term: bake
-        # `jq` into the image and drop these install lines.
-        run: |
-          JQ_VERSION=1.7.1
-          (
-            cd /tmp
-            wget -q "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
-            wget -q "https://raw.githubusercontent.com/jqlang/jq/master/sig/v${JQ_VERSION}/sha256sum.txt"
-            grep 'jq-linux-amd64$' sha256sum.txt | sha256sum -c -
-            install -m 0755 jq-linux-amd64 /usr/local/bin/jq
-          )
-          bash tests/scripts/test-export-run-logs.sh
+        run: bash tests/scripts/test-export-run-logs.sh
       - name: Bundle distribution (Linux)
         # Exercise the #2005 packaging path on every PR/push: release.yml is
         # tag-driven and cannot be dry-run, so the bundling + rpath rewrite is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     # across re-runs. Bump during Release prep — see
     # `.claude/skills/preparing-for-release/SKILL.md` and
     # `.claude/skills/ci-image-workflow/SKILL.md`.
-    container: ${{ matrix.llvm_install == 'container' && format('ghcr.io/{0}/ry-ci-glibc-old:llvm-21-rev12', github.repository_owner) || null }}
+    container: ${{ matrix.llvm_install == 'container' && format('ghcr.io/{0}/ry-ci-glibc-old:llvm-21-rev15', github.repository_owner) || null }}
     steps:
       - uses: actions/checkout@v4
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 # .github/workflows/build-ci-image.yml). The CI image already provides:
 #   - clang/clang++ 21 (source-built, /usr/local/llvm)
 #   - cmake (/opt/cmake), ninja (/opt/ninja), ccache (/usr/local/bin/ccache)
-#   - OpenSSL 3 (/opt/openssl), cppcheck (/opt/cppcheck)
+#   - jq (/usr/local/bin/jq), OpenSSL 3 (/opt/openssl), cppcheck (/opt/cppcheck)
 #   - vendored gtest source tarball at $RY_VENDORED_GTEST_TARBALL
 #   - CC/CXX/PATH/LD_LIBRARY_PATH/OPENSSL_ROOT_DIR/LLVM_DIR pre-set
 #

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -224,7 +224,35 @@ RUN set -eux; \
     rm -rf "rust-${RUST_VERSION}-${RARCH}" "${TARBALL}" "${TARBALL}.sha256"
 
 #
-# Stage 7: cppcheck-builder — source-build cppcheck.
+# Stage 7: jq-bootstrap — download jq prebuilt binary.
+#
+# Single-binary download from jqlang/jq releases. Integrity verified
+# against the project's published sig/v<ver>/sha256sum.txt companion —
+# the same channel used by the previous inline ci.yml install step
+# before #2401 baked jq into the image. Mirrors the ninja-bootstrap
+# pattern (prebuilt binary from github releases) and preserves the
+# "no apt anywhere" image invariant (#1505).
+#
+FROM gcc:14-trixie AS jq-bootstrap
+
+ARG JQ_VERSION=1.7.1
+ARG TARGETARCH
+
+WORKDIR /tmp
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64)  JARCH=amd64 ;; \
+        arm64)  JARCH=arm64 ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    wget -q "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-${JARCH}"; \
+    wget -q "https://raw.githubusercontent.com/jqlang/jq/master/sig/v${JQ_VERSION}/sha256sum.txt"; \
+    grep "jq-linux-${JARCH}\$" sha256sum.txt | sha256sum -c -; \
+    install -m 0755 "jq-linux-${JARCH}" /opt/jq; \
+    rm -f "jq-linux-${JARCH}" sha256sum.txt
+
+#
+# Stage 8: cppcheck-builder — source-build cppcheck.
 #
 FROM gcc:14-trixie AS cppcheck-builder
 
@@ -258,13 +286,14 @@ ARG LLVM_VERSION=21.1.8
 ARG GTEST_VERSION=1.17.0
 
 LABEL org.opencontainers.image.source=https://github.com/t0k0sh1/ry
-LABEL org.opencontainers.image.description="ry CI image — gcc:14-trixie + LLVM ${LLVM_VERSION} (source-built) + OpenSSL 3 + cmake + ninja + ccache + cppcheck + Rust (static.rust-lang.org). Built entirely from github.com + rust-lang.org sources; no apt anywhere."
+LABEL org.opencontainers.image.description="ry CI image — gcc:14-trixie + LLVM ${LLVM_VERSION} (source-built) + OpenSSL 3 + cmake + ninja + ccache + cppcheck + jq + Rust (static.rust-lang.org). Built entirely from github.com + rust-lang.org sources; no apt anywhere."
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
 # Copy artefacts from builder stages.
 COPY --from=cmake-bootstrap /opt/cmake /opt/cmake
 COPY --from=ninja-bootstrap /opt/ninja /opt/ninja
 COPY --from=ccache-bootstrap /opt/ccache /usr/local/bin/ccache
+COPY --from=jq-bootstrap /opt/jq /usr/local/bin/jq
 COPY --from=openssl-builder /opt/openssl /opt/openssl
 COPY --from=llvm-builder /usr/local/llvm /usr/local/llvm
 COPY --from=cppcheck-builder /opt/cppcheck /opt/cppcheck


### PR DESCRIPTION
## Summary

- ry-ci 内 `docker/ci.Dockerfile` に新規 `jq-bootstrap` stage (multi-arch prebuilt + sha256 verify) を追加し、final image に `/usr/local/bin/jq` を baked-in。
- `ci.yml` の inline jq install (16 lines, prebuilt download + sha256 verify) を削除し、test step を `bash tests/scripts/test-export-run-logs.sh` の 1 行に。
- `release.yml` の immutable image pin を `ry-ci-glibc-old:llvm-21-rev12` → `rev15` に bump。

## Design notes

- Issue 本文は `apt-get install -y jq` を示唆しているが、`docker/ci.Dockerfile` 冒頭で「No \`apt\`/\`apt-get\` invocations anywhere — central immunity property (#1505)」が image の中心的不変条件として明示されているため、apt 採用は意図的に避けた。代わりに既存の `ninja-bootstrap` / 旧 inline install と同じパターン (jqlang/jq の prebuilt binary + project published `sig/v<ver>/sha256sum.txt` を `sha256sum -c` で verify) を新 stage に切り出している。同等の意図 + 不変条件保持。
- `ci-glibc-old.Dockerfile` は変更せず: release container の build job (`scripts/bundle-dist.sh` / `verify-bundle.sh`) が jq 未使用のため、`.claude/rules/ci-workflows.md` の「shared CI tools belong in \`docker/ci.Dockerfile\`; release-required tools also belong in \`docker/ci-glibc-old.Dockerfile\`」指針通り `ry-ci` のみへの追加に留めた。release.yml の pin bump は `build-ci-image.yml` の `compute-tag` ロジックが両 image を同一 rev で publish するための事務的な追従であり、内容変更ではない。
- `release.yml` pin の `rev15` は `ry-ci` / `ry-ci-glibc-old` 双方の現在の max が `rev14` であることを GHCR API で確認した上での予測値。merge 前に `build-ci-image.yml` が実際に publish した rev tag と一致することを確認すること (concurrent build があった場合は `rev16` 以降になる可能性)。

## Local validation

- `docker buildx build --platform linux/amd64 --target jq-bootstrap -f docker/ci.Dockerfile docker/` → sha256 verify + install OK
- `docker buildx build --platform linux/arm64 --target jq-bootstrap -f docker/ci.Dockerfile docker/` → sha256 verify + install OK
- `docker run /opt/jq --version` → `jq-1.7.1`
- `docker buildx build --check -f docker/ci.Dockerfile docker/` → warnings 0
- `.claude/skills/pre-commit-checklist/run-export-run-logs-tests.sh` → pass (host jq 1.8.2)

## Test plan

- [ ] PR push 後に自動 trigger される `build-ci-image.yml` を待ち、`rev15` (もしくは concurrent build が起きていれば後続の rev) が publish されることを確認。
- [ ] 公開された実 rev が pin (`rev15`) と一致しない場合、`release.yml` を実 rev へ修正コミット。
- [ ] image publish 後に PR の `ci.yml` を re-run し、`Test (export-run-logs JSONL schema, #2300)` step が `command -v jq` を抜けて pass することを確認 (image 公開前に走った run は inline install を消した状態で旧 image を引くため fail する想定)。

## Out of scope omissions

- Docs / changelog: 過去の chore(ci) PR (#2344, #2198 等) と同じく無し (CI/infra のみ、user-visible behavior の変化なし)。

Closes #2401