### PR TITLE
fix(scripts/export-run-logs): generate RUN_NONCE from /dev/urandom

### DIFF
--- a/changelog.d/2402-export-run-logs-collision-safe-nonce.md
+++ b/changelog.d/2402-export-run-logs-collision-safe-nonce.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `scripts/export-run-logs.sh` の `RUN_NONCE` 生成を microsecond ベース (`jq -nr 'now * 1000000 | floor'`) から `/dev/urandom` 由来の decimal uint64 に置き換え、生成ロジックを sourceable helper `scripts/lib/run-nonce.sh` (`gen_run_nonce`) に切り出し。これにより同一 wall-clock 秒内で複数の invocation が並走しても `run-id` (`YYYYMMDD-HHMMSS-<short-sha>-<nonce>`) が衝突しなくなる。`tests/scripts/test-export-run-logs.sh` に同一 shell プロセス内で `gen_run_nonce` を 50 回呼んで全値が distinct であることを assert する回帰チェックを追加 (PID stable な `$$` ベース実装への regression を検知)。`docs/architecture/jsonl-run-logs.md` を新しい nonce 仕様にあわせて更新。(#2402)

--- a/docs/architecture/jsonl-run-logs.md
+++ b/docs/architecture/jsonl-run-logs.md
@@ -55,11 +55,12 @@ exits 1 with a clear message if `jq` is missing.
     gtest.json                     # only if --target=ry_tests
 ```
 
-- `<run-id>` = `YYYYMMDD-HHMMSS-<short-sha>-<microseconds>` (UTC). The
-  microsecond component is a nonce that prevents two invocations within
-  the same wall-clock second from colliding on the run directory. When
-  the working directory is not a git repo or git is unavailable,
-  `<short-sha>` is the literal `nogit`.
+- `<run-id>` = `YYYYMMDD-HHMMSS-<short-sha>-<nonce>` (UTC). The nonce is a
+  decimal uint64 read from `/dev/urandom` so that two invocations within
+  the same wall-clock second — including concurrent invocations from a
+  single shell — do not collide on the run directory. When the working
+  directory is not a git repo or git is unavailable, `<short-sha>` is the
+  literal `nogit`.
 - `<attempt>` is the per-run 1-based invocation counter, zero-padded to
   four digits. It guarantees per-invocation uniqueness even if the same
   target is passed more than once in a single run.

--- a/scripts/export-run-logs.sh
+++ b/scripts/export-run-logs.sh
@@ -31,6 +31,9 @@ if root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
 fi
 cd "$REPO_ROOT"
 
+# shellcheck source=scripts/lib/run-nonce.sh
+source "$REPO_ROOT/scripts/lib/run-nonce.sh"
+
 # Paths recorded in JSONL must be repo-relative. Reject absolute and
 # parent-escaping paths up-front so a misconfigured RY_BUILD_DIR /
 # RY_LOG_DIR / positional target cannot leak into the metadata.
@@ -167,7 +170,7 @@ if ! is_repo_relative_path "$LOG_DIR_BASE"; then
   echo "error: RY_LOG_DIR must be a repo-relative path (got: $LOG_DIR_BASE)" >&2
   exit 1
 fi
-RUN_NONCE="$(jq -nr 'now * 1000000 | floor')"
+RUN_NONCE="$(gen_run_nonce)"
 RUN_ID="$(date -u +%Y%m%d-%H%M%S)-$GIT_SHORT-$RUN_NONCE"
 RUN_DIR="$LOG_DIR_BASE/$RUN_ID"
 ARTIFACTS_DIR="$RUN_DIR/artifacts"

--- a/scripts/lib/run-nonce.sh
+++ b/scripts/lib/run-nonce.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Shared helper for scripts/export-run-logs.sh.
+# Source this file (do not exec) and call gen_run_nonce.
+#
+# gen_run_nonce prints a collision-safe nonce on stdout: 8 bytes from
+# /dev/urandom, decoded as one decimal uint64. The wall-clock prefix in
+# RUN_ID already orders runs chronologically, so the nonce only has to be
+# unique. Reading /dev/urandom in-process means two calls in the SAME shell
+# (same PID, same $$) still differ — that's the exact regression #2402 guards
+# against, and the reason this lives in a sourceable helper rather than a
+# separate subprocess.
+
+gen_run_nonce() {
+  od -An -N8 -tu8 /dev/urandom | tr -d ' \n'
+}

--- a/tests/scripts/test-export-run-logs.sh
+++ b/tests/scripts/test-export-run-logs.sh
@@ -234,3 +234,30 @@ if [[ "$sym_target" != "$LINK_DIR/linked.test.ry" ]]; then
 fi
 
 echo "OK: tests/scripts/test-export-run-logs.sh — symlinked .test.ry discovery (#2403)"
+
+# ---- RUN_NONCE in-process uniqueness (#2402) ------------------------------
+# Source the helper and call gen_run_nonce many times within this same shell
+# (constant PID / $$). A nonce derived from $$ alone would yield the same
+# value for every call here and fail this check; a wall-clock-only nonce with
+# microsecond resolution can also collide under tight in-process loops. The
+# real /dev/urandom-backed helper trivially passes.
+
+# shellcheck source=../../scripts/lib/run-nonce.sh
+source "scripts/lib/run-nonce.sh"
+
+NONCE_ITERATIONS=50
+nonces=()
+for ((i = 0; i < NONCE_ITERATIONS; i++)); do
+  nonces+=("$(gen_run_nonce)")
+done
+
+unique_nonce_count="$(printf '%s\n' "${nonces[@]}" | sort -u | wc -l | tr -d ' ')"
+if [[ "$unique_nonce_count" != "$NONCE_ITERATIONS" ]]; then
+  echo "error: gen_run_nonce produced duplicates within a single shell —" >&2
+  echo "       expected $NONCE_ITERATIONS unique values, got $unique_nonce_count." >&2
+  echo "       this catches regressions where RUN_NONCE depends on per-process state" >&2
+  echo "       like \$\$ (PID) instead of a true entropy source (#2402)." >&2
+  exit 1
+fi
+
+echo "OK: tests/scripts/test-export-run-logs.sh — ${NONCE_ITERATIONS} in-process nonces unique (#2402)"


### PR DESCRIPTION
## Summary

- `scripts/export-run-logs.sh` の `<run-id>` nonce を microsecond timestamp (`jq -nr 'now * 1000000 | floor'`) から `/dev/urandom` 由来の decimal uint64 に置き換え、同一 wall-clock 秒内の concurrent invocation でも `run-id` が衝突しないようにする。
- 生成ロジックを sourceable helper `scripts/lib/run-nonce.sh` (`gen_run_nonce`) に切り出し、テストが同一 shell プロセス内で 50 回呼んで全 distinct であることを assert する回帰チェックを追加。これは PID 安定な `$$` ベース実装(#2300 で optional follow-up として提案されていたパス)への regression を確実に検知する。
- `docs/architecture/jsonl-run-logs.md` を新しい nonce 仕様に更新、`changelog.d/2402-...` フラグメントを追加。

## Notes

- Issue 本文は `$$` が現コードに混入している前提で書かれているが、実態は microsecond timestamp で `$$` は元から含まれていない (#2300 の "Optional, lower priority" follow-up は merge されなかった)。よって close criterion #1 (`$$` 排除) は vacuously 満たされ、実質の修正は microsecond → `/dev/urandom` への置換となる。
- Charset は decimal を維持 (issue の "string length, charset 等の根本的変更" out of scope 制約に従う)。

## Test plan

- [x] `./.claude/skills/pre-commit-checklist/run-export-run-logs-tests.sh` → exit 0 (`50 in-process nonces unique`)
- [x] `./.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` → clean
- [x] ネガティブコントロール: `gen_run_nonce() { printf '%s' "$$"; }` に一時差し替え → 新テストが `got 1` で fail することを確認、その後復元
- [ ] CI green

Closes #2402