### PR TITLE
fix(fmt): preserve `import ry.<mod>` canonical form

### DIFF
--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -168,7 +168,14 @@ void Formatter::formatImport(const ImportStmt &s) {
 
 void Formatter::formatQualifiedImport(const QualifiedImportStmt &s) {
     emit("import ");
-    emit(s.module_name);
+    if (!s.import_path.empty()) {
+        std::string dotted = s.import_path;
+        for (auto &c : dotted)
+            if (c == '/') c = '.';
+        emit(dotted);
+    } else {
+        emit(s.module_name);
+    }
     if (s.alias.has_value()) {
         emit(" as ");
         emit(*s.alias);

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -225,6 +225,12 @@ TEST(Formatter, StatementFormatting) {
     // Alias propagates through qualified const access.
     EXPECT_EQ(fmt("import math as m\nx = m.PI\n"),
               "import math as m\nx = m.PI\n");
+    // #2423: `import ry.<mod>` canonical form must be preserved by fmt.
+    EXPECT_EQ(fmt("import ry.math\n"), "import ry.math\n");
+    EXPECT_EQ(fmt("import ry.math as m\n"), "import ry.math as m\n");
+    EXPECT_EQ(fmt("import ry.json5\n"), "import ry.json5\n");
+    EXPECT_EQ(fmt("from ry.net import open as net_open\n"),
+              "from ry.net import open as net_open\n");
     // Return
     {
         auto src = "fn f() -> int:\n    return 42\n";


### PR DESCRIPTION
## Summary

- `formatQualifiedImport` emitted only `module_name` (the bare last segment, e.g. `math`), dropping the `ry.` namespace prefix and producing `import math as m` — a hard error after #2351.
- Use `import_path` with slash→dot conversion when non-empty to reconstruct the original dotted form (`import ry.math as m`).
- Add round-trip regression tests for `import ry.math`, `import ry.math as m`, `import ry.json5`, and `from ry.net import open as net_open`.

Closes #2423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Import formatting now preserves the intended module path when an explicit import path is available, while still falling back to the module name when needed.
  * Standard-library imports under `ry.` now round-trip without unwanted changes, including aliased imports and `from ... import ...` forms.

* **Tests**
  * Added coverage to verify import formatting stays consistent for several common `ry.` import patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->