### PR TITLE
fix(test/http): use OS-assigned port + portCallback for readiness

### DIFF
--- a/.claude/rules/tests-cpp-conventions.md
+++ b/.claude/rules/tests-cpp-conventions.md
@@ -14,3 +14,4 @@ paths:
 - Do not write C++ string literals like `"\x00a"`; `\x` consumes following hex digits. Use char arrays or adjacent literals.
 - Clear or overwrite thread-local HTTP error state before asserting message content.
 - In subprocess tests, pass the full `RY_BINARY_PATH` as `argv[0]` to preserve Linux stdlib resolution.
+- HTTP server tests using `http.listen` bind with OS-assigned port `0` and pass a capturing `portCallback: fn(int) -> Unit` that records the bound port for a readiness poll (e.g. a captured `AtomicInt`); never hard-code a port + `sleep()` (flaky under the full suite: #2421). The `portCallback` may be a block-body lambda or a single-expression `-> Unit` lambda whose body is a Unit-returning call (e.g. `(p: int) -> Unit => store(p)`); both are supported since #2421. A non-Unit single-expression body (e.g. `=> x + 1`) is a type error.

--- a/changelog.d/2421-http-listen-portcallback-capture.md
+++ b/changelog.d/2421-http-listen-portcallback-capture.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The 5-argument form of `http.listen` (with a `portCallback: fn(int) -> Unit`) now works when `portCallback` captures variables. Previously the callback was invoked through a raw `void(i64)` call that treated the closure value as a bare function pointer, crashing at runtime for any capturing callback — including the documented pattern of binding to port `0` and storing the OS-assigned port through a captured handle. The callback is now dispatched through the standard closure-call path, so every closure form runs correctly. (#2421)

--- a/changelog.d/2421-single-expr-unit-lambda-codegen.md
+++ b/changelog.d/2421-single-expr-unit-lambda-codegen.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- A single-expression lambda with an explicit `-> Unit` return type whose body is a Unit-returning call (e.g. `(p: int) -> Unit => store(p)`) no longer crashes the compiler. The single-expression codegen path returned the body's value unconditionally, but a Unit-returning call produces no value, so codegen dereferenced a null value and segfaulted; it now emits `ret void` for a Unit-typed body and rejects a non-Unit single-expression body as a type error (matching `return <expr>` in a Unit function). (#2421)

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -288,10 +288,16 @@ static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
     }
 
     llvm::Value *portCallback = nullptr;
+    std::optional<CodeGen::FnTypeInfo> portCallbackInfo;
     if (e.args.size() == 5) {
         portCallback = cg.emitExpr(*e.args[4]);
         if (portCallback->getType() != cg.ptrTy_)
             cg.codegenError("listen() portCallback must be fn(int) -> Unit");
+        auto *cbInfo = cg.lookupFnTypeInfo(portCallback);
+        if (!cbInfo || cbInfo->paramTypes.size() != 1 ||
+            cbInfo->paramTypes[0] != cg.i64Ty_ || !cbInfo->returnType->isVoidTy())
+            cg.codegenError("listen() portCallback must be fn(int) -> Unit");
+        portCallbackInfo = *cbInfo;
     }
 
     // Return type: Result<Unit, Error>
@@ -346,9 +352,10 @@ static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
     if (portCallback) {
         auto portFn = cg.getRuntimeFn("__ry_listener_port", cg.i64Ty_, {cg.ptrTy_});
         llvm::Value *actualPort = cg.builder_.CreateCall(portFn, {listener}, "actual_port");
-        auto callbackFnTy = llvm::FunctionType::get(
-            llvm::Type::getVoidTy(*cg.ctx_), {cg.i64Ty_}, false);
-        cg.builder_.CreateCall(callbackFnTy, portCallback, {actualPort});
+        // Invoke through emitLambdaCall so every closure calling convention
+        // (uniform closure / plain fn ptr / captured closure) is handled; a raw
+        // void(i64) CreateCall mis-invokes a capturing closure struct.
+        cg.emitLambdaCall(portCallback, *portCallbackInfo, {actualPort}, "");
     }
 
     bool hasMaxRequests = (e.args.size() >= 4);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -412,7 +412,13 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
         // Emit body
         if (e->expr_body) {
             llvm::Value *val = emitExpr(*e->expr_body);
-            if (isAnyType(retTy) && !isAnyType(val->getType()))
+            if (retTy->isVoidTy()) {
+                // #2421: single-expression lambda with a Unit (void) return
+                // type. The body was emitted above for its side effects; its
+                // value is null for a Unit-returning call (see emitUserFnCall)
+                // and must not be coerced or dereferenced. Skip the value-
+                // coercion chain; the tail below emits `ret void` instead.
+            } else if (isAnyType(retTy) && !isAnyType(val->getType()))
                 val = wrapInAny(val);
             else if (isAnyType(val->getType()) && !isAnyType(retTy) && canAnyHoldType(retTy)) {
                 // Path 9-return (#2379): rejected by [strict-any/any-implicit-unwrap].
@@ -474,15 +480,32 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
                     }
                 }
             }
-            if (val->getType() != retTy)
-                codegenError("lambda expression return type mismatch: expected '" +
-                    reverseResolveTypeName(retTy) + "', found '" +
-                    reverseResolveTypeName(val->getType()) + "'");
-            // Retain return value before scope cleanup to prevent dangling pointer
-            // when returning a value loaded from an ARC-managed captured variable
-            tryRetainArcSource(val);
-            emitScopeCleanupToDepth(0);
-            builder_.CreateRet(val);
+            if (!retTy->isVoidTy()) {
+                if (val->getType() != retTy)
+                    codegenError("lambda expression return type mismatch: expected '" +
+                        reverseResolveTypeName(retTy) + "', found '" +
+                        reverseResolveTypeName(val->getType()) + "'");
+                // Retain return value before scope cleanup to prevent dangling pointer
+                // when returning a value loaded from an ARC-managed captured variable
+                tryRetainArcSource(val);
+                emitScopeCleanupToDepth(0);
+                builder_.CreateRet(val);
+            } else {
+                // #2421: Unit-returning single-expression lambda. A Unit-typed
+                // body (e.g. a Unit-returning call, which yields a null Value —
+                // see emitUserFnCall) was emitted above for its side effects;
+                // clean up the scope and emit `ret void`, mirroring the
+                // block-body path. A body that produces a real (non-Unit) value
+                // cannot be returned from a Unit lambda, so reject it — matching
+                // `return <expr>` in a Unit function and the parser's rejection
+                // of a bare value-expression statement.
+                if (val != nullptr && !val->getType()->isVoidTy())
+                    codegenError("lambda expression return type mismatch: expected "
+                        "'Unit', found '" + reverseResolveTypeName(val->getType()) +
+                        "'");
+                emitScopeCleanupToDepth(0);
+                builder_.CreateRetVoid();
+            }
         } else {
             for (auto &stmt : e->body)
                 std::visit([this](auto &st) { emitStmt(st); }, stmt);

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -234,6 +234,44 @@ TEST_F(CodeGenTest, LambdaMultiLine) {
     EXPECT_EQ(runSource(src), "7\n3\n");
 }
 
+TEST_F(CodeGenTest, LambdaUnitReturnSingleExpr) {
+    // #2421: a single-expression lambda with an explicit `-> Unit` return type
+    // (`=> expr` where expr is Unit-typed) must compile and run. The body is
+    // evaluated for its side effects and Unit is returned; a void-returning
+    // body yields a null Value that previously crashed codegen (the single-expr
+    // path dereferenced it / fed it to CreateRet, unlike the block-body path).
+    std::string src =
+        "fn emit(x: int) -> Unit:\n"
+        "    print(x)\n"
+        "run = (n: int) -> Unit => emit(n)\n"
+        "run(7)";
+    EXPECT_EQ(runSource(src), "7\n");
+}
+
+TEST_F(CodeGenTest, LambdaUnitReturnSingleExprAsArgument) {
+    // #2421: the same single-expression `-> Unit` lambda passed as an argument
+    // and invoked through the closure-call path (the http.listen portCallback
+    // shape: `(p: int) -> Unit => store(p)`).
+    std::string src =
+        "fn emit(x: int) -> Unit:\n"
+        "    print(x)\n"
+        "fn apply(f: fn(int) -> Unit, v: int) -> Unit:\n"
+        "    f(v)\n"
+        "apply((n: int) -> Unit => emit(n), 9)";
+    EXPECT_EQ(runSource(src), "9\n");
+}
+
+TEST_F(CodeGenTest, LambdaUnitReturnSingleExprNonUnitBodyRejected) {
+    // #2421: a single-expression `-> Unit` lambda whose body produces a real
+    // (non-Unit) value is a type error — the value cannot be returned from a
+    // Unit lambda, mirroring `return <expr>` in a Unit function. Only Unit-
+    // typed bodies (side-effecting calls) are accepted on this path.
+    std::string src =
+        "f = (x: int) -> Unit => x + 1\n"
+        "f(5)";
+    EXPECT_THROW(runSource(src), std::runtime_error);
+}
+
 TEST_F(CodeGenTest, LambdaClosure) {
     std::string src =
         "offset = 10\n"

--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -472,19 +472,32 @@ fn method(req: HttpRequest) -> str
 fn path(req: HttpRequest) -> str
 @native("http")
 fn response(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>
+@native("thread")
+fn atomicIntNew(value: int) -> AtomicInt
+@native("thread")
+fn atomicIntLoad(atomic: AtomicInt) -> int
+@native("thread")
+fn atomicIntStore(atomic: AtomicInt, value: int) -> Unit
+@native("thread")
+fn atomicIntFree(atomic: AtomicInt) -> Unit
 )";
 
 TEST_F(CodeGenTest, HttpListenMaxRequests) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async fn server() -> str:
-    listen("127.0.0.1", 18932, (req: HttpRequest) -> Result<HttpResponse, Error>:
+async fn server(portHolder: AtomicInt) -> str:
+    listen("127.0.0.1", 0, (req: HttpRequest) -> Result<HttpResponse, Error>:
         return response(200, {"Content-Type": "text/plain"}, "ok")
-    , 1)
+    , 1, (p: int) -> Unit:
+        atomicIntStore(portHolder, p)
+    )
     return "done"
 
-t = server()
-sleep(200)
-case connect("127.0.0.1", 18932):
+portHolder = atomicIntNew(0)
+t = server(portHolder)
+port = 0
+while port == 0:
+    port = atomicIntLoad(portHolder)
+case connect("127.0.0.1", port):
     Ok(conn):
         case send(conn, toBytes("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             Ok(_):
@@ -508,24 +521,30 @@ case connect("127.0.0.1", 18932):
         print("false")
         print("false")
 result = blockOn(t)
+atomicIntFree(portHolder)
 print(result)
 )"), "true\ntrue\ndone\n");
 }
 
 TEST_F(CodeGenTest, HttpListenMaxRequestsMultiple) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async fn server() -> str:
-    listen("127.0.0.1", 18933, (req: HttpRequest) -> Result<HttpResponse, Error>:
+async fn server(portHolder: AtomicInt) -> str:
+    listen("127.0.0.1", 0, (req: HttpRequest) -> Result<HttpResponse, Error>:
         path = path(req)
         return response(200, {"Content-Type": "text/plain"}, path)
-    , 2)
+    , 2, (p: int) -> Unit:
+        atomicIntStore(portHolder, p)
+    )
     return "done"
 
-t = server()
-sleep(200)
+portHolder = atomicIntNew(0)
+t = server(portHolder)
+port = 0
+while port == 0:
+    port = atomicIntLoad(portHolder)
 
 # First request
-case connect("127.0.0.1", 18933):
+case connect("127.0.0.1", port):
     Ok(conn):
         case send(conn, toBytes("GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             Ok(_):
@@ -546,7 +565,7 @@ case connect("127.0.0.1", 18933):
         print("false")
 
 # Second request
-case connect("127.0.0.1", 18933):
+case connect("127.0.0.1", port):
     Ok(conn):
         case send(conn, toBytes("GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             Ok(_):
@@ -567,24 +586,30 @@ case connect("127.0.0.1", 18933):
         print("false")
 
 result = blockOn(t)
+atomicIntFree(portHolder)
 print(result)
 )"), "true\ntrue\ndone\n");
 }
 
 TEST_F(CodeGenTest, HttpKeepAlive) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async fn server() -> str:
-    listen("127.0.0.1", 18934, (req: HttpRequest) -> Result<HttpResponse, Error>:
+async fn server(portHolder: AtomicInt) -> str:
+    listen("127.0.0.1", 0, (req: HttpRequest) -> Result<HttpResponse, Error>:
         path = path(req)
         return response(200, {"Content-Type": "text/plain"}, path)
-    , 2)
+    , 2, (p: int) -> Unit:
+        atomicIntStore(portHolder, p)
+    )
     return "done"
 
-t = server()
-sleep(200)
+portHolder = atomicIntNew(0)
+t = server(portHolder)
+port = 0
+while port == 0:
+    port = atomicIntLoad(portHolder)
 
 # Send two requests on the same connection (keep-alive)
-case connect("127.0.0.1", 18934):
+case connect("127.0.0.1", port):
     Ok(conn):
         # First request
         case send(conn, toBytes("GET /first HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")):
@@ -631,23 +656,34 @@ case connect("127.0.0.1", 18934):
         print("false")
 
 result = blockOn(t)
+atomicIntFree(portHolder)
 print(result)
 )"), "true\ntrue\ntrue\ntrue\ndone\n");
 }
 
 TEST_F(CodeGenTest, HttpConnectionClose) {
+    // The portCallback is a single-expression `-> Unit` lambda
+    // (`=> atomicIntStore(...)`) bound to a local and passed to `listen` to pin
+    // the #2421 fix end-to-end: prior to #2421 this lambda form crashed codegen
+    // (single-expr Unit lambda path) AND the 5-arg `http.listen` mis-invoked
+    // any capturing callback (raw void(i64) call vs. closure struct). Hits both
+    // fixes in one execution path.
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async fn server() -> str:
-    listen("127.0.0.1", 18935, (req: HttpRequest) -> Result<HttpResponse, Error>:
+async fn server(portHolder: AtomicInt) -> str:
+    pcb = (p: int) -> Unit => atomicIntStore(portHolder, p)
+    listen("127.0.0.1", 0, (req: HttpRequest) -> Result<HttpResponse, Error>:
         return response(200, {"Content-Type": "text/plain"}, "ok")
-    , 2)
+    , 2, pcb)
     return "done"
 
-t = server()
-sleep(200)
+portHolder = atomicIntNew(0)
+t = server(portHolder)
+port = 0
+while port == 0:
+    port = atomicIntLoad(portHolder)
 
 # Send request with Connection: close
-case connect("127.0.0.1", 18935):
+case connect("127.0.0.1", port):
     Ok(conn):
         case send(conn, toBytes("GET /test HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")):
             Ok(_):
@@ -672,7 +708,7 @@ case connect("127.0.0.1", 18935):
         print("false")
 
 # Second request on new connection to reach maxRequests
-case connect("127.0.0.1", 18935):
+case connect("127.0.0.1", port):
     Ok(conn):
         case send(conn, toBytes("GET /test2 HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             Ok(_):
@@ -693,24 +729,30 @@ case connect("127.0.0.1", 18935):
         print("false")
 
 result = blockOn(t)
+atomicIntFree(portHolder)
 print(result)
 )"), "true\ntrue\ntrue\ndone\n");
 }
 
 TEST_F(CodeGenTest, HttpKeepAliveWithMaxRequests) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async fn server() -> str:
-    listen("127.0.0.1", 18936, (req: HttpRequest) -> Result<HttpResponse, Error>:
+async fn server(portHolder: AtomicInt) -> str:
+    listen("127.0.0.1", 0, (req: HttpRequest) -> Result<HttpResponse, Error>:
         path = path(req)
         return response(200, {"Content-Type": "text/plain"}, path)
-    , 3)
+    , 3, (p: int) -> Unit:
+        atomicIntStore(portHolder, p)
+    )
     return "done"
 
-t = server()
-sleep(200)
+portHolder = atomicIntNew(0)
+t = server(portHolder)
+port = 0
+while port == 0:
+    port = atomicIntLoad(portHolder)
 
 # Send 3 requests on the same keep-alive connection
-case connect("127.0.0.1", 18936):
+case connect("127.0.0.1", port):
     Ok(conn):
         # Request 1
         case send(conn, toBytes("GET /a HTTP/1.1\r\nHost: localhost\r\n\r\n")):
@@ -766,6 +808,7 @@ case connect("127.0.0.1", 18936):
         print("false")
 
 result = blockOn(t)
+atomicIntFree(portHolder)
 print(result)
 )"), "true\ntrue\ntrue\ndone\n");
 }


### PR DESCRIPTION
## Summary

HTTP server tests now bind to port `0` and poll an `AtomicInt` set by the
`http.listen` `portCallback` for readiness, removing both flake sources
(fixed-port collision under the full suite and fixed `sleep`) at the
test-design level. Two codegen bugs surfaced by the OS-assigned-port pattern
are also fixed: the 5-arg `http.listen` now dispatches `portCallback` through
the standard closure-call path (was raw `void(i64)`, broken for any capturing
callback), and the single-expression `-> Unit` lambda codegen path now emits
`ret void` for a Unit body (was SEGV on the resulting null value) and rejects
a non-Unit body as a type error.

Closes #2421

## Test plan

- [x] `ry_tests` full suite (3027 passed, 0 failed)
- [x] `--gtest_repeat=100 --gtest_break_on_failure` over the 5 HTTP tests
      and the 3 new single-expression `-> Unit` lambda detector tests
      (800 executions, 0 failed)
- [x] `ry test -p` (221 files, 0 failed)
- [x] ASan + UBSan via Docker on `ry_tests` + `ry test -p` (0 sanitizer findings)
- [x] cppcheck via Docker (exit 0)
- [x] prompt-refs lint (clean)