### PR TITLE
fix(parser): reject `f(args)[T](args)` chained call instead of silent split

### DIFF
--- a/changelog.d/2426-parser-reject-chained-call-after-index-or-call.md
+++ b/changelog.d/2426-parser-reject-chained-call-after-index-or-call.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `f(args)[T]("arg")` 等の chained call (callee が単一 IDENT でない `<expr>(args)`) を parser が silent split せず明示的な parse error で reject するよう変更。従来は `r = make(42)[int]("inner")` を 2 文 `r = make(42)[int]` + `("inner")` に silent 分解し、`ry fmt` 後に改行で分断されたコードが出力されて「fmt が壊した」と誤認される原因となっていた。エラーメッセージは関連 issue #809 (chained call サポートは `not_planned`) への参照と、中間変数への束縛 (`tmp = f(args)[T]` → `tmp(args)`) という workaround を含む。`Ident[T](args)` (`identity[int](42)` 等) や `f(...)?[T]` / `f(...)?.method()` は引き続き正常動作する。 (#2426)

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -381,7 +381,12 @@ unary_expr       ::= ( '-' | '+' | '~' | 'not' | 'await' | 'weak' ) unary_expr
    `?`). */
 postfix_expression ::= primary_expression { postfix_op }
 
-postfix_op       ::= '(' [ argument_list ] ')'                       // call
+postfix_op       ::= '(' [ argument_list ] ')'                       // call; the C++ parser only accepts '(...)' when the
+                                                                       // callee is a bare IDENT (handled in parsePrimary, not the
+                                                                       // postfix loop). `<expr>(args)` chained calls such as
+                                                                       // `f(args)(args)` or `f(args)[T](args)` are rejected at
+                                                                       // parse time with a clear diagnostic referencing #809
+                                                                       // (the chained-call feature request, not_planned). #2426.
                    | '[' type_expr { ',' type_expr } ']' '(' [ argument_list ] ')'
                                                                        // generic call: f[T](args); the C++ parser only accepts this form
                                                                        // when the callee is a bare IDENT (#1906, see #1885 / #1887)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -663,6 +663,27 @@ empty container literal), use the explicit `name[Type](args)` syntax:
 firstOf[int]([])   # empty list: tell the compiler T = int explicitly
 ```
 
+The `name[Type](args)` form requires `name` to be a bare identifier.
+Chained shapes such as `f(args)[T](args)` (apply `[T](args)` to the
+result of `f(args)`) and `f(args)(args)` are rejected at parse time
+with a diagnostic referencing the chained-call feature request, which
+is tracked as not_planned. Bind the intermediate result to a variable
+and call it directly:
+
+```ry
+fn makeMultiplier(a: int) -> fn(int) -> int:
+    fn step(b: int) -> int:
+        return a * b
+    return step
+
+# Not supported: chained call on an expression result
+# r = makeMultiplier(2)(3)
+
+# Workaround: introduce a temporary
+m = makeMultiplier(2)
+print(m(3))   # 6
+```
+
 Conflicting inferences across arguments produce a clear compile error
 naming the type parameter and function rather than an opaque type
 mismatch:

--- a/src/parser/parser_expr.cpp
+++ b/src/parser/parser_expr.cpp
@@ -1204,6 +1204,24 @@ ExprPtr Parser::parsePostfixContinuation(ExprPtr expr) {
     // parseProgram / block body loops to accommodate (#2136).
     while (true) {
         TokenKind cur = lex_.peek().kind;
+        // #2426: chained call `<expr>(args)` is not supported (#809 is
+        // not_planned). The C++ parser only accepts the generic call form
+        // `Ident[T](args)` in parsePrimary (#1906); a `(...)` immediately
+        // following an IndexExpr/CallExpr postfix has historically been
+        // dropped, causing `r = f(args)[T]("x")` to silent-split into
+        // `r = f(args)[T]` plus a stray `("x")` expression statement and
+        // misleading users into reporting it as a fmt bug. Reject the
+        // pattern explicitly here so the error surfaces at the call site
+        // instead of through corrupted formatter output.
+        if (cur == TokenKind::LParen) {
+            Token paren = lex_.peek();
+            parseError(paren.line,
+                "chained call '<expr>(args)' is not supported (see #809); "
+                "the parser only accepts '(...)' when the callee is a bare "
+                "identifier (e.g. 'f(args)' or 'f[T](args)'). Bind the "
+                "intermediate result to a variable first, e.g. "
+                "'tmp = f(args)[T]' then 'tmp(args)'");
+        }
         if (cur != TokenKind::Dot && cur != TokenKind::LBracket &&
             cur != TokenKind::Question) {
             // Multiline UFCS chain continuation (#2115): speculatively

--- a/src/parser/parser_expr.cpp
+++ b/src/parser/parser_expr.cpp
@@ -1205,22 +1205,23 @@ ExprPtr Parser::parsePostfixContinuation(ExprPtr expr) {
     while (true) {
         TokenKind cur = lex_.peek().kind;
         // #2426: chained call `<expr>(args)` is not supported (#809 is
-        // not_planned). The C++ parser only accepts the generic call form
-        // `Ident[T](args)` in parsePrimary (#1906); a `(...)` immediately
-        // following an IndexExpr/CallExpr postfix has historically been
-        // dropped, causing `r = f(args)[T]("x")` to silent-split into
-        // `r = f(args)[T]` plus a stray `("x")` expression statement and
-        // misleading users into reporting it as a fmt bug. Reject the
-        // pattern explicitly here so the error surfaces at the call site
-        // instead of through corrupted formatter output.
+        // not_planned). parsePrimary owns every direct-call form (bare
+        // `f(args)`, `Ident[T](args)`, `Error(...)`, `Enum::Variant(...)`,
+        // generic enum constructor) up front, so the postfix loop only sees
+        // `(` when the user is trying to apply `(args)` to an already-parsed
+        // postfix expression. Pre-fix, that `(` was dropped, so
+        // `r = f(args)[T]("x")` silently split into `r = f(args)[T]` plus a
+        // stray `("x")` expression statement and users reported it as a fmt
+        // bug. Reject the pattern explicitly here so the error surfaces at
+        // the call site instead of through corrupted formatter output.
         if (cur == TokenKind::LParen) {
             Token paren = lex_.peek();
             parseError(paren.line,
                 "chained call '<expr>(args)' is not supported (see #809); "
-                "the parser only accepts '(...)' when the callee is a bare "
-                "identifier (e.g. 'f(args)' or 'f[T](args)'). Bind the "
-                "intermediate result to a variable first, e.g. "
-                "'tmp = f(args)[T]' then 'tmp(args)'");
+                "the parser does not apply '(...)' to the result of a "
+                "preceding postfix expression such as 'f(args)[T](...)' or "
+                "'f(args)(...)'. Bind the intermediate result to a variable "
+                "first, e.g. 'tmp = f(args)[T]' then 'tmp(args)'");
         }
         if (cur != TokenKind::Dot && cur != TokenKind::LBracket &&
             cur != TokenKind::Question) {

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -1185,3 +1185,50 @@ TEST(Formatter, MultilineInlineLambdaNonTrailingPreservesInlineComment) {
     EXPECT_EQ(out, src);
     EXPECT_EQ(fmt(out), out);
 }
+
+// ===== Chained-call adjacent shapes round-trip (#2426) =====
+// Companion to the ParserTest.ChainedCall* coverage: the patterns that
+// look superficially like the rejected `f(...)[T](...)` (i.e. ones that
+// also build an IndexExpr or ErrorPropagateExpr off a CallExpr base)
+// must continue to round-trip cleanly.
+
+TEST(FormatterTest, ErrorPropagateThenIndexRoundTrip) {
+    // [regression: #2426] — `f(...)?[T]` ends on `]`; the rejection gate
+    // only fires when the next token is `(`, so this must format & verify.
+    auto src = "fn make() -> Option<List<int>>:\n"
+               "    return Some([1, 2, 3])\n"
+               "r = make()?[0]\n";
+    auto formatted = fmt(src);
+    EXPECT_NE(formatted.find("make()?[0]"), std::string::npos) << formatted;
+    EXPECT_EQ(fmt(formatted), formatted);
+    std::string reason;
+    EXPECT_TRUE(Formatter::verifyFormatting(formatted, reason)) << reason;
+}
+
+TEST(FormatterTest, ErrorPropagateThenMethodCallRoundTrip) {
+    // [regression: #2426] — `f(...)?.method()` collapses to UFCS prefix
+    // `method(f(...)?)`. Pin the canonical form so a later parser change
+    // does not regress the verify path.
+    auto src = "fn make() -> Option<int>:\n"
+               "    return Some(42)\n"
+               "r = make()?.toStr()\n";
+    auto formatted = fmt(src);
+    EXPECT_NE(formatted.find("toStr(make()?)"), std::string::npos) << formatted;
+    EXPECT_EQ(fmt(formatted), formatted);
+    std::string reason;
+    EXPECT_TRUE(Formatter::verifyFormatting(formatted, reason)) << reason;
+}
+
+TEST(FormatterTest, BareIdentGenericCallRoundTrip) {
+    // [regression: #2426] — `identity[int](42)` is parsed atomically in
+    // parsePrimary; ensure fmt keeps the bracket form intact (the
+    // CallExpr.callee carries the internal `identity<int>` representation).
+    auto src = "fn identity<T>(x: T) -> T:\n"
+               "    return x\n"
+               "r = identity[int](42)\n";
+    auto formatted = fmt(src);
+    EXPECT_NE(formatted.find("identity[int](42)"), std::string::npos) << formatted;
+    EXPECT_EQ(fmt(formatted), formatted);
+    std::string reason;
+    EXPECT_TRUE(Formatter::verifyFormatting(formatted, reason)) << reason;
+}

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -1,3 +1,4 @@
+#include "ry/diagnostic/diagnostic.hpp"
 #include "ry/formatter.hpp"
 #include "ry/lexer/lexer.hpp"
 #include "ry/parser/parser.hpp"
@@ -1231,4 +1232,16 @@ TEST(FormatterTest, BareIdentGenericCallRoundTrip) {
     EXPECT_EQ(fmt(formatted), formatted);
     std::string reason;
     EXPECT_TRUE(Formatter::verifyFormatting(formatted, reason)) << reason;
+}
+
+TEST(FormatterTest, ChainedCallRejectedByFormatter) {
+    // [regression: #2426] — the original bug surfaced through `ry fmt`, so
+    // pin that fmt itself now propagates the parser rejection instead of
+    // silently round-tripping the input into two split statements. Without
+    // this guard a future formatter refactor that bypasses parsing (e.g. a
+    // textual pass) could re-introduce the silent-split shape.
+    auto src = "fn make<T>(x: T) -> T:\n"
+               "    return x\n"
+               "r = make(42)[int](\"inner\")\n";
+    EXPECT_THROW(fmt(src), DiagnosticError);
 }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -5266,3 +5266,79 @@ TEST(ParserTest, DocDirectiveSingleLineStringArg) {
     EXPECT_EQ(se.value, "single line");
     EXPECT_FALSE(se.is_block);
 }
+
+// ===== Chained call rejection (#2426) =====
+// Ry only accepts the generic-call form `Ident[T](args)` in parsePrimary
+// (#1906); `<expr>(args)` for an arbitrary postfix expression is not
+// supported and is tracked as #809 (not_planned). Before #2426 the parser
+// silently dropped the trailing `(args)`, producing two unrelated
+// statements and misleading users into reporting fmt as the culprit.
+// These tests pin the explicit `parseError` path.
+
+TEST(ParserTest, ChainedCallAfterGenericIndexRejected) {
+    // [regression: #2426] — the canonical bug shape from the issue title.
+    EXPECT_THROW(parseStr("r = make(42)[int](\"inner\")\n"), DiagnosticError);
+}
+
+TEST(ParserTest, ChainedCallAfterGenericIndexEmptyArgsRejected) {
+    // [regression: #2426]
+    EXPECT_THROW(parseStr("r = make(42)[int]()\n"), DiagnosticError);
+}
+
+TEST(ParserTest, ChainedCallAfterGenericIndexNamedArgRejected) {
+    // [regression: #2426]
+    EXPECT_THROW(parseStr("r = make(42)[int](key=1)\n"), DiagnosticError);
+}
+
+TEST(ParserTest, ChainedCallAfterGenericIndexMultiArgRejected) {
+    // [regression: #2426] — the silent-split flavour pre-fix; the tuple
+    // (1, 2) used to be re-parsed as an independent ExprStmt.
+    EXPECT_THROW(parseStr("r = make(42)[int](1, 2)\n"), DiagnosticError);
+}
+
+TEST(ParserTest, ChainedCallAfterCallRejected) {
+    // [regression: #2426] — covers the `f(a)(b)` shape from #809.
+    EXPECT_THROW(parseStr("r = make()(7)\n"), DiagnosticError);
+}
+
+TEST(ParserTest, ChainedCallRejectionMentionsIssue809) {
+    // [regression: #2426] — message must give users a path forward.
+    try {
+        parseStr("r = make(42)[int](\"inner\")\n");
+        FAIL() << "expected DiagnosticError";
+    } catch (const DiagnosticError &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("#809"), std::string::npos) << msg;
+        EXPECT_NE(msg.find("chained call"), std::string::npos) << msg;
+    }
+}
+
+TEST(ParserTest, GenericCallOnBareIdentStillAccepted) {
+    // [regression: #2426] — guard against over-rejecting; `identity[int](42)`
+    // is parsed inside parsePrimary (parsePostfixContinuation never sees the
+    // '(' for this shape), so the new gate must not affect it.
+    Program prog = parseStr("r = identity[int](42)\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(s.value->data));
+}
+
+TEST(ParserTest, ErrorPropagateThenIndexStillAccepted) {
+    // [regression: #2426] — `f(...)?[T]` parses as `Index(?Wrap(Call), T)`
+    // and the next token after `]` is Newline, not `(`, so the gate stays
+    // silent. Pin the shape so a later refactor cannot reintroduce the
+    // silent-split path here.
+    Program prog = parseStr("r = make(42)?[int]\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<IndexExpr>>(s.value->data));
+}
+
+TEST(ParserTest, ErrorPropagateThenMethodCallStillAccepted) {
+    // [regression: #2426] — `f(...)?.method()` becomes a UFCS CallExpr;
+    // ensures the rejection gate does not bleed into the dot-call path.
+    Program prog = parseStr("r = make()?.toStr()\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(s.value->data));
+}


### PR DESCRIPTION
## Summary

- Parser silently split `r = make(42)[int]("inner")` into two statements (`r = make(42)[int]` + `("inner")`), and `ry fmt` rendered the split as a newline, leading users to report it as a fmt bug (#2426).
- `parsePostfixContinuation` now rejects `(` in the postfix loop with a clear diagnostic referencing #809 (chained-call feature request, not_planned) and the intermediate-variable workaround. `Ident[T](args)` (parsePrimary path), `f(...)?[T]`, and `f(...)?.method()` are unaffected.
- Grammar (`docs/grammar.ebnf`) and Generic Functions reference doc updated with the restriction; doc workaround verified to run.

Closes #2426

## Test plan

- [x] `cmake --build build-rust` — clean
- [x] `./build-rust/ry_tests` — 3062/3062 passed (includes 12 new regression tests: 6 rejection + 3 positive parser, 3 fmt round-trip)
- [x] `./build-rust/ry test -p` — 221/221 spec tests passed
- [x] `bash scripts/check-examples.sh` — 102/102 canonical examples passed
- [x] `./.claude/skills/pre-commit-checklist/run-asan.sh` — exit 0
- [x] `./.claude/skills/pre-commit-checklist/run-static-analysis-all.sh` — exit 0
- [x] `./.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` — clean
- [x] `./build-rust/ry run` on chained-call inputs (assign + case-arm tail positions) → clean parse error, no hard error
- [x] `./build-rust/ry run` on the docs `makeMultiplier` workaround → prints `6`
- [ ] `./.claude/skills/pre-commit-checklist/run-fuzz.sh` — pre-existing Docker build failure (`undefined reference to ry_lower_bool_const` from recent Rust upper-codegen migration); confirmed by re-running on origin/main with `git stash`. Unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chained call patterns that previously parsed incorrectly are now rejected with a clear error message.
  * Formatting now stays stable for supported postfix and generic-call forms, avoiding broken-looking output.

* **Documentation**
  * Updated grammar and function docs to clarify which call shapes are supported, which are rejected, and how to rewrite them using an intermediate variable.

* **Tests**
  * Added regression coverage for rejected chained calls and confirmed supported cases still round-trip correctly through formatting and parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->