### PR TITLE
fix(lexer): accept \u{HHHH} unicode escape in string literals

### DIFF
--- a/changelog.d/2427-lexer-unicode-escape.md
+++ b/changelog.d/2427-lexer-unicode-escape.md
@@ -1,0 +1,7 @@
+### Added
+
+- Ry 文字列リテラルに `\u{HHHH}` Unicode escape を実装 (`src/lexer/lexer.cpp`)。1 〜 6 桁の hex を `{...}` で囲み、対応する Unicode scalar value を UTF-8 として decode する (例: `"\u{1F600}"` → 😀 = `\xF0\x9F\x98\x80`)。regular string (~672)、block string (~582)、f-string (~829) の 3 つの escape switch 全てから共通の `decodeUnicodeEscape` + `appendUtf8` ヘルパを呼ぶ実装で乖離を防止。バリデーションは `0x10FFFF` を上限、surrogate range `0xD800..0xDFFF`、`\u{}` 空、`\u41` (`{`欠落)、`\u{41` (`}`欠落)、`\u{ZZZ}` (非 hex)、`\u{1234567}` (7 桁以上) を全て構造化エラーに変換する。raw string (`r"..."`) は escape 非処理の既存契約を維持し `\u{...}` を literal の 10 byte として保持する。
+
+### Fixed
+
+- `ry fmt` が `\u{HHHH}` Unicode escape を含む合法な Ry プログラムを `unknown escape sequence '\u'` で reject していたバグを修正 (#2427)。PR #2373 (closes #2326) の "Notes on known-fmt issues" で fmt 単独の欠陥として宣言されていたが、原因は fmt と `ry run` が共有する lexer が `\u` 自体を escape として認識していなかったことで (fmt 専用 string parser は存在せず `Formatter::escapeString` の default arm に decode 済み UTF-8 byte を素通しさせるだけ)、lexer 側に escape を実装したことで自動的に fmt も close criteria を満たすようになった。fmt は decode 済み literal UTF-8 (`"😀"`) を出力するため、二度目の format pass は固定点となり (`Formatter::verifyFormatting` で idempotency 検証) round-trip も保持される。 (#2427)

--- a/src/lexer/lexer.cpp
+++ b/src/lexer/lexer.cpp
@@ -1,5 +1,6 @@
 #include "ry/lexer/lexer.hpp"
 #include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <stdexcept>
 #include <unordered_map>
@@ -30,6 +31,90 @@ static void consumeDigitsWithSeparators(const std::string &src, size_t &pos,
             break;
         }
     }
+}
+
+// Append a Unicode scalar value as UTF-8 bytes to `dst`. The caller is
+// responsible for ensuring `cp <= 0x10FFFF` and `cp` is not a surrogate
+// (see decodeUnicodeEscape, which validates before calling).
+static void appendUtf8(std::string &dst, uint32_t cp) {
+    if (cp < 0x80u) {
+        dst.push_back(static_cast<char>(cp));
+    } else if (cp < 0x800u) {
+        dst.push_back(static_cast<char>(0xC0u | (cp >> 6)));
+        dst.push_back(static_cast<char>(0x80u | (cp & 0x3Fu)));
+    } else if (cp < 0x10000u) {
+        dst.push_back(static_cast<char>(0xE0u | (cp >> 12)));
+        dst.push_back(static_cast<char>(0x80u | ((cp >> 6) & 0x3Fu)));
+        dst.push_back(static_cast<char>(0x80u | (cp & 0x3Fu)));
+    } else {
+        dst.push_back(static_cast<char>(0xF0u | (cp >> 18)));
+        dst.push_back(static_cast<char>(0x80u | ((cp >> 12) & 0x3Fu)));
+        dst.push_back(static_cast<char>(0x80u | ((cp >> 6) & 0x3Fu)));
+        dst.push_back(static_cast<char>(0x80u | (cp & 0x3Fu)));
+    }
+}
+
+// Decode a `\u{HHHH}` escape. On entry, `pos` is positioned at the `{`
+// (the caller has already consumed the leading `\` and `u`). On normal
+// return, the parsed UTF-8 bytes are appended to `dst` and `pos`/`col`
+// are advanced past the last hex digit so that `pos` points AT the
+// closing `}` — the caller's trailing `++pos; ++col` (which always
+// follows the escape switch) then consumes the `}`. This matches the
+// single-character escape contract used by the surrounding code.
+//
+// Rejects: missing `{`, missing `}`, empty `\u{}`, non-hex characters,
+// more than 6 hex digits, surrogate range `0xD800..0xDFFF`, and values
+// above `0x10FFFF`.
+static void decodeUnicodeEscape(const std::string &src, size_t &pos,
+                                int &col, int line, std::string &dst) {
+    if (pos >= src.size() || src[pos] != '{') {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": expected '{' after '\\u' in unicode escape");
+    }
+    ++pos; ++col;  // consume '{'
+    size_t start = pos;
+    uint32_t cp = 0;
+    while (pos < src.size() && src[pos] != '}') {
+        char ch = src[pos];
+        if (pos - start >= 6) {
+            throw std::runtime_error("line " + std::to_string(line) +
+                                     ": unicode escape has too many digits (max 6)");
+        }
+        uint32_t digit;
+        if (ch >= '0' && ch <= '9') {
+            digit = static_cast<uint32_t>(ch - '0');
+        } else if (ch >= 'a' && ch <= 'f') {
+            digit = static_cast<uint32_t>(ch - 'a') + 10u;
+        } else if (ch >= 'A' && ch <= 'F') {
+            digit = static_cast<uint32_t>(ch - 'A') + 10u;
+        } else {
+            throw std::runtime_error("line " + std::to_string(line) +
+                                     ": invalid hex digit '" +
+                                     std::string(1, ch) +
+                                     "' in unicode escape");
+        }
+        cp = (cp << 4) | digit;
+        ++pos; ++col;
+    }
+    if (pos >= src.size()) {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": unterminated unicode escape (missing '}')");
+    }
+    if (pos == start) {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": empty unicode escape '\\u{}'");
+    }
+    if (cp > 0x10FFFFu) {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": unicode code point out of range (max 0x10FFFF)");
+    }
+    if (cp >= 0xD800u && cp <= 0xDFFFu) {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": unicode code point in surrogate range");
+    }
+    appendUtf8(dst, cp);
+    // Leave `pos` AT the closing '}'. The caller's trailing `++pos; ++col`
+    // (after the surrounding escape switch) consumes the '}'.
 }
 
 static const std::unordered_map<std::string, TokenKind> keyword_map = {
@@ -586,6 +671,10 @@ Token Lexer::readToken() {
                     case '\\': raw += '\\'; break;
                     case '"':  raw += '"';  break;
                     case '0':  raw += '\0'; break;
+                    case 'u':
+                        ++pos_; ++col_;  // past 'u'; helper expects '{'
+                        decodeUnicodeEscape(src_, pos_, col_, line_, raw);
+                        break;
                     default:
                         throw std::runtime_error("line " + std::to_string(line_) +
                                                  ": unknown escape sequence '\\" +
@@ -676,6 +765,10 @@ Token Lexer::readToken() {
                     case '\\': str += '\\'; break;
                     case '"':  str += '"';  break;
                     case '0':  str += '\0'; break;
+                    case 'u':
+                        ++pos_; ++col_;  // past 'u'; helper expects '{'
+                        decodeUnicodeEscape(src_, pos_, col_, line_, str);
+                        break;
                     default:
                         throw std::runtime_error("line " + std::to_string(line_) +
                                                  ": unknown escape sequence '\\" +
@@ -833,6 +926,10 @@ Token Lexer::readFStringSegment(bool isStart) {
                 case '\\': str += '\\'; break;
                 case '"':  str += '"';  break;
                 case '0':  str += '\0'; break;
+                case 'u':
+                    ++pos_; ++col_;  // past 'u'; helper expects '{'
+                    decodeUnicodeEscape(src_, pos_, col_, line_, str);
+                    break;
                 default:
                     throw std::runtime_error("line " + std::to_string(line_) +
                                              ": unknown escape sequence '\\" +

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -344,6 +344,57 @@ fn utf8SupportTests():
   fn shouldReverseUtf8String():
     expect(reverse("あいう")).toEq("ういあ")
 
+@describe("unicode escape \\u{HHHH} (#2427)")
+fn unicodeEscapeTests():
+  @it("should decode ASCII unicode escape")
+  fn shouldDecodeAsciiUnicodeEscape():
+    expect("\u{41}").toEq("A")
+    expect("\u{61}").toEq("a")
+    expect("\u{20}").toEq(" ")
+  @it("should decode BMP unicode escape to multi-byte UTF-8")
+  fn shouldDecodeBmpUnicodeEscape():
+    # U+3042 HIRAGANA LETTER A → 3-byte UTF-8
+    expect("\u{3042}").toEq("あ")
+    expect(byteLen("\u{3042}")).toEq(3)
+    expect("\u{3042}").toHaveLen(1)
+  @it("should decode supplementary plane unicode escape to 4-byte UTF-8")
+  fn shouldDecodeSupplementaryPlaneUnicodeEscape():
+    # U+1F600 GRINNING FACE → 4-byte UTF-8
+    expect("\u{1F600}").toEq("😀")
+    expect(byteLen("\u{1F600}")).toEq(4)
+    expect("\u{1F600}").toHaveLen(1)
+  @it("should accept lowercase hex digits")
+  fn shouldAcceptLowercaseHexDigits():
+    expect("\u{1f600}").toEq("😀")
+    expect("\u{abcd}").toEq("\u{ABCD}")
+  @it("should support max code point U+10FFFF")
+  fn shouldSupportMaxCodePoint():
+    expect(byteLen("\u{10FFFF}")).toEq(4)
+  @it("should accept 1 to 6 hex digit forms")
+  fn shouldAccept1To6HexDigitForms():
+    # 1, 2, 3, 4, and 6 hex digits each map to a distinct code point.
+    expect("\u{a}").toEq("\n")
+    expect("\u{ff}").toEq("\u{FF}")
+    expect("\u{abc}").toEq("\u{ABC}")
+    expect("\u{abcd}").toEq("\u{ABCD}")
+    expect(byteLen("\u{10ffff}")).toEq(4)
+  @it("should accept \\u{0} as a NUL byte")
+  fn shouldAcceptUEscapeZeroAsNul():
+    # NUL-containing strings: use `==` per #1051 / spec conventions.
+    expect("\u{0}" == "\0").toEq(true)
+    expect(byteLen("\u{0}")).toEq(1)
+  @it("should mix with other escape sequences and literal text")
+  fn shouldMixWithOtherEscapesAndLiteralText():
+    expect("a\u{41}b\nc\u{1F600}").toEq("aAb\nc😀")
+  @it("should decode inside triple-quoted block strings")
+  fn shouldDecodeInsideBlockStrings():
+    s = """\u{1F600}"""
+    expect(s).toEq("😀")
+  @it("should decode inside f-strings independently of {expr}")
+  fn shouldDecodeInsideFStrings():
+    name = "world"
+    expect(f"\u{48}\u{69}, {name}").toEq("Hi, world")
+
 @describe("type conversion")
 fn typeConversionTests():
   @it("should return Ok for valid int input")

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -28,6 +28,79 @@ TEST(Formatter, LiteralFormatting) {
     EXPECT_EQ(fmt("x = none\n"), "x = none\n");
 }
 
+// ===== All-Escape Round-Trip (#2427 scope item 3) =====
+//
+// Issue #2427 close criterion 3 requires every lexer-accepted escape to
+// round-trip through `ry fmt`. The lexer accepts six single-character
+// escapes (`\n`, `\r`, `\t`, `\\`, `\"`, `\0`) plus the new `\u{HHHH}`;
+// each one's output spelling is fixed by `Formatter::escapeString`.
+// Anchoring all six in one place catches a future drift where, e.g.,
+// `\0` gets removed from the encoder but stays in the decoder.
+TEST(Formatter, AllEscapeSequenceRoundTrip) {
+    EXPECT_EQ(fmt("x = \"\\n\"\n"), "x = \"\\n\"\n");
+    EXPECT_EQ(fmt("x = \"\\r\"\n"), "x = \"\\r\"\n");
+    EXPECT_EQ(fmt("x = \"\\t\"\n"), "x = \"\\t\"\n");
+    EXPECT_EQ(fmt("x = \"\\\\\"\n"), "x = \"\\\\\"\n");
+    EXPECT_EQ(fmt("x = \"\\\"\"\n"), "x = \"\\\"\"\n");
+    EXPECT_EQ(fmt("x = \"\\0\"\n"), "x = \"\\0\"\n");
+    // All six in one literal, in different positions
+    EXPECT_EQ(fmt("x = \"\\n\\r\\t\\\\\\\"\\0\"\n"),
+              "x = \"\\n\\r\\t\\\\\\\"\\0\"\n");
+}
+
+// Regex literals (lexer.cpp:534) intentionally pass `\u` through verbatim
+// to the regex engine. The lexer fix added a `case 'u':` ONLY to the
+// string-literal escape switches, not to the regex tokenizer's escape
+// pass-through; this regression guard pins that boundary.
+TEST(Formatter, RegexLiteralUnicodeEscapePassthrough) {
+    EXPECT_EQ(fmt("x = /\\u{1F600}/\n"), "x = /\\u{1F600}/\n");
+}
+
+// ===== Unicode Escape Round-Trip (#2427) =====
+//
+// The lexer decodes `\u{HHHH}` to UTF-8 bytes; the formatter has no
+// dedicated `\u` re-encoding and routes the decoded bytes through
+// `escapeString`'s default arm, which passes any non-special byte through
+// verbatim. The user-visible effect is that `\u{...}` is normalized to a
+// literal UTF-8 character on first format and is then a fixed point.
+TEST(Formatter, UnicodeEscapeRoundTrip) {
+    // ASCII collapses to its character
+    EXPECT_EQ(fmt("x = \"\\u{41}\"\n"), "x = \"A\"\n");
+    // Non-BMP decodes to a 4-byte UTF-8 sequence (U+1F600 GRINNING FACE)
+    EXPECT_EQ(fmt("x = \"\\u{1F600}\"\n"),
+              "x = \"\xF0\x9F\x98\x80\"\n");
+    // Mixed with surrounding content and other escapes
+    EXPECT_EQ(fmt("x = \"a\\u{41}b\\nc\\u{1F600}\"\n"),
+              "x = \"aAb\\nc\xF0\x9F\x98\x80\"\n");
+
+    // Idempotency: a second format pass leaves the output untouched.
+    {
+        const std::string out1 = fmt("x = \"\\u{1F600}\"\n");
+        const std::string out2 = fmt(out1);
+        EXPECT_EQ(out1, out2);
+    }
+
+    // verifyFormatting re-parses the formatted output and re-formats; the
+    // round-trip must converge (close criterion #2 in #2427).
+    {
+        const std::string out = fmt("x = \"\\u{1F600}\"\n");
+        std::string reason;
+        EXPECT_TRUE(Formatter::verifyFormatting(out, reason)) << reason;
+    }
+
+    // f-string path: lexer decodes inside the FString segments, formatter
+    // re-emits via escapeString on the segment value. The f-string is
+    // kept with an interpolation segment so the `f` prefix is preserved
+    // (a pre-existing fmt pass strips `f` from no-interpolation literals).
+    EXPECT_EQ(fmt("y = 1\nx = f\"\\u{1F600} {y}\"\n"),
+              "y = 1\nx = f\"\xF0\x9F\x98\x80 {y}\"\n");
+
+    // Block string path: lexer decodes inside `"""..."""`, formatter
+    // re-emits the decoded bytes via escapeBlockString.
+    EXPECT_EQ(fmt("x = \"\"\"\\u{1F600}\"\"\"\n"),
+              "x = \"\"\"\xF0\x9F\x98\x80\"\"\"\n");
+}
+
 // ===== Block String Literal Formatting (#1843) =====
 
 TEST(Formatter, BlockStringLiteralFormatting) {

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -601,6 +601,170 @@ TEST(LexerTest, StringLiteralTokens) {
     }
 }
 
+// ===== Unicode escape \u{HHHH} (#2427) =====
+//
+// Verified across regular strings, block strings, and f-strings since the
+// three lexer sites share `decodeUnicodeEscape` but each has its own
+// surrounding loop; a regression in one would not surface in the others.
+
+TEST(LexerTest, UnicodeEscapeRegularString) {
+    // ASCII
+    {
+        auto toks = tokenize("\"\\u{41}\"");
+        ASSERT_EQ(toks.size(), 2u);
+        EXPECT_EQ(toks[0].kind, TokenKind::String);
+        EXPECT_EQ(toks[0].value, "A");
+    }
+    // 1-byte boundary
+    {
+        auto toks = tokenize("\"\\u{7F}\"");
+        EXPECT_EQ(toks[0].value, std::string("\x7F"));
+    }
+    // 2-byte UTF-8 boundary (cp = 0x80)
+    {
+        auto toks = tokenize("\"\\u{80}\"");
+        EXPECT_EQ(toks[0].value, std::string("\xC2\x80"));
+    }
+    // 2-byte UTF-8 upper bound (cp = 0x7FF)
+    {
+        auto toks = tokenize("\"\\u{7FF}\"");
+        EXPECT_EQ(toks[0].value, std::string("\xDF\xBF"));
+    }
+    // 3-byte UTF-8 boundary (cp = 0x800)
+    {
+        auto toks = tokenize("\"\\u{800}\"");
+        EXPECT_EQ(toks[0].value, std::string("\xE0\xA0\x80"));
+    }
+    // 3-byte UTF-8 upper bound (cp = 0xFFFF)
+    {
+        auto toks = tokenize("\"\\u{FFFF}\"");
+        EXPECT_EQ(toks[0].value, std::string("\xEF\xBF\xBF"));
+    }
+    // 4-byte UTF-8 boundary (cp = 0x10000)
+    {
+        auto toks = tokenize("\"\\u{10000}\"");
+        EXPECT_EQ(toks[0].value, std::string("\xF0\x90\x80\x80"));
+    }
+    // U+1F600 GRINNING FACE
+    {
+        auto toks = tokenize("\"\\u{1F600}\"");
+        EXPECT_EQ(toks[0].value, std::string("\xF0\x9F\x98\x80"));
+    }
+    // Max valid code point (cp = 0x10FFFF)
+    {
+        auto toks = tokenize("\"\\u{10FFFF}\"");
+        EXPECT_EQ(toks[0].value, std::string("\xF4\x8F\xBF\xBF"));
+    }
+    // Lowercase hex
+    {
+        auto toks = tokenize("\"\\u{1f600}\"");
+        EXPECT_EQ(toks[0].value, std::string("\xF0\x9F\x98\x80"));
+    }
+    // NUL: \u{0} produces a single NUL byte
+    {
+        auto toks = tokenize("\"\\u{0}\"");
+        // Avoid embedded `\0` in C-string ctor.
+        EXPECT_EQ(toks[0].value, std::string(1, '\0'));
+    }
+    // Mixed with neighbouring content
+    {
+        auto toks = tokenize("\"a\\u{41}b\"");
+        EXPECT_EQ(toks[0].value, "aAb");
+    }
+    // Mixed with other single-char escapes
+    {
+        auto toks = tokenize("\"\\n\\u{41}\\t\"");
+        EXPECT_EQ(toks[0].value, "\nA\t");
+    }
+    // Adjacent unicode escapes
+    {
+        auto toks = tokenize("\"\\u{41}\\u{42}\\u{43}\"");
+        EXPECT_EQ(toks[0].value, "ABC");
+    }
+}
+
+TEST(LexerTest, UnicodeEscapeErrors) {
+    // Missing '{' (e.g. user typed `\u41` instead of `\u{41}`)
+    EXPECT_THROW(tokenize("\"\\u41\""), std::runtime_error);
+    // Missing '}' inside a single-line string: greedy parse hits the
+    // closing quote as a non-hex char.
+    EXPECT_THROW(tokenize("\"\\u{41\""), std::runtime_error);
+    // Empty: `\u{}`
+    EXPECT_THROW(tokenize("\"\\u{}\""), std::runtime_error);
+    // Non-hex digit
+    EXPECT_THROW(tokenize("\"\\u{ZZZ}\""), std::runtime_error);
+    // Above 0x10FFFF
+    EXPECT_THROW(tokenize("\"\\u{110000}\""), std::runtime_error);
+    // Surrogate range
+    EXPECT_THROW(tokenize("\"\\u{D800}\""), std::runtime_error);
+    EXPECT_THROW(tokenize("\"\\u{DBFF}\""), std::runtime_error);
+    EXPECT_THROW(tokenize("\"\\u{DC00}\""), std::runtime_error);
+    EXPECT_THROW(tokenize("\"\\u{DFFF}\""), std::runtime_error);
+    // More than 6 hex digits — caught before value validation so we don't
+    // silently accept 7-digit values that happen to land in range.
+    EXPECT_THROW(tokenize("\"\\u{1234567}\""), std::runtime_error);
+    // Abrupt EOF after '\u' (no '{')
+    EXPECT_THROW(tokenize("\"\\u"), std::runtime_error);
+    // Abrupt EOF inside `\u{...` (no '}')
+    EXPECT_THROW(tokenize("\"\\u{1F"), std::runtime_error);
+}
+
+TEST(LexerTest, UnicodeEscapeBlockString) {
+    {
+        auto toks = tokenize("\"\"\"\\u{1F600}\"\"\"");
+        ASSERT_GE(toks.size(), 2u);
+        EXPECT_EQ(toks[0].kind, TokenKind::BlockString);
+        EXPECT_EQ(toks[0].value, std::string("\xF0\x9F\x98\x80"));
+    }
+    {
+        auto toks = tokenize("\"\"\"a\\u{41}b\"\"\"");
+        EXPECT_EQ(toks[0].kind, TokenKind::BlockString);
+        EXPECT_EQ(toks[0].value, "aAb");
+    }
+    // Block-string error path uses the same helper, so a malformed escape
+    // still throws.
+    EXPECT_THROW(tokenize("\"\"\"\\u{}\"\"\""), std::runtime_error);
+}
+
+TEST(LexerTest, UnicodeEscapeFString) {
+    {
+        auto toks = tokenize("f\"\\u{1F600}\"");
+        ASSERT_GE(toks.size(), 2u);
+        EXPECT_EQ(toks[0].kind, TokenKind::FStringEnd);
+        EXPECT_EQ(toks[0].value, std::string("\xF0\x9F\x98\x80"));
+    }
+    {
+        auto toks = tokenize("f\"hello\\u{41}\"");
+        EXPECT_EQ(toks[0].kind, TokenKind::FStringEnd);
+        EXPECT_EQ(toks[0].value, "helloA");
+    }
+    // `\u{...}` must not collide with f-string `{expr}` interpolation —
+    // the backslash routes through the escape switch before the `{`-as-
+    // interpolation-open branch is considered.
+    {
+        auto toks = tokenize("f\"\\u{41}{x}\"");
+        ASSERT_GE(toks.size(), 4u);
+        EXPECT_EQ(toks[0].kind, TokenKind::FStringStart);
+        EXPECT_EQ(toks[0].value, "A");
+        EXPECT_EQ(toks[1].kind, TokenKind::Ident);
+        EXPECT_EQ(toks[1].value, "x");
+        EXPECT_EQ(toks[2].kind, TokenKind::FStringEnd);
+    }
+    // f-string error path mentions "in f-string" suffix
+    EXPECT_THROW(tokenize("f\"\\u{ZZZ}\""), std::runtime_error);
+}
+
+// Raw strings (`r"..."`) intentionally pass through escapes verbatim
+// (lexer.cpp:534), so `\u{...}` remains the literal byte sequence rather
+// than being decoded. The lexer must not invoke the unicode decoder on
+// this path.
+TEST(LexerTest, UnicodeEscapeRawStringPassthrough) {
+    auto toks = tokenize(R"(r"\u{1F600}")");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::String);
+    EXPECT_EQ(toks[0].value, "\\u{1F600}");
+}
+
 // ===== F-string tokens =====
 
 TEST(LexerTest, FStringTokens) {


### PR DESCRIPTION
## Summary

- Add `\u{HHHH}` Unicode escape decoding to the Ry lexer for regular, block, and f-strings via shared `appendUtf8` + `decodeUnicodeEscape` helpers. Validates 1-6 hex digits, caps at `0x10FFFF`, rejects surrogate range `0xD800..0xDFFF`, and structures errors for missing `{` / `}`, empty `\u{}`, non-hex chars, and 7+ digit forms.
- Issue #2427 was filed as a `ry fmt` bug, but `ry fmt` and `ry run` share the same lexer — both rejected `\u{HHHH}` identically. A fmt-only fix would have made fmt accept input that `ry run` still rejected, breaking close criterion #2 (fmt output must parse via `ry`). The lexer-side fix lets the formatter's existing `escapeString` default arm pass decoded UTF-8 bytes through verbatim, so `"\u{1F600}"` formats to `"😀"` and is then a fixed point.
- Scope-item-2 audit: `\xHH` / `\v` / `\b` / `\f` are rejected by both lexer and fmt; `\0` / `\r` / `\t` / `\n` / `\\` / `\"` are accepted by both. No fmt↔lexer divergence remains.

## Test plan

- [x] `cmake --build build-rust` — clean
- [x] `build-rust/ry_tests` — 3042 / 3042 unit tests pass (5 new `LexerTest.UnicodeEscape*` + 3 new `Formatter.*Escape*` cases incl. all-six-escape round-trip and regex `\u` passthrough regression guard)
- [x] `build-rust/ry test -p` — 221 spec files / 0 failures (9 new cases under `unicode escape \u{HHHH} (#2427)` in `tests/spec/strings.test.ry`)
- [x] `bash scripts/check-examples.sh` — 102 / 102 canonical examples pass
- [x] `.claude/skills/pre-commit-checklist/run-asan.sh` — clean
- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` — clean
- [x] Empirical: `ry run` on `s = "\u{1F600}"` prints 😀; `ry fmt` then `ry fmt --check` idempotent; block string and f-string variants also work

Skipped: `run-fuzz.sh` — pre-existing infrastructure failure on `main` (`undefined reference to ry_lower_bool_const` linker error, reproduced via `git stash` on main without this PR's changes; unrelated to the lexer change).

Closes #2427