### PR TITLE
chore(changelog): add missing v0.0.30 fragments for #2314 / #2396 / #2423

### DIFF
--- a/changelog.d/2314-json5-unicode-unquoted-keys.md
+++ b/changelog.d/2314-json5-unicode-unquoted-keys.md
@@ -1,0 +1,5 @@
+### Added
+
+- `json5` の unquoted object key を ASCII subset から ECMAScript `IdentifierName` 全体に拡張した (`share/std/json5/json5.cpp`)。`unicode-ident` ベースの `XID_Start` / `XID_Continue` に加えて `$` / `_` / ZWNJ (`U+200C`) / ZWJ (`U+200D`) と `\uHHHH` escape (BMP / surrogate pair) を受理する。これにより JavaScript の `JSON5.parse`、Python の `pyjson5`、Rust `json5` crate との cross-language 相互運用ギャップが解消され、日本語 / 中国語 / 韓国語 / ギリシャ語 / アラビア・インド数字 / combining mark を含むキーがそのまま渡せるようになる。RFC 3629 strict UTF-8 codepoint decoder / encoder を json5.cpp 内に追加し、ASCII 連続部は escape を含まない区間として bulk copy するため ASCII-only キーの FFI 越境は発生しない。
+- `crates/xid/` を新規 Rust cdylib として追加 (`unicode-ident` の薄いラッパ)。`__ry_xid_start(u32)` / `__ry_xid_continue(u32)` の 2 シンボルを export し、`emit` クレートと同じパターンで `ry` / `ry_tests` にリンクして dlopen 済み `libry_json5` からプロセス内で resolve させる (inter-library link dependency なし)。
+- 拒否ケース (Unicode digit start / punctuation start / 不正な escape / `true` 等の予約語キーワードに Unicode サフィックスを連結したもの) は明示的なパースエラーとして返る。`parse_bool` / `parse_null` / `parse_number` の hex literal trailing guard も ECMAScript IdentifierContinue を意識した境界判定に揃えた。(#2314)

--- a/changelog.d/2396-mock-spy-called-matchers.md
+++ b/changelog.d/2396-mock-spy-called-matchers.md
@@ -1,0 +1,5 @@
+### Added
+
+- `testing` モジュールに 3 つの bool-returning matcher intrinsic を追加: `calledWith(name, args...)` (記録された呼び出しのうち少なくとも 1 件が一致すれば `true`)、`calledTimes(name, n)` (呼び出し回数が `n` と等しければ `true`)、`lastCalledWith(name, args...)` (最後の呼び出しが一致すれば `true`)。既存の `verifyCalledWith` (int 返却) と同じコンパイル時バリデーション (関数が存在する / mock or spy 済みである / 引数の arity と型が一致する) と lifecycle (it-end auto-clear、`mockClear` / `mockReset` / `mockResetAll` で reset) を共有する。`lastCalledWith` のバックエンドとして `__ry_mock_last_call_matches` runtime helper を新規追加。引数記録 IR は `emitCalledMatcherImpl` ヘルパに共通化し、runtime call と結果変換のみが mode 別に分岐する。
+- 新規 spec test `tests/spec/called_with.test.ry` を追加 (30 ケース、int / float / bool / str / List / Set / Map / record / tuple / fn / zero-arg + overload sig 形式 + `mockReset` / `mockResetAll` の相互作用をカバー)。`tests/spec/spy.test.ry` / `tests/spec/mock.test.ry` の既存挙動は behavior-preserving refactor のため退行なし。
+- スコープ外として明示的にドロップした項目: `spy.calls` / `mock.calls` プロパティアクセサ。Ry には function value へのプロパティアクセス機構がなく、内部記録バッファは opaque な kind-tagged int でできているため、`List<tuple<paramTypes>>` として export するには overload ごとの typed deserializer が必要になる。引数レベルのアサーションは本 PR の 3 matcher で完全にカバーできるため、現時点では露出しない。(#2396)

--- a/changelog.d/2423-fmt-preserve-ry-qualified-import.md
+++ b/changelog.d/2423-fmt-preserve-ry-qualified-import.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ry fmt` が `import ry.<mod>` 形式の qualified import を `import <mod>` (bare 形式) に書き換える破壊書換を行い、#2351 で hard error 化された legacy syntax を生成する不具合を修正。`Formatter::formatQualifiedImport` が `module_name` (dotted path の最終セグメント、例: `math`) のみを emit して `ry.` namespace prefix を脱落させていたのが原因。AST 側には dotted path の生の slash 表記 (`ry/math`) が `import_path` として保持されているため、これが非空の場合は slash を dot に変換して `ry.math` を再構成し、空のときのみ `module_name` への従来 fallback を行うよう修正。`tests/test_formatter.cpp` に `import ry.math` / `import ry.math as m` / `import ry.json5` / `from ry.net import open as net_open` の 4 ケースを round-trip 退行テストとして追加した。(#2423)


### PR DESCRIPTION
## Summary

v0.0.30 milestone で close 済みだが `changelog.d/` に fragment が漏れていた user-visible な変更 3 件を追加する。`/preparing-for-release v0.0.30` 起動前に `scripts/assemble-changelog.sh` が user-visible な変更を完全列挙できるようにする目的の release prep 補完。

| Issue | PR | 追加先 | 概要 |
|---|---|---|---|
| #2314 | #2356 | Added | `json5` の unquoted object key を ECMAScript `IdentifierName` 全体 (Unicode XID + ZWNJ/ZWJ + `\uHHHH` escape) に拡張 |
| #2396 | #2409 | Added | `testing` に `calledWith` / `calledTimes` / `lastCalledWith` matcher を追加 |
| #2423 | #2430 | Fixed | `ry fmt` が `import ry.<mod>` を bare 形式に破壊書換し #2351 hard-error syntax を生成していた問題を修正 |

#2426 (#2436) は merge 時点で fragment 同梱済みのため対象外。#1702 (`try:` block) と #2312 (revert) はリリース前に同一 milestone 内で往復済みのためフラグメント不要 (released 版でユーザーには露出しない)。

## Verification

- [x] `bash scripts/assemble-changelog.sh --dry-run` の出力で 3 件全てが該当セクション (`### Added` x2、`### Fixed` x1) に正しく流入することを確認 (Added: 19 → 25、Fixed: 23 → 24)。
- [x] 既存の他フラグメントへの影響なし (差分は新規 3 ファイル追加のみ)。

## Skipped checks

- tests / sanitizers / fuzz: コード変更なし (markdown のみ)、`changelog.d/` は `.claude/rules/changelog-fragments.md` policy 通り CI でビルドされない。
- prompt-refs-lint: 対象は `.claude/**/*.md` / `AGENTS.md` / `CLAUDE.md` で、`changelog.d/` は scope 外。

## Test plan

- [x] `scripts/assemble-changelog.sh --dry-run` でアセンブル後の `### Added` / `### Fixed` セクションに 3 件の bullet が出現することを確認。