### PR TITLE
fix(lexer): implement `\xNN` hex escape in string literals (#2440)

### DIFF
--- a/changelog.d/2440-lexer-hex-escape.md
+++ b/changelog.d/2440-lexer-hex-escape.md
@@ -1,0 +1,7 @@
+### Added
+
+- Ry 文字列リテラルに `\xNN` hex escape を実装 (`src/lexer/lexer.cpp`)。`\xNN` は厳密に 2 桁の hex digit を要求し、対応する単一バイト (0x00 〜 0xFF) を文字列に追加する (例: `"\x41"` → `"A"`, `"\xFF"` → 単一バイト `0xFF`)。`\u{HHHH}` が UTF-8 encode 済みの Unicode code point を生成するのと異なり、`\xNN` は生のバイト 1 つを生成するため、`\x80` 〜 `\xFF` 単独では valid UTF-8 にならない点も既存の `\0` と同じ扱い。regular string、block string、f-string の 3 つの escape switch 全てから共通の `decodeHexEscape` ヘルパを呼ぶ実装で乖離を防止。バリデーションは EOF mid-escape、hex digit 不足 (例: `"\x4"`)、非 hex digit (例: `"\xZZ"`, `"\x4Z"`) を構造化エラーに変換する。raw string (`r"..."`) は escape 非処理の既存契約を維持し `\x41` を literal の 4 byte として保持する。
+
+### Fixed
+
+- 文字列リテラル中の `\xNN` hex escape が `unknown escape sequence '\x'` で reject されていたバグを修正 (#2440)。`docs/reference/builtins-string.md:20` は `\xNN` が標準 escape 集合に含まれると明記していたが、PR #2427 (`\u{HHHH}`) と同様に lexer の 3 つの escape switch のいずれにも `case 'x':` が存在しなかった。`ry fmt` も同じ lexer を共有するため自動的に `\xNN` を受理するようになり、decode 済み literal byte を出力する (例: `"\x41"` → `"A"`)。`\xFF` のように非 UTF-8 single byte に decode される escape は fmt 出力後に source file が非 UTF-8 になるが、format 自体は exit 0 で idempotent (`\u{FF}` が valid な 2-byte UTF-8 に decode されるのと対照的)。

--- a/src/lexer/lexer.cpp
+++ b/src/lexer/lexer.cpp
@@ -117,6 +117,52 @@ static void decodeUnicodeEscape(const std::string &src, size_t &pos,
     // (after the surrounding escape switch) consumes the '}'.
 }
 
+// Decode a `\xNN` escape. On entry, `pos` is positioned at the first hex
+// digit (the caller has already consumed the leading `\` and `x`). Exactly
+// two hex digits are required, producing a single raw byte (0x00 - 0xFF)
+// appended to `dst`. On normal return, `pos`/`col` are advanced to the
+// SECOND hex digit so that the caller's trailing `++pos; ++col` (which
+// always follows the escape switch) consumes it — matching the single-
+// character escape contract used by the surrounding code.
+//
+// Unlike `\u{...}`, the result is NOT UTF-8 encoded; `\xFF` produces a
+// single 0xFF byte even though that byte is not valid UTF-8 standalone.
+//
+// Rejects: EOF mid-escape, non-hex digit at either position.
+static void decodeHexEscape(const std::string &src, size_t &pos,
+                            int &col, int line, std::string &dst) {
+    auto hexValue = [](char ch) -> int {
+        if (ch >= '0' && ch <= '9') return ch - '0';
+        if (ch >= 'a' && ch <= 'f') return (ch - 'a') + 10;
+        if (ch >= 'A' && ch <= 'F') return (ch - 'A') + 10;
+        return -1;
+    };
+    if (pos >= src.size()) {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": incomplete '\\x' escape: expected 2 hex digits");
+    }
+    int hi = hexValue(src[pos]);
+    if (hi < 0) {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": invalid hex digit '" +
+                                 std::string(1, src[pos]) + "' in '\\x' escape");
+    }
+    ++pos; ++col;
+    if (pos >= src.size()) {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": incomplete '\\x' escape: expected 2 hex digits");
+    }
+    int lo = hexValue(src[pos]);
+    if (lo < 0) {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": invalid hex digit '" +
+                                 std::string(1, src[pos]) + "' in '\\x' escape");
+    }
+    dst.push_back(static_cast<char>((hi << 4) | lo));
+    // Leave `pos` AT the second hex digit. The caller's trailing
+    // `++pos; ++col` (after the surrounding escape switch) consumes it.
+}
+
 static const std::unordered_map<std::string, TokenKind> keyword_map = {
     {"and",       TokenKind::And},
     {"or",        TokenKind::Or},
@@ -675,6 +721,10 @@ Token Lexer::readToken() {
                         ++pos_; ++col_;  // past 'u'; helper expects '{'
                         decodeUnicodeEscape(src_, pos_, col_, line_, raw);
                         break;
+                    case 'x':
+                        ++pos_; ++col_;  // past 'x'; helper expects 1st hex digit
+                        decodeHexEscape(src_, pos_, col_, line_, raw);
+                        break;
                     default:
                         throw std::runtime_error("line " + std::to_string(line_) +
                                                  ": unknown escape sequence '\\" +
@@ -768,6 +818,10 @@ Token Lexer::readToken() {
                     case 'u':
                         ++pos_; ++col_;  // past 'u'; helper expects '{'
                         decodeUnicodeEscape(src_, pos_, col_, line_, str);
+                        break;
+                    case 'x':
+                        ++pos_; ++col_;  // past 'x'; helper expects 1st hex digit
+                        decodeHexEscape(src_, pos_, col_, line_, str);
                         break;
                     default:
                         throw std::runtime_error("line " + std::to_string(line_) +
@@ -929,6 +983,10 @@ Token Lexer::readFStringSegment(bool isStart) {
                 case 'u':
                     ++pos_; ++col_;  // past 'u'; helper expects '{'
                     decodeUnicodeEscape(src_, pos_, col_, line_, str);
+                    break;
+                case 'x':
+                    ++pos_; ++col_;  // past 'x'; helper expects 1st hex digit
+                    decodeHexEscape(src_, pos_, col_, line_, str);
                     break;
                 default:
                     throw std::runtime_error("line " + std::to_string(line_) +

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -395,6 +395,45 @@ fn unicodeEscapeTests():
     name = "world"
     expect(f"\u{48}\u{69}, {name}").toEq("Hi, world")
 
+@describe("hex escape \\xNN (#2440)")
+fn hexEscapeTests():
+  @it("should decode ASCII hex escape")
+  fn shouldDecodeAsciiHexEscape():
+    expect("\x41").toEq("A")
+    expect("\x61").toEq("a")
+    expect("\x20").toEq(" ")
+  @it("should produce a single raw byte")
+  fn shouldProduceSingleRawByte():
+    # `\xNN` is a single byte, distinct from `\u{NN}` which is UTF-8 encoded.
+    expect(byteLen("\x41")).toEq(1)
+    expect(byteLen("\x7F")).toEq(1)
+    # `\xFF` is one raw byte, while `\u{FF}` is two UTF-8 bytes (U+00FF).
+    expect(byteLen("\xFF")).toEq(1)
+    expect(byteLen("\u{FF}")).toEq(2)
+  @it("should accept lowercase / uppercase / mixed hex digits")
+  fn shouldAcceptHexDigitCases():
+    expect("\xab" == "\xAB").toEq(true)
+    expect("\xaB" == "\xAB").toEq(true)
+  @it("should accept \\x00 as a NUL byte")
+  fn shouldAcceptHexEscapeZeroAsNul():
+    expect("\x00" == "\0").toEq(true)
+    expect(byteLen("\x00")).toEq(1)
+  @it("should mix with other escape sequences and literal text")
+  fn shouldMixWithOtherEscapesAndLiteralText():
+    expect("a\x41b\nc").toEq("aAb\nc")
+    expect("\x41\u{42}").toEq("AB")
+  @it("should decode chained \\xNN escapes")
+  fn shouldDecodeChainedHexEscapes():
+    expect("\x41\x42\x43").toEq("ABC")
+  @it("should decode inside triple-quoted block strings")
+  fn shouldDecodeInsideBlockStrings():
+    s = """\x41"""
+    expect(s).toEq("A")
+  @it("should decode inside f-strings")
+  fn shouldDecodeInsideFStrings():
+    name = "world"
+    expect(f"\x48\x69, {name}").toEq("Hi, world")
+
 @describe("type conversion")
 fn typeConversionTests():
   @it("should return Ok for valid int input")

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -765,6 +765,150 @@ TEST(LexerTest, UnicodeEscapeRawStringPassthrough) {
     EXPECT_EQ(toks[0].value, "\\u{1F600}");
 }
 
+// ===== Hex escape \xNN (#2440) =====
+//
+// `\xNN` decodes exactly two hex digits into a single raw byte (0x00 - 0xFF),
+// distinct from `\u{HHHH}` which encodes a Unicode code point as UTF-8.
+// Verified across regular strings, block strings, and f-strings since the
+// three lexer sites share `decodeHexEscape` but each has its own surrounding
+// loop; a regression in one would not surface in the others.
+
+TEST(LexerTest, HexEscapeRegularString) {
+    // ASCII (the repro from the issue)
+    {
+        auto toks = tokenize("\"\\x41\"");
+        ASSERT_EQ(toks.size(), 2u);
+        EXPECT_EQ(toks[0].kind, TokenKind::String);
+        EXPECT_EQ(toks[0].value, "A");
+    }
+    // 0x00: \x00 produces a single NUL byte
+    {
+        auto toks = tokenize("\"\\x00\"");
+        EXPECT_EQ(toks[0].value, std::string(1, '\0'));
+    }
+    // 0x7F (ASCII boundary)
+    {
+        auto toks = tokenize("\"\\x7F\"");
+        EXPECT_EQ(toks[0].value, std::string(1, static_cast<char>(0x7F)));
+    }
+    // 0x80 (non-UTF-8 single byte)
+    {
+        auto toks = tokenize("\"\\x80\"");
+        EXPECT_EQ(toks[0].value, std::string(1, static_cast<char>(0x80)));
+    }
+    // 0xFF (max single byte)
+    {
+        auto toks = tokenize("\"\\xFF\"");
+        EXPECT_EQ(toks[0].value, std::string(1, static_cast<char>(0xFF)));
+    }
+    // Lowercase hex
+    {
+        auto toks = tokenize("\"\\xab\"");
+        EXPECT_EQ(toks[0].value, std::string(1, static_cast<char>(0xAB)));
+    }
+    // Uppercase hex
+    {
+        auto toks = tokenize("\"\\xAB\"");
+        EXPECT_EQ(toks[0].value, std::string(1, static_cast<char>(0xAB)));
+    }
+    // Mixed case
+    {
+        auto toks = tokenize("\"\\xaB\"");
+        EXPECT_EQ(toks[0].value, std::string(1, static_cast<char>(0xAB)));
+    }
+    // Mixed with neighbouring content
+    {
+        auto toks = tokenize("\"a\\x41b\"");
+        EXPECT_EQ(toks[0].value, "aAb");
+    }
+    // Mixed with other single-char escapes
+    {
+        auto toks = tokenize("\"\\n\\x41\\t\"");
+        EXPECT_EQ(toks[0].value, "\nA\t");
+    }
+    // Adjacent hex escapes
+    {
+        auto toks = tokenize("\"\\x41\\x42\\x43\"");
+        EXPECT_EQ(toks[0].value, "ABC");
+    }
+    // Mixed with `\u{...}`
+    {
+        auto toks = tokenize("\"\\x41\\u{42}\"");
+        EXPECT_EQ(toks[0].value, "AB");
+    }
+}
+
+TEST(LexerTest, HexEscapeErrors) {
+    // Abrupt EOF after '\x' (no hex digits, string unterminated)
+    EXPECT_THROW(tokenize("\"\\x"), std::runtime_error);
+    // Closing quote where the first hex digit was expected
+    EXPECT_THROW(tokenize("\"\\x\""), std::runtime_error);
+    // Only one hex digit before the closing quote
+    EXPECT_THROW(tokenize("\"\\x4\""), std::runtime_error);
+    // Non-hex first digit
+    EXPECT_THROW(tokenize("\"\\xZZ\""), std::runtime_error);
+    // Non-hex second digit
+    EXPECT_THROW(tokenize("\"\\x4Z\""), std::runtime_error);
+    // Abrupt EOF in the middle of the escape
+    EXPECT_THROW(tokenize("\"\\x4"), std::runtime_error);
+}
+
+TEST(LexerTest, HexEscapeBlockString) {
+    {
+        auto toks = tokenize("\"\"\"\\x41\"\"\"");
+        ASSERT_GE(toks.size(), 2u);
+        EXPECT_EQ(toks[0].kind, TokenKind::BlockString);
+        EXPECT_EQ(toks[0].value, "A");
+    }
+    {
+        auto toks = tokenize("\"\"\"a\\x41b\"\"\"");
+        EXPECT_EQ(toks[0].kind, TokenKind::BlockString);
+        EXPECT_EQ(toks[0].value, "aAb");
+    }
+    // Non-UTF-8 byte still produced in block string form
+    {
+        auto toks = tokenize("\"\"\"\\xFF\"\"\"");
+        EXPECT_EQ(toks[0].kind, TokenKind::BlockString);
+        EXPECT_EQ(toks[0].value, std::string(1, static_cast<char>(0xFF)));
+    }
+    // Block-string error path uses the same helper
+    EXPECT_THROW(tokenize("\"\"\"\\xZZ\"\"\""), std::runtime_error);
+}
+
+TEST(LexerTest, HexEscapeFString) {
+    {
+        auto toks = tokenize("f\"\\x41\"");
+        ASSERT_GE(toks.size(), 2u);
+        EXPECT_EQ(toks[0].kind, TokenKind::FStringEnd);
+        EXPECT_EQ(toks[0].value, "A");
+    }
+    {
+        auto toks = tokenize("f\"hello\\x41\"");
+        EXPECT_EQ(toks[0].kind, TokenKind::FStringEnd);
+        EXPECT_EQ(toks[0].value, "helloA");
+    }
+    // `\xNN` must not collide with f-string `{expr}` interpolation
+    {
+        auto toks = tokenize("f\"\\x41{x}\"");
+        ASSERT_GE(toks.size(), 4u);
+        EXPECT_EQ(toks[0].kind, TokenKind::FStringStart);
+        EXPECT_EQ(toks[0].value, "A");
+        EXPECT_EQ(toks[1].kind, TokenKind::Ident);
+        EXPECT_EQ(toks[1].value, "x");
+        EXPECT_EQ(toks[2].kind, TokenKind::FStringEnd);
+    }
+    // f-string error path (message includes "in f-string" suffix)
+    EXPECT_THROW(tokenize("f\"\\xZZ\""), std::runtime_error);
+}
+
+// Raw strings pass `\xNN` through verbatim, same as `\u{...}`.
+TEST(LexerTest, HexEscapeRawStringPassthrough) {
+    auto toks = tokenize(R"(r"\x41")");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::String);
+    EXPECT_EQ(toks[0].value, "\\x41");
+}
+
 // ===== F-string tokens =====
 
 TEST(LexerTest, FStringTokens) {


### PR DESCRIPTION
## Summary

- 3 つの escape switch (block / regular / f-string) 全てに `\xNN` hex escape decoder (`decodeHexEscape`) を実装。厳密に 2 桁の hex digit で単一バイト (0x00 - 0xFF) を生成 (`\u{HHHH}` の UTF-8 encoding と区別)。
- `docs/reference/builtins-string.md:20` で標準 escape 集合に含まれると documented されていたが PR #2427 (`\u{HHHH}`) と同じ位置に `case 'x':` が欠落していた問題を修正。
- `ry fmt` も同じ lexer を共有するため自動的に受理。

## Self-verification

| Check | Result |
|---|---|
| ry_tests (3076 件) | pass |
| spec tests (221 ファイル) | pass |
| examples (102/102) | pass |
| ASan | pass (exit 0) |
| prompt-refs lint | clean |
| fuzz | skip (pre-existing `ry_lower_bool_const` link error、main でも再現、本変更と無関係) |

## Test plan

- [x] Red→Green: 実装前は `unknown escape sequence '\x'` で reject、実装後 pass
- [x] 完全性 grep: `case 'x'` が 3 箇所、各 `case 'u'` と隣接
- [x] Issue repro: `print("\x41")` が `A` を出力
- [x] formatter idempotency: `\x41`/`\xFF` を含むファイルで exit 0 + 二度目 fmt で no-diff
- [x] semantics: `byteLen("\xFF") == 1` ≠ `byteLen("\u{FF}") == 2`

Closes #2440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `\xNN` hex escape sequences in string literals, including regular strings, block strings, and f-strings.
  * Hex escapes now decode to a single byte, with mixed-case hex digits and `\x00` supported.

* **Bug Fixes**
  * Fixed cases where `\xNN` was previously treated as an unknown escape.
  * Invalid or incomplete hex escapes now produce clear errors, and raw strings keep `\xNN` as literal text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->