### PR TITLE
refactor(codegen): clean up descriptor-driven native dispatch scaffolding

### DIFF
--- a/include/ry/codegen_native_dispatch.hpp
+++ b/include/ry/codegen_native_dispatch.hpp
@@ -26,12 +26,16 @@ enum class CodeGenReturnWrapping : uint8_t {
     IteratorFromHandle,   // synthesize Iterator<T> with next-fn calling exported_symbol(handle, &out)
 
     // #2393: thread sync-primitive *Free entries (lockFree / rwlockFree /
-    // semaphoreFree / barrierFree / atomicIntFree / atomicBoolFree). No
-    // runtime fn is called; the destructor lives in ResourceKindRegistry
-    // and emitResourceFree emits the null-check + ARC-release sequence.
-    // The handle arg is at `desc.handle_param_index` (must be 0 — the
-    // *Free customEmitters all take the resource as the sole arg) with
-    // `desc.handle_resource_kind` selecting the destructor.
+    // semaphoreFree / barrierFree). No runtime fn is called; the destructor
+    // lives in ResourceKindRegistry and emitResourceFree emits the
+    // null-check + ARC-release sequence. The handle arg lives at
+    // `desc.handle_param_index` (must be 0 — the *Free entries all take the
+    // resource as the sole arg) with `desc.handle_resource_kind` selecting
+    // the destructor. atomicIntFree / atomicBoolFree are NOT routed through
+    // this wrapping; they remain Pattern B carve-outs (see
+    // codegen_call_thread.cpp's emitThreadAtomicFree) so they can share the
+    // AtomicInt / AtomicBool resource-kind type check with the rest of the
+    // atomic family.
     ResourceFree,
 };
 

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -1103,6 +1103,8 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
             llvm_unreachable("ResultPtrWithListMeta not used in generic native dispatch");
         case ReturnWrapping::IteratorFromHandle:
             llvm_unreachable("IteratorFromHandle handled above (early return)");
+        case ReturnWrapping::ResourceFree:
+            llvm_unreachable("ResourceFree handled above (early return)");
         }
         return res;
     };

--- a/src/codegen_call_thread.cpp
+++ b/src/codegen_call_thread.cpp
@@ -631,39 +631,15 @@ static llvm::Value *emitThreadAtomicBoolOp(CodeGen &cg, const CallExpr &e) {
 //     i1↔i64 zext/trunc, CAS i64→i1 trunc, or a non-callee SSA name like
 //     "atomic_int") that the declarative descriptor cannot express
 //     byte-exactly. Mirrors the #2340 precedent that carved
-//     `threadSpawn`/`threadJoin` out of thread_table.
-//
-// `thread_table` is intentionally empty: `dispatchThread` returns nullptr,
-// letting the descriptor-driven path (`emitGenericNativeCall`) handle every
-// sync-primitive callee. Atomics short-circuit earlier in
-// `emitExprVariant`'s Pattern B chain (`emitBuiltinThread`) before the
-// stdlib dispatcher loop runs.
-static const CodeGen::NativeDispatchEntry thread_table[] = {};
-
-// Gate the dispatcher: only proceed if any thread sig is actually registered.
-// Probe two representative anchors covering the carved-out (threadSpawn) and
-// table-driven (lockNew) sides of the module; a single sig from either side
-// is enough to confirm the user imported `thread`. Mirrors the O(1)
-// `sigs.count(...)` shape used by `isJsonImported` / `isJson5Imported`.
-//
-// `libry_thread` registration: emitTableDrivenNativeCall registers the
-// library from the sig's library field on entry (#2340), and the auto-link
-// in `getRuntimeFn` / `emitRuntimeCallDirect` covers downstream paths whose
-// runtime symbols carry a `__ry_thread_*` / `__ry_lock_*` / etc. prefix
-// (#2393). The previous explicit `_.insert("thread")` was redundant with
-// both layers.
-static bool isThreadImported(CodeGen &cg) {
-    const auto &sigs = cg.getNativeFnSigs();
-    return sigs.count("thread::threadSpawn") || sigs.count("thread::lockNew");
-}
+//     `threadSpawn`/`threadJoin` out of the package's dispatch table.
 
 RY_REGISTER_STDLIB_PACKAGE(thread, "share/std/thread/thread.ry", dispatchThread)
 static llvm::Value *dispatchThread(CodeGen &, const CallExpr &) {
-    // #2393: thread_table is empty (see above). Returning nullptr lets the
-    // dispatch chain proceed to `emitGenericNativeCall`, which consumes the
-    // per-overload kOverrides entries for lock / rwlock / semaphore /
-    // barrier. Atomics are handled by `emitBuiltinThread` earlier in
-    // `emitExprVariant`'s Pattern B chain.
+    // #2393: thread sync primitives are consumed by the descriptor-driven
+    // path (`emitGenericNativeCall` with the `kOverrides` entries for lock /
+    // rwlock / semaphore / barrier). Atomics remain Pattern B carve-outs
+    // and are handled by `emitBuiltinThread` earlier in `emitExprVariant`'s
+    // chain. Returning nullptr here lets the dispatch chain fall through.
     return nullptr;
 }
 


### PR DESCRIPTION
## Summary
- Remove the empty `thread_table[]` and unused `isThreadImported` helper from `src/codegen_call_thread.cpp` so the descriptor-driven path stands on its own; `dispatchThread`'s comment now documents the current sync-primitives-via-descriptor / atomics-via-Pattern-B split without referencing the removed table.
- Add an explicit `ReturnWrapping::ResourceFree` arm with `llvm_unreachable` to the inner switch in `emitGenericNativeCall::emitCallAndWrap` (the early return at the top of the function still owns the only reachable path — no `default:` arm, so future enum additions stay covered).
- Update the `ResourceFree` enum doc in `include/ry/codegen_native_dispatch.hpp` to list only the four descriptor-driven entries (`lockFree` / `rwlockFree` / `semaphoreFree` / `barrierFree`) and note that `atomicIntFree` / `atomicBoolFree` stay Pattern B carve-outs.

Closes #2444

## Test plan
- [x] `cmake --build build-rust` — zero warnings from the touched files (verified after a full 74/74 rebuild)
- [x] `./build-rust/ry_tests --gtest_filter='NativeCallDescriptor.*:CodeGen*Thread*:CodeGen*Native*'` — 41 passed (covers `Override_LockFreeIsResourceFree`)
- [x] `./build-rust/ry test tests/spec/thread.test.ry` — 31 passed
- [x] `./.claude/skills/pre-commit-checklist/run-tests.sh` — 221 files, 0 failures
- [x] `./.claude/skills/pre-commit-checklist/run-asan.sh` — 221 files, 0 failures
- [x] `./.claude/skills/pre-commit-checklist/run-static-analysis-all.sh` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how certain return-value wrapping paths are handled, including which cases are excluded.
* **Bug Fixes**
  * Improved native dispatch handling so special return cases follow the correct path consistently.
* **Refactor**
  * Simplified thread dispatch logic by removing redundant checks and streamlining fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->