### PR TITLE
refactor(emit): centralize Rust ABI guard and type-handle plumbing

### DIFF
--- a/crates/emit/src/abi.rs
+++ b/crates/emit/src/abi.rs
@@ -15,7 +15,7 @@ use std::ffi::{c_char, c_int, c_void};
 
 use llvm_sys::prelude::*;
 
-use crate::context::{EmitCtx, ValueRef};
+use crate::context::{EmitCtx, TypeRef, ValueRef};
 
 // Per-op C boundary entry points live in child modules (one per migrated op),
 // each calling the matching `core` engine method on `EmitCtx`. The cdylib
@@ -604,14 +604,19 @@ pub(crate) unsafe fn resolve(c: &EmitCtx, id: RyValueId) -> RyValueRef {
 }
 
 // =============================================================
-// Shared boundary input-validation helpers (#2080). Every IR-emitting entry
-// point converts malformed input to its sentinel rather than passing an unvetted
-// handle to the `core` engine (which forwards it straight to the LLVM C API). The
-// ctx + handle validation lives in `ctx_access::checked_cx` above (co-located
-// with the confined reify it builds on, #2081); the two helpers below fold the
-// remaining per-op inline guard sequences that runtime_call / result / any / cow
-// each spelled out — required-id resolution and FFI-array borrow — into one
-// shared contract so the guard policy is uniform across the boundary.
+// Shared boundary input-validation helpers (#2080, #2445). Every IR-emitting
+// entry point converts malformed input to its sentinel rather than passing an
+// unvetted handle to the `core` engine (which forwards it straight to the LLVM
+// C API). The ctx + handle validation lives in `ctx_access::checked_cx` above
+// (co-located with the confined reify it builds on, #2081); the helpers below
+// fold the remaining per-op inline guard sequences — required value-id
+// resolution (runtime_call / result), required type-handle conversion (option
+// / reduce / primitive, the pilot of #2445), the NULL `name` → empty-CString
+// fallback (primitive's previously-local `name_or_empty`), and FFI-array
+// borrow (runtime_call / control_flow) — into one shared contract so the
+// guard policy is uniform across the boundary. Per-module `opt_*` /
+// `*_kind_from` selectors (any / cow / bounds) stay local until a follow-up
+// pass extends the helper set.
 // =============================================================
 
 // Resolve a value id to `Some(ValueRef)`, or `None` when it resolves to NULL
@@ -627,6 +632,35 @@ pub(crate) unsafe fn resolve_value(c: &EmitCtx, id: RyValueId) -> Option<ValueRe
         None
     } else {
         Some(ValueRef(v))
+    }
+}
+
+// Convert a boundary `RyTypeRef` to `Some(TypeRef)`, or `None` on NULL. Mirrors
+// `resolve_value`'s required-vs-optional split: a *required* type handle maps
+// `None` to the entry point's sentinel (`let Some(ty) = req_type(p) else {
+// return 0 }`), while an *optional* one (e.g. the branch-specific `target_ty`
+// in `RyAnyUnwrapDesc`) stores the `Option` directly. Subsumes the per-entry
+// `if ty.is_null() { return 0 } … TypeRef(as_type(ty))` pair the primitive /
+// option / reduce shells repeated for every type field.
+#[inline]
+pub(crate) fn req_type(p: RyTypeRef) -> Option<TypeRef> {
+    if p.is_null() {
+        None
+    } else {
+        Some(TypeRef(as_type(p)))
+    }
+}
+
+// NULL `name` → empty CString pointer. Several `LLVMBuild*` entries treat their
+// SSA-name argument as optional at the C boundary (api.h spells it `NULL → ""`);
+// the engine forwards the pointer verbatim to LLVM, so the abi shell substitutes
+// the empty CString once here instead of every op re-spelling the ternary.
+#[inline]
+pub(crate) fn name_or_empty(name: *const c_char) -> *const c_char {
+    if name.is_null() {
+        c"".as_ptr()
+    } else {
+        name
     }
 }
 

--- a/crates/emit/src/abi/option.rs
+++ b/crates/emit/src/abi/option.rs
@@ -2,8 +2,6 @@
 //! value id / translate the opaque type handle, call the `core` `EmitCtx`
 //! method, and intern the produced aggregate (intern / resolve are abi-side).
 
-use crate::context::TypeRef;
-
 use super::*;
 
 /// Wrap the interned `inner_id` into a `Some` of Option type `opt_ty`; return the
@@ -19,13 +17,13 @@ pub unsafe extern "C" fn ry_emit_option_wrap_some(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if opt_ty.is_null() {
+    let Some(opt) = req_type(opt_ty) else {
         return 0;
-    }
+    };
     let Some(inner) = resolve_value(c, inner_id) else {
         return 0;
     };
-    let val = c.option_wrap_some(inner, TypeRef(as_type(opt_ty)));
+    let val = c.option_wrap_some(inner, opt);
     intern(c, to_ry_value(val.0))
 }
 
@@ -40,9 +38,9 @@ pub unsafe extern "C" fn ry_emit_option_wrap_none(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if opt_ty.is_null() {
+    let Some(opt) = req_type(opt_ty) else {
         return 0;
-    }
-    let val = c.option_wrap_none(TypeRef(as_type(opt_ty)));
+    };
+    let val = c.option_wrap_none(opt);
     intern(c, to_ry_value(val.0))
 }

--- a/crates/emit/src/abi/primitive.rs
+++ b/crates/emit/src/abi/primitive.rs
@@ -9,7 +9,7 @@
 
 use std::ffi::{c_char, c_int};
 
-use crate::context::{AtomicBinOp, AtomicOrdering, IcmpPred, TypeRef};
+use crate::context::{AtomicBinOp, AtomicOrdering, IcmpPred};
 
 use super::*;
 
@@ -43,16 +43,6 @@ fn icmp_pred_from(p: c_int) -> Option<IcmpPred> {
         Some(IcmpPred::Uge)
     } else {
         None
-    }
-}
-
-// NUL name pointer → empty-string default (mirrors abi/control_flow.rs).
-#[inline]
-unsafe fn name_or_empty(name: *const c_char) -> *const c_char {
-    if name.is_null() {
-        c"".as_ptr()
-    } else {
-        name
     }
 }
 
@@ -101,10 +91,10 @@ pub unsafe extern "C" fn ry_emit_alloca(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if ty.is_null() {
+    let Some(t) = req_type(ty) else {
         return 0;
-    }
-    let v = c.build_alloca(TypeRef(as_type(ty)), name_or_empty(name));
+    };
+    let v = c.build_alloca(t, name_or_empty(name));
     intern(c, to_ry_value(v.0))
 }
 
@@ -119,13 +109,13 @@ pub unsafe extern "C" fn ry_emit_load(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if ty.is_null() {
+    let Some(t) = req_type(ty) else {
         return 0;
-    }
+    };
     let Some(ptr) = resolve_value(c, ptr_id) else {
         return 0;
     };
-    let v = c.build_load(TypeRef(as_type(ty)), ptr, name_or_empty(name));
+    let v = c.build_load(t, ptr, name_or_empty(name));
     intern(c, to_ry_value(v.0))
 }
 
@@ -185,14 +175,14 @@ pub unsafe extern "C" fn ry_emit_atomic_load(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if ty.is_null() {
+    let Some(t) = req_type(ty) else {
         return 0;
-    }
+    };
     let Some(ptr) = resolve_value(c, ptr_id) else {
         return 0;
     };
     let v = c.build_atomic_load(
-        TypeRef(as_type(ty)),
+        t,
         ptr,
         atomic_ordering_from(ordering),
         alignment,
@@ -248,13 +238,13 @@ pub unsafe extern "C" fn ry_emit_gep(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if base_ty.is_null() {
+    let Some(base) = req_type(base_ty) else {
         return 0;
-    }
+    };
     let (Some(ptr), Some(idx)) = (resolve_value(c, ptr_id), resolve_value(c, idx_id)) else {
         return 0;
     };
-    let v = c.build_gep(TypeRef(as_type(base_ty)), ptr, idx, name_or_empty(name));
+    let v = c.build_gep(base, ptr, idx, name_or_empty(name));
     intern(c, to_ry_value(v.0))
 }
 
@@ -272,18 +262,13 @@ pub unsafe extern "C" fn ry_emit_struct_gep(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if struct_ty.is_null() {
+    let Some(st) = req_type(struct_ty) else {
         return 0;
-    }
+    };
     let Some(ptr) = resolve_value(c, ptr_id) else {
         return 0;
     };
-    let v = c.build_struct_gep(
-        TypeRef(as_type(struct_ty)),
-        ptr,
-        field_idx,
-        name_or_empty(name),
-    );
+    let v = c.build_struct_gep(st, ptr, field_idx, name_or_empty(name));
     intern(c, to_ry_value(v.0))
 }
 
@@ -302,13 +287,13 @@ pub unsafe extern "C" fn ry_emit_array_gep(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if array_ty.is_null() {
+    let Some(arr) = req_type(array_ty) else {
         return 0;
-    }
+    };
     let (Some(base), Some(idx)) = (resolve_value(c, base_id), resolve_value(c, idx_id)) else {
         return 0;
     };
-    let v = c.build_array_gep(TypeRef(as_type(array_ty)), base, idx, name_or_empty(name));
+    let v = c.build_array_gep(arr, base, idx, name_or_empty(name));
     intern(c, to_ry_value(v.0))
 }
 
@@ -371,13 +356,13 @@ pub unsafe extern "C" fn ry_emit_zext(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if dest_ty.is_null() {
+    let Some(dest) = req_type(dest_ty) else {
         return 0;
-    }
+    };
     let Some(val) = resolve_value(c, val_id) else {
         return 0;
     };
-    let v = c.build_zext(val, TypeRef(as_type(dest_ty)), name_or_empty(name));
+    let v = c.build_zext(val, dest, name_or_empty(name));
     intern(c, to_ry_value(v.0))
 }
 
@@ -397,13 +382,13 @@ pub unsafe extern "C" fn ry_emit_trunc(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if dest_ty.is_null() {
+    let Some(dest) = req_type(dest_ty) else {
         return 0;
-    }
+    };
     let Some(val) = resolve_value(c, val_id) else {
         return 0;
     };
-    let v = c.build_trunc(val, TypeRef(as_type(dest_ty)), name_or_empty(name));
+    let v = c.build_trunc(val, dest, name_or_empty(name));
     intern(c, to_ry_value(v.0))
 }
 
@@ -423,13 +408,13 @@ pub unsafe extern "C" fn ry_emit_sext(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if dest_ty.is_null() {
+    let Some(dest) = req_type(dest_ty) else {
         return 0;
-    }
+    };
     let Some(val) = resolve_value(c, val_id) else {
         return 0;
     };
-    let v = c.build_sext(val, TypeRef(as_type(dest_ty)), name_or_empty(name));
+    let v = c.build_sext(val, dest, name_or_empty(name));
     intern(c, to_ry_value(v.0))
 }
 
@@ -619,10 +604,10 @@ pub unsafe extern "C" fn ry_emit_const_int(
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if ty.is_null() {
+    let Some(t) = req_type(ty) else {
         return 0;
-    }
-    let v = c.const_int(TypeRef(as_type(ty)), value, sign_extend != 0);
+    };
+    let v = c.const_int(t, value, sign_extend != 0);
     intern(c, to_ry_value(v.0))
 }
 
@@ -634,10 +619,10 @@ pub unsafe extern "C" fn ry_emit_const_null(ctx: *mut RyEmitCtx, ty: RyTypeRef) 
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if ty.is_null() {
+    let Some(t) = req_type(ty) else {
         return 0;
-    }
-    let v = c.const_null(TypeRef(as_type(ty)));
+    };
+    let v = c.const_null(t);
     intern(c, to_ry_value(v.0))
 }
 
@@ -650,9 +635,9 @@ pub unsafe extern "C" fn ry_emit_undef(ctx: *mut RyEmitCtx, ty: RyTypeRef) -> Ry
     let Some(c) = checked_cx(ctx) else {
         return 0;
     };
-    if ty.is_null() {
+    let Some(t) = req_type(ty) else {
         return 0;
-    }
-    let v = c.build_undef(TypeRef(as_type(ty)));
+    };
+    let v = c.build_undef(t);
     intern(c, to_ry_value(v.0))
 }

--- a/crates/emit/src/abi/reduce.rs
+++ b/crates/emit/src/abi/reduce.rs
@@ -17,8 +17,6 @@
 
 use std::ffi::c_int;
 
-use crate::context::TypeRef;
-
 use super::*;
 
 /// `sum([..])`: emit the list-sum loop over the List at `list_ptr_id`; return the
@@ -37,14 +35,10 @@ pub unsafe extern "C" fn ry_emit_reduce_sum_list(
     let Some(list_ptr) = resolve_value(c, list_ptr_id) else {
         return 0;
     };
-    if elem_ty.is_null() || list_header_ty.is_null() {
+    let (Some(elem), Some(header)) = (req_type(elem_ty), req_type(list_header_ty)) else {
         return 0;
-    }
-    let result = c.reduce_sum_list(
-        list_ptr,
-        TypeRef(as_type(elem_ty)),
-        TypeRef(as_type(list_header_ty)),
-    );
+    };
+    let result = c.reduce_sum_list(list_ptr, elem, header);
     intern(c, to_ry_value(result.0))
 }
 
@@ -63,10 +57,10 @@ pub unsafe extern "C" fn ry_emit_reduce_sum_step(
     let (Some(acc), Some(v)) = (resolve_value(c, acc_id), resolve_value(c, val_id)) else {
         return 0;
     };
-    if elem_ty.is_null() {
+    let Some(elem) = req_type(elem_ty) else {
         return 0;
-    }
-    let result = c.reduce_sum_step(acc, v, TypeRef(as_type(elem_ty)));
+    };
+    let result = c.reduce_sum_step(acc, v, elem);
     intern(c, to_ry_value(result.0))
 }
 
@@ -88,10 +82,10 @@ pub unsafe extern "C" fn ry_emit_reduce_minmax_list_loop(
     let (Some(data), Some(len)) = (resolve_value(c, data_id), resolve_value(c, len_id)) else {
         return 0;
     };
-    if elem_ty.is_null() {
+    let Some(elem) = req_type(elem_ty) else {
         return 0;
-    }
-    let result = c.reduce_minmax_list_loop(data, len, TypeRef(as_type(elem_ty)), is_max != 0);
+    };
+    let result = c.reduce_minmax_list_loop(data, len, elem, is_max != 0);
     intern(c, to_ry_value(result.0))
 }
 
@@ -112,9 +106,9 @@ pub unsafe extern "C" fn ry_emit_reduce_minmax_step(
     let (Some(best), Some(v)) = (resolve_value(c, best_id), resolve_value(c, val_id)) else {
         return 0;
     };
-    if elem_ty.is_null() {
+    let Some(elem) = req_type(elem_ty) else {
         return 0;
-    }
-    let result = c.reduce_minmax_step(best, v, TypeRef(as_type(elem_ty)), is_max != 0);
+    };
+    let result = c.reduce_minmax_step(best, v, elem, is_max != 0);
     intern(c, to_ry_value(result.0))
 }

--- a/crates/emit/src/primitive/util.rs
+++ b/crates/emit/src/primitive/util.rs
@@ -3,15 +3,31 @@
 
 use std::ffi::{c_char, CStr, CString};
 
-// Wrap a byte vector as a `CString`. Inputs must not contain interior NUL
-// bytes; otherwise the `CString::new(...).unwrap()` panic unwinds across the
-// `unsafe extern "C" fn` boundary (UB). All callers (`cname_*`) uphold this
-// structurally — inputs are static literals or `cstr_bytes` returns
-// (NUL-stripped by construction).
+// Wrap a byte vector as a `CString`. The structural invariant — `cname_*`
+// callers feed only static literals or `cstr_bytes` returns (NUL-stripped by
+// construction) — means a clean caller never has an interior NUL. The debug
+// assertion still signals an upstream bug if one slips in; the build path
+// itself goes through `cstring_lossy`, which strips any NUL defensively so the
+// boundary is panic-impossible (the previous `CString::new(v).unwrap()` would
+// have unwound across the `unsafe extern "C" fn` boundary on a future
+// invariant violation, which is UB).
 #[inline]
 fn make_cstring(v: Vec<u8>) -> CString {
     debug_assert!(!v.contains(&0), "interior NUL in cname input");
-    CString::new(v).unwrap()
+    cstring_lossy(v)
+}
+
+// Infallible CString construction: strip any interior NUL byte and wrap the
+// remainder via `from_vec_unchecked`. Separated from `make_cstring` so the
+// panic-impossible path is testable without the debug assertion firing first,
+// satisfying #2445's "infallible path that cannot unwind across an extern \"C\"
+// call" requirement.
+#[inline]
+fn cstring_lossy(mut v: Vec<u8>) -> CString {
+    v.retain(|&b| b != 0);
+    // SAFETY: the `retain` above guarantees `v` contains no interior NUL byte,
+    // satisfying `CString::from_vec_unchecked`'s precondition.
+    unsafe { CString::from_vec_unchecked(v) }
 }
 
 // Build a NUL-terminated CString name from a prefix + suffix (for SSA names
@@ -44,5 +60,44 @@ pub(crate) unsafe fn cstr_bytes<'a>(p: *const c_char) -> &'a [u8] {
         b""
     } else {
         CStr::from_ptr(p).to_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cname3, cname_pfx, cstring_lossy};
+
+    // Clean-input parity: the public cname builders must round-trip prefix /
+    // suffix byte slices into a NUL-terminated CString verbatim. Locks the
+    // happy-path behavior the composite emitters (cow / bounds / cast /
+    // header) depend on for SSA-name shaping.
+    #[test]
+    fn cname_pfx_concatenates_clean_inputs() {
+        assert_eq!(
+            cname_pfx(b"prefix", b"_suffix").to_bytes(),
+            b"prefix_suffix"
+        );
+    }
+
+    #[test]
+    fn cname3_concatenates_three_clean_inputs() {
+        assert_eq!(cname3(b"a_", b"b", b"_c").to_bytes(), b"a_b_c");
+    }
+
+    // Panic-impossible safeguard: if a future `cname_*` caller violates the
+    // structural NUL-free invariant, the build path must still return a
+    // well-formed `CString` — NEVER panic across the `unsafe extern "C" fn`
+    // boundary (the previous `CString::new(v).unwrap()` would have unwound,
+    // which is UB). Testing `cstring_lossy` directly bypasses the debug
+    // assertion in `make_cstring` so the safety net is exercised in the
+    // default debug profile too. Locks the AC for #2445.
+    #[test]
+    fn cstring_lossy_strips_interior_nul() {
+        assert_eq!(cstring_lossy(b"abc\0def\0".to_vec()).to_bytes(), b"abcdef");
+    }
+
+    #[test]
+    fn cstring_lossy_passes_clean_input_through_verbatim() {
+        assert_eq!(cstring_lossy(b"hello".to_vec()).to_bytes(), b"hello");
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `req_type` (mandatory `RyTypeRef → Option<TypeRef>`) and surface `name_or_empty` as shared abi-layer helpers in `crates/emit/src/abi.rs`.
- Migrate `abi/option.rs` (2 entries), `abi/reduce.rs` (4 entries), and `abi/primitive.rs` (12 entries) to the new helpers, removing the local `name_or_empty` from primitive; guard order preserved at every site.
- Make `primitive::util::make_cstring` panic-impossible across the `extern "C"` boundary by routing through `cstring_lossy` (NUL-strip + `from_vec_unchecked`), with a debug profile test that exercises the safeguard.

Pilot scope of #2445; the remaining proposal items (descriptor-borrow helper, optional-type, `Option<ValueRef> → RyValueId` interning, parallel-array resolution over any/cow/runtime_call/function/collection) are deferred to a follow-up pass.

Closes #2445

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --lib` (4 tests, including the `cstring_lossy` safeguard)
- [x] `cmake --build build-rust`
- [x] `./build-rust/ry_tests --gtest_filter='AbiLayout.*:EmitAbiGuardTest.*:EmitLlvmIrTest.*:CodeGenTest.*'` — 1262 tests passed, confirming IR byte-exactness
- [x] `./build-rust/ry_tests` — 3091 tests passed
- [x] `./build-rust/ry test -p` — 221 spec test files passed
- [x] ASan+UBSan run
- [x] `scripts/check-emit-abi-no-ir.sh`, `check-emit-composite-no-primitive.sh`, `check-emit-llvm-ir-gen-concentration.sh`, `check-examples.sh` (102/102)