### PR TITLE
feat(self-update): block downgrade to v0.0.29 and earlier

### DIFF
--- a/changelog.d/2457-self-update-block-legacy-downgrade.md
+++ b/changelog.d/2457-self-update-block-legacy-downgrade.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `ry self-update v0.0.29` (および v0.0.29 以下のすべてのバージョン) を refuse するようガードを追加。これらのバージョンの `install_native_libs` filter は `libemit` / `liblower` / `libLLVM` / `libzstd` を install しないため、ダウングレード後の forward `ry self-update` で新 binary が必要とする lib が install されず、binary が起動不能になる (libLLVM 不在による dyld error 報告と同型の症状)。`resolve_update_target` で `requested_tag` の major/minor/patch を semver parser (先頭 `v` / leading zero / pre-release suffix / 4-segment suffix を許容、`-` / `+` を先頭 digit guard で reject) に通し、`<= v0.0.29` ならエラー終了する。緊急回避用に `RY_ALLOW_LEGACY_DOWNGRADE=1` (sticker-shock warning 付きで通る) と `RY_UPDATE_REPO != t0k0sh1/ry` (fork CI 用に guard skip) の escape hatch を用意。`v0.0.30` 以降は従来通り、`ry self-update` 引数なしも常に最新 stable を引くので影響なし。 (#2457)

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -221,6 +221,14 @@ ry self-update v0.0.1       # Update to a specified version
 3. If the current version is the same, exits with `"Already up to date."`
 4. Downloads the binary and replaces the current executable
 
+### Downgrade Limits
+
+`v0.0.29` and earlier shipped an `install_native_libs` filter that does not install `libemit` / `liblower` / `libLLVM` / `libzstd`. After downgrading to those versions, a subsequent forward `ry self-update` would not lay down the libs the new binary needs and the binary would fail to start. To prevent that lock-out:
+
+- `ry self-update v0.0.29` (or any earlier version) exits with an error and leaves the existing binary untouched.
+- `ry self-update v0.0.30` and later proceed normally.
+- If a downgrade to a pre-v0.0.30 release is unavoidable, set `RY_ALLOW_LEGACY_DOWNGRADE=1` to opt in. A warning is printed and the update proceeds; use `ry-rescue` to recover if the binary stops starting after a later forward update.
+
 ### Security
 
 Release archives are verified in two steps:

--- a/include/ry/cli/self_update.hpp
+++ b/include/ry/cli/self_update.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
@@ -18,6 +19,43 @@ struct UpdateTarget {
 bool is_valid_tag(const std::string &tag);
 
 namespace detail {
+
+struct Semver {
+    uint64_t major;
+    uint64_t minor;
+    uint64_t patch;
+
+    bool operator<=(const Semver &other) const {
+        if (major != other.major) return major < other.major;
+        if (minor != other.minor) return minor < other.minor;
+        return patch <= other.patch;
+    }
+};
+
+// Parse major.minor.patch from a tag string. Tolerates an optional leading
+// 'v', leading zeros, and any trailing pre-release / build / extra-segment
+// suffix (e.g. "v0.0.29-rc.1", "v0.0.29.1"); only the first three numeric
+// components are inspected. Returns nullopt for malformed input.
+std::optional<Semver> parse_semver(const std::string &tag);
+
+// True iff `tag` parses to a version <= v0.0.29. Those releases predate
+// the libemit / liblower / libLLVM / libzstd entries in install_native_libs,
+// so a later forward jump after downgrading to them leaves the binary
+// unable to resolve its bundled libs.
+bool is_legacy_downgrade_target(const std::string &tag);
+
+enum class DowngradeGuardResult {
+    Allowed,             // Tag is not legacy, or repo is a fork
+    AllowedWithWarning,  // Legacy tag, but RY_ALLOW_LEGACY_DOWNGRADE=1 opted in
+    Blocked,             // Legacy tag, no escape hatch — refuse update
+};
+
+// Pure policy used by resolve_update_target. Kept side-effect-free so the
+// full branch matrix can be tested without env mutation or network.
+DowngradeGuardResult check_downgrade_guard(
+    const std::string &tag,
+    const std::string &repo,
+    bool allow_legacy_env_set);
 
 PlatformInfo detect_platform();
 std::string get_executable_path();

--- a/src/cli/self_update.cpp
+++ b/src/cli/self_update.cpp
@@ -66,6 +66,58 @@ bool is_valid_tag(const std::string &tag) {
 
 namespace detail {
 
+std::optional<Semver> parse_semver(const std::string &tag) {
+    const char *p = tag.c_str();
+    const char *end = p + tag.size();
+
+    if (p < end && (*p == 'v' || *p == 'V')) ++p;
+
+    auto parse_uint = [&](uint64_t &out) -> bool {
+        // Require a leading decimal digit. strtoull would otherwise silently
+        // accept '+' / '-' / whitespace and yield garbage for tags like
+        // "v-1.0.0" (which is_valid_tag's [0-9A-Za-z._-]+ permits).
+        if (p >= end || *p < '0' || *p > '9') return false;
+        char *eptr = nullptr;
+        errno = 0;
+        out = std::strtoull(p, &eptr, 10);
+        if (errno == ERANGE) return false;
+        if (eptr == p) return false;
+        p = eptr;
+        return true;
+    };
+
+    Semver v{};
+    if (!parse_uint(v.major)) return std::nullopt;
+    if (p >= end || *p != '.') return std::nullopt;
+    ++p;
+    if (!parse_uint(v.minor)) return std::nullopt;
+    if (p >= end || *p != '.') return std::nullopt;
+    ++p;
+    if (!parse_uint(v.patch)) return std::nullopt;
+    // Anything after patch (pre-release, build metadata, 4-part suffix) is
+    // tolerated — only major.minor.patch matters for the legacy guard.
+    return v;
+}
+
+bool is_legacy_downgrade_target(const std::string &tag) {
+    auto v = parse_semver(tag);
+    if (!v) return false;
+    static constexpr Semver LEGACY_CUTOFF{0, 0, 29};
+    return *v <= LEGACY_CUTOFF;
+}
+
+DowngradeGuardResult check_downgrade_guard(
+    const std::string &tag,
+    const std::string &repo,
+    bool allow_legacy_env_set) {
+    // Forks (custom RY_UPDATE_REPO) don't share the upstream install-filter
+    // history, so skip the guard entirely for them (CI test convenience).
+    if (repo != "t0k0sh1/ry") return DowngradeGuardResult::Allowed;
+    if (!is_legacy_downgrade_target(tag)) return DowngradeGuardResult::Allowed;
+    if (allow_legacy_env_set) return DowngradeGuardResult::AllowedWithWarning;
+    return DowngradeGuardResult::Blocked;
+}
+
 PlatformInfo detect_platform() {
     PlatformInfo info;
 #ifdef __APPLE__
@@ -218,6 +270,36 @@ UpdateTarget resolve_update_target(const std::optional<std::string> &tag, const 
         // Caller guarantees the tag is already validated (is_valid_tag) and
         // normalized with the leading "v" prefix.
         const std::string &requested = *tag;
+
+        // Refuse downgrades to releases whose install_native_libs filter
+        // predates libemit / liblower / libLLVM / libzstd (#2457). Without
+        // this guard, the user's next forward `ry self-update` would skip
+        // installing libs the new binary depends on, leaving it unable to
+        // start — same failure mode as the original libLLVM-missing report.
+        const char *allow_env = std::getenv("RY_ALLOW_LEGACY_DOWNGRADE");
+        bool allow_legacy = (allow_env && strcmp(allow_env, "1") == 0);
+        switch (check_downgrade_guard(requested, get_repo(), allow_legacy)) {
+        case DowngradeGuardResult::Blocked:
+            std::cerr << "Error: Version " << requested
+                      << " is not supported as a downgrade target.\n"
+                      << "  v0.0.29 and earlier are forward-incompatible with the current self-update\n"
+                      << "  install logic (libemit / liblower / libLLVM / libzstd are not installed by\n"
+                      << "  those versions' install_native_libs filter).\n"
+                      << "  Supported downgrade range: v0.0.30 or later.\n"
+                      << "  For emergency recovery, use `ry-rescue` (see #2455).\n";
+            return target;
+        case DowngradeGuardResult::AllowedWithWarning:
+            std::cerr << "Warning: RY_ALLOW_LEGACY_DOWNGRADE=1 — proceeding with downgrade to "
+                      << requested << ".\n"
+                      << "  After this, re-running `ry self-update` to come forward may leave the\n"
+                      << "  binary unable to start because the older install_native_libs filter\n"
+                      << "  does not install libemit / liblower / libLLVM / libzstd. Use\n"
+                      << "  `ry-rescue` to recover if that happens.\n";
+            break;
+        case DowngradeGuardResult::Allowed:
+            break;
+        }
+
         std::string url = build_download_url(requested, platform);
         std::string status;
         run_command({CURL_PATH, "-sfL", "-o", "/dev/null", "-w", "%{http_code}", "--head", url}, &status);
@@ -764,7 +846,8 @@ int cmd_self_update(int argc, char *argv[]) {
             std::cerr << "  (no args)    Update to latest stable release\n";
             std::cerr << "  <version>    Update to a specific version (e.g. v0.0.1)\n";
             std::cerr << "\nEnvironment:\n";
-            std::cerr << "  RY_SKIP_SIGNATURE=1  Skip signature verification (unsafe)\n";
+            std::cerr << "  RY_SKIP_SIGNATURE=1         Skip signature verification (unsafe)\n";
+            std::cerr << "  RY_ALLOW_LEGACY_DOWNGRADE=1 Allow downgrade to v0.0.29 or earlier (unsafe)\n";
             std::cerr << "\nEmergency recovery:\n";
             std::cerr << "  If ry fails to start (e.g. missing ~/.ry/lib/libLLVM),\n";
             std::cerr << "  run 'ry-rescue' instead — it is a standalone POSIX shell\n";

--- a/tests/test_self_update.cpp
+++ b/tests/test_self_update.cpp
@@ -735,3 +735,194 @@ TEST(SelfUpdate, SignaturePolicyMissingSignatureSkipAllowed) {
     auto action = evaluate_signature_policy(false, false, true);
     EXPECT_EQ(action, SignatureAction::SkipAllowed);
 }
+
+// --- Semver parsing tests (#2457) ---
+
+TEST(SelfUpdate, ParseSemverBasic) {
+    auto v = parse_semver("v0.0.29");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->major, 0u);
+    EXPECT_EQ(v->minor, 0u);
+    EXPECT_EQ(v->patch, 29u);
+}
+
+TEST(SelfUpdate, ParseSemverWithoutVPrefix) {
+    auto v = parse_semver("0.0.30");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->major, 0u);
+    EXPECT_EQ(v->minor, 0u);
+    EXPECT_EQ(v->patch, 30u);
+}
+
+TEST(SelfUpdate, ParseSemverWithPreRelease) {
+    auto v = parse_semver("v0.0.30-rc.1");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->patch, 30u);
+}
+
+TEST(SelfUpdate, ParseSemverWithBuildMetadata) {
+    auto v = parse_semver("v1.2.3+build.42");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->major, 1u);
+    EXPECT_EQ(v->minor, 2u);
+    EXPECT_EQ(v->patch, 3u);
+}
+
+TEST(SelfUpdate, ParseSemverFourPartTreatedAsThreePart) {
+    // Hypothetical 4-segment hotfix tag: the legacy guard inspects only the
+    // first three numeric components, so an extra ".1" must not be confused
+    // for the patch.
+    auto v = parse_semver("v0.0.29.1");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->patch, 29u);
+}
+
+TEST(SelfUpdate, ParseSemverLeadingZeros) {
+    auto v = parse_semver("v00.00.29");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->major, 0u);
+    EXPECT_EQ(v->minor, 0u);
+    EXPECT_EQ(v->patch, 29u);
+}
+
+TEST(SelfUpdate, ParseSemverRejectsEmpty) {
+    EXPECT_FALSE(parse_semver("").has_value());
+    EXPECT_FALSE(parse_semver("v").has_value());
+}
+
+TEST(SelfUpdate, ParseSemverRejectsMissingSegments) {
+    EXPECT_FALSE(parse_semver("v0").has_value());
+    EXPECT_FALSE(parse_semver("v0.1").has_value());
+}
+
+TEST(SelfUpdate, ParseSemverRejectsNonDigit) {
+    // is_valid_tag's regex permits "-" inside the tag, so verify the
+    // semver parser refuses to swallow a leading sign that strtoull
+    // would otherwise silently accept.
+    EXPECT_FALSE(parse_semver("v-1.0.0").has_value());
+    EXPECT_FALSE(parse_semver("v0.-1.0").has_value());
+    EXPECT_FALSE(parse_semver("not-a-version").has_value());
+}
+
+// --- Legacy downgrade guard policy tests (#2457) ---
+
+TEST(SelfUpdate, IsLegacyDowngradeTargetBlocksThroughV0029) {
+    EXPECT_TRUE(is_legacy_downgrade_target("v0.0.0"));
+    EXPECT_TRUE(is_legacy_downgrade_target("v0.0.1"));
+    EXPECT_TRUE(is_legacy_downgrade_target("v0.0.29"));
+    EXPECT_TRUE(is_legacy_downgrade_target("0.0.29"));
+}
+
+TEST(SelfUpdate, IsLegacyDowngradeTargetAllowsV0030AndLater) {
+    EXPECT_FALSE(is_legacy_downgrade_target("v0.0.30"));
+    EXPECT_FALSE(is_legacy_downgrade_target("v0.0.31"));
+    EXPECT_FALSE(is_legacy_downgrade_target("v0.1.0"));
+    EXPECT_FALSE(is_legacy_downgrade_target("v1.0.0"));
+}
+
+TEST(SelfUpdate, IsLegacyDowngradeTargetTreatsFourPartByFirstThree) {
+    // v0.0.29.1 → major.minor.patch = 0.0.29 → blocked.
+    EXPECT_TRUE(is_legacy_downgrade_target("v0.0.29.1"));
+    // v0.0.0.99 → major.minor.patch = 0.0.0 → blocked.
+    EXPECT_TRUE(is_legacy_downgrade_target("v0.0.0.99"));
+}
+
+TEST(SelfUpdate, IsLegacyDowngradeTargetAcceptsPreReleaseOnAllowedPatch) {
+    EXPECT_FALSE(is_legacy_downgrade_target("v0.0.30-rc.1"));
+}
+
+TEST(SelfUpdate, IsLegacyDowngradeTargetIgnoresUnparseable) {
+    // Unparseable tags fall through — let the URL existence check report
+    // them as "not found" rather than mislabel them as a downgrade attempt.
+    EXPECT_FALSE(is_legacy_downgrade_target("not-a-version"));
+    EXPECT_FALSE(is_legacy_downgrade_target("v"));
+}
+
+TEST(SelfUpdate, CheckDowngradeGuardBlocksLegacyOnCanonicalRepo) {
+    EXPECT_EQ(check_downgrade_guard("v0.0.29", "t0k0sh1/ry", false),
+              DowngradeGuardResult::Blocked);
+    EXPECT_EQ(check_downgrade_guard("v0.0.1", "t0k0sh1/ry", false),
+              DowngradeGuardResult::Blocked);
+}
+
+TEST(SelfUpdate, CheckDowngradeGuardAllowsLegacyWithOptIn) {
+    EXPECT_EQ(check_downgrade_guard("v0.0.29", "t0k0sh1/ry", true),
+              DowngradeGuardResult::AllowedWithWarning);
+}
+
+TEST(SelfUpdate, CheckDowngradeGuardSkipsForForkRepo) {
+    // A fork's tags don't share the upstream install-filter history, so the
+    // guard must not interfere with self-update against a forked release.
+    EXPECT_EQ(check_downgrade_guard("v0.0.29", "fork/ry", false),
+              DowngradeGuardResult::Allowed);
+    EXPECT_EQ(check_downgrade_guard("v0.0.1", "other/fork", false),
+              DowngradeGuardResult::Allowed);
+}
+
+TEST(SelfUpdate, CheckDowngradeGuardAllowsCurrentAndForward) {
+    EXPECT_EQ(check_downgrade_guard("v0.0.30", "t0k0sh1/ry", false),
+              DowngradeGuardResult::Allowed);
+    EXPECT_EQ(check_downgrade_guard("v0.0.31", "t0k0sh1/ry", false),
+              DowngradeGuardResult::Allowed);
+    EXPECT_EQ(check_downgrade_guard("v0.1.0", "t0k0sh1/ry", false),
+              DowngradeGuardResult::Allowed);
+}
+
+// --- resolve_update_target legacy-downgrade integration (#2457) ---
+//
+// The guard must short-circuit before any network call. We isolate RY_UPDATE_REPO
+// and RY_ALLOW_LEGACY_DOWNGRADE so the test result is independent of the
+// developer's shell environment.
+
+class ResolveUpdateTargetLegacyGuardTest : public ::testing::Test {
+protected:
+    std::optional<std::string> saved_repo;
+    std::optional<std::string> saved_allow;
+
+    void SetUp() override {
+        if (const char *env = std::getenv("RY_UPDATE_REPO")) saved_repo = env;
+        if (const char *env = std::getenv("RY_ALLOW_LEGACY_DOWNGRADE")) saved_allow = env;
+        unsetenv("RY_UPDATE_REPO");
+        unsetenv("RY_ALLOW_LEGACY_DOWNGRADE");
+    }
+
+    void TearDown() override {
+        if (saved_repo) setenv("RY_UPDATE_REPO", saved_repo->c_str(), 1);
+        else unsetenv("RY_UPDATE_REPO");
+        if (saved_allow) setenv("RY_ALLOW_LEGACY_DOWNGRADE", saved_allow->c_str(), 1);
+        else unsetenv("RY_ALLOW_LEGACY_DOWNGRADE");
+    }
+};
+
+TEST_F(ResolveUpdateTargetLegacyGuardTest, ReturnsEmptyTargetForV0029) {
+    PlatformInfo p{"linux", "amd64"};
+    testing::internal::CaptureStderr();
+    auto target = resolve_update_target(std::optional<std::string>{"v0.0.29"}, p);
+    std::string err = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(target.tag.empty());
+    EXPECT_TRUE(target.download_url.empty());
+    EXPECT_NE(err.find("not supported as a downgrade target"), std::string::npos);
+    EXPECT_NE(err.find("v0.0.30 or later"), std::string::npos);
+    EXPECT_NE(err.find("ry-rescue"), std::string::npos);
+}
+
+TEST_F(ResolveUpdateTargetLegacyGuardTest, ReturnsEmptyTargetForV001) {
+    PlatformInfo p{"linux", "amd64"};
+    testing::internal::CaptureStderr();
+    auto target = resolve_update_target(std::optional<std::string>{"v0.0.1"}, p);
+    std::string err = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(target.tag.empty());
+    EXPECT_NE(err.find("not supported as a downgrade target"), std::string::npos);
+}
+
+TEST_F(ResolveUpdateTargetLegacyGuardTest, ReturnsEmptyTargetForFourPartLegacyTag) {
+    PlatformInfo p{"linux", "amd64"};
+    testing::internal::CaptureStderr();
+    auto target = resolve_update_target(std::optional<std::string>{"v0.0.29.1"}, p);
+    std::string err = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(target.tag.empty());
+    EXPECT_NE(err.find("not supported as a downgrade target"), std::string::npos);
+}


### PR DESCRIPTION
## Summary

- `ry self-update <tag>` refuses any tag whose major.minor.patch is `<= v0.0.29`. Those releases' `install_native_libs` filter does not lay down `libemit` / `liblower` / `libLLVM` / `libzstd`, so a subsequent forward `ry self-update` from one of them leaves the new binary unable to start.
- Escape hatches: `RY_ALLOW_LEGACY_DOWNGRADE=1` (user opt-in with a warning) and `RY_UPDATE_REPO != t0k0sh1/ry` (fork CI bypass).
- Guard logic split into a pure `check_downgrade_guard(tag, repo, allow_env)` so the full branch matrix is tested without env mutation or network; the mandated `resolve_update_target("v0.0.29", …)` assertion works offline because the guard short-circuits before the curl HEAD check.

## Test plan

- [x] `./build-rust/ry_tests` (3117/3117 pass, 21 new tests for `parse_semver`, `is_legacy_downgrade_target`, `check_downgrade_guard`, and `resolve_update_target` rejection paths).
- [x] ASan + UBSan via `./.claude/skills/pre-commit-checklist/run-asan.sh` — exit 0, 221 test files.
- [x] cppcheck via `./.claude/skills/pre-commit-checklist/run-static-analysis-all.sh` — exit 0.
- [x] Prompt-refs lint — clean.
- [x] Manual CLI: `./build-rust/ry self-update v0.0.29` → exit 1 with the spec error; `RY_ALLOW_LEGACY_DOWNGRADE=1 …` prints the warning and proceeds; `RY_UPDATE_REPO=other/fork …` bypasses the guard and falls through to the normal not-found path.

Closes #2457