### PR TITLE
chore(install): block legacy v0.0.X install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ print(ry.math.PI)          # 3.141592653589793
 curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh
 ```
 
-To specify a particular version (replace `<X.Y.Z>` with a version listed on the [Releases](https://github.com/t0k0sh1/ry/releases) page):
+To specify a particular version (replace `<X.Y.Z>` with a version listed on the [Releases](https://github.com/t0k0sh1/ry/releases) page; **v0.0.30 or later** — earlier release assets were retired in #2458):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh -s v<X.Y.Z>

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -209,7 +209,7 @@ Updates ry itself to the latest version. Downloads a binary from GitHub Releases
 
 ```bash
 ry self-update              # Update to the latest stable version
-ry self-update v0.0.1       # Update to a specified version
+ry self-update v0.0.30      # Update to a specified version (v0.0.30 or later)
 ```
 
 ### Behavior

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,26 @@ OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 case "$ARCH" in arm64|aarch64) ARCH="arm64" ;; x86_64|amd64) ARCH="amd64" ;; esac
 
+# Block install of v0.0.29 and earlier (#2458). Those release assets were
+# retired and the pre-#2005 install_native_libs filter is incompatible with
+# the current shared-libLLVM layout; a successful install would still leave
+# the binary unable to start. Mirrors the ry self-update guard in
+# src/cli/self_update.cpp (#2457). The check is skipped for forks
+# (REPO != t0k0sh1/ry) and via RY_ALLOW_LEGACY_DOWNGRADE=1.
+if [ "$VERSION" != "latest" ] && [ "$REPO" = "t0k0sh1/ry" ] && [ -z "${RY_ALLOW_LEGACY_DOWNGRADE:-}" ]; then
+    case "$VERSION" in
+        v0.0.[1-9]|v0.0.[1-9]-*|v0.0.1[0-9]|v0.0.1[0-9]-*|v0.0.2[0-9]|v0.0.2[0-9]-*)
+            echo "ERROR: ry $VERSION is no longer installable." >&2
+            echo "  v0.0.29 and earlier release assets were retired (#2458)" >&2
+            echo "  and the install layout is incompatible with the current runtime (#2457)." >&2
+            echo "  Use v0.0.30 or later, or omit the version to install the latest stable release:" >&2
+            echo "    curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh" >&2
+            echo "  Override (not recommended; assets are unavailable): RY_ALLOW_LEGACY_DOWNGRADE=1" >&2
+            exit 1
+            ;;
+    esac
+fi
+
 if [ "$VERSION" = "latest" ]; then
   DOWNLOAD_URL="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
     | grep "browser_download_url.*${OS}-${ARCH}.tar.gz\"" \

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ case "$ARCH" in arm64|aarch64) ARCH="arm64" ;; x86_64|amd64) ARCH="amd64" ;; esa
 # the binary unable to start. Mirrors the ry self-update guard in
 # src/cli/self_update.cpp (#2457). The check is skipped for forks
 # (REPO != t0k0sh1/ry) and via RY_ALLOW_LEGACY_DOWNGRADE=1.
-if [ "$VERSION" != "latest" ] && [ "$REPO" = "t0k0sh1/ry" ] && [ -z "${RY_ALLOW_LEGACY_DOWNGRADE:-}" ]; then
+if [ "$VERSION" != "latest" ] && [ "$REPO" = "t0k0sh1/ry" ] && [ "${RY_ALLOW_LEGACY_DOWNGRADE:-}" != "1" ]; then
     case "$VERSION" in
         v0.0.[1-9]|v0.0.[1-9]-*|v0.0.1[0-9]|v0.0.1[0-9]-*|v0.0.2[0-9]|v0.0.2[0-9]-*)
             echo "ERROR: ry $VERSION is no longer installable." >&2


### PR DESCRIPTION
## Summary

- `install.sh` exits early when an explicit `v0.0.1`..`v0.0.29` tag is requested (assets retired in #2458; install layout incompatible with current runtime per #2457).
- Mirrors the `ry self-update` guard in `src/cli/self_update.cpp` and honors the same `RY_ALLOW_LEGACY_DOWNGRADE=1` escape hatch and fork bypass (`REPO != t0k0sh1/ry`).
- Updates `docs/reference/project.md` example and `README.md` minimum-version note to point at v0.0.30 as the floor.

Refs #2458 (asset deletion already executed; "Retired" release-page notes and offsite-backup report remain outstanding).

## Test plan

- [x] `sh -n install.sh`
- [x] `install.sh v0.0.1` / `v0.0.5-rc1` / `v0.0.10` / `v0.0.20` / `v0.0.29` → exit 1 with guidance
- [x] `install.sh v0.0.30` / `v0.0.100` / `v0.1.0` → not blocked (no early-fail path)
- [x] `RY_ALLOW_LEGACY_DOWNGRADE=1 install.sh v0.0.29` → bypassed (proceeds to download, 404 since asset retired)
- [x] `bash .claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation instructions for macOS Apple Silicon, including the minimum supported release version.
  * Updated the self-update example to show a newer supported version.

* **Bug Fixes**
  * Prevented installation of unsupported older release versions when a specific version is requested.
  * Added a clearer error message and guidance to install a supported release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->