### PR TITLE
refactor(codegen): migrate json dispatcher to descriptor-driven

### DIFF
--- a/docs/architecture/native-call-boundary.md
+++ b/docs/architecture/native-call-boundary.md
@@ -32,6 +32,9 @@ Current descriptor fields are conceptually:
 | `handle_param_index` / `handle_resource_kind` | resource parameter validation and dispatch disambiguation |
 | `nul_checks` | ordered NUL-safety checks before the call |
 | `iterator_elem_type_name` | element type for iterator-returning natives |
+| `any_by_ptr_param_index` / `any_by_ptr_alloca_hint` | `any`-typed param slots whose C ABI takes `const RyAny *`; descriptor consumer wraps to `any` (if needed), alloca + store, and substitutes the pointer. The hint preserves the pre-migration alloca SSA name byte-exactly. |
+| `synthetic_trailing_i64` | optional trailing `i64` constant injected after the Ry args; covers the "2-arg overload routes to the same C symbol as 3-arg with a default sentinel" pattern (e.g. `json::dump` injecting `indent = -1`) |
+| `call_name_hint` | SSA name hint for the runtime call result, used verbatim when set and `e.callee` otherwise; reproduces pre-migration call names such as `lockAcquire_status` or `json_dump_status` byte-exactly |
 | `mockable` | whether test mock/spy dispatch can intercept the call |
 | `overload_group_id` | grouping for multi-arity overload families |
 
@@ -54,9 +57,12 @@ A call is descriptor-driven when the runtime symbol and wrapping policy are mech
 The following stay outside the descriptor:
 
 - compiler builtins with name-keyed dispatch
-- type-driven dispatch such as numeric `math::abs`, polymorphic JSON stringify, or thread thunk synthesis
+- type-driven dispatch such as numeric `math::abs`, polymorphic JSON `stringify` / `stringifySafe`, or thread thunk synthesis
 - first-class native thunk metadata; thunks consume descriptors but are not descriptor fields
 - hand-written emitters that synthesize control flow, such as 3+-arg HTTP `listen`
+- parametric callees such as `json::load[T]` whose runtime symbol depends on a type argument parsed from the callee string
+
+Functions that previously sat in the "hand-written emitter" group have been migrated to the descriptor path as the needed capabilities were added; `json::dump` joined in #2481 via `any_by_ptr_*` and `synthetic_trailing_i64`. `json5::dump` is tracked in #2482 and reuses the same fields.
 
 These exceptions are compiler builtins or custom lowering paths, not runtime ABI exceptions.
 

--- a/include/ry/native_call_descriptor.hpp
+++ b/include/ry/native_call_descriptor.hpp
@@ -81,6 +81,31 @@ struct NativeCallDescriptor {
     std::string exported_symbol;
     std::vector<NativeNulCheckSpec> nul_checks;
     std::string iterator_elem_type_name;
+
+    // #2481: per-overload "wrap an `any`-typed param slot as
+    // (wrapInAny? + alloca + store -> ptr)" — required by json::dump
+    // (and json5::dump, #2482) whose C ABI takes `const RyAny *`.
+    // `any_by_ptr_param_index` is the 0-based arg index (-1 = none).
+    // `any_by_ptr_alloca_hint` is the SSA name hint for the alloca
+    // (empty -> derive `<callee>_any_in`); set explicitly for byte-
+    // exact IR preservation under migration.
+    int any_by_ptr_param_index = -1;
+    std::string any_by_ptr_alloca_hint;
+
+    // #2481: append a synthetic trailing `i64` constant to the C call
+    // when the C ABI takes more args than the Ry declaration. Used by
+    // json::dump's 2-arg overload to inject `indent = -1` so both
+    // overloads route to a single `__ry_json_dump_file(ptr, ptr, i64)`
+    // symbol. Empty `optional` = no injection.
+    std::optional<int64_t> synthetic_trailing_i64;
+
+    // #2481: SSA name hint for the runtime-call result. The pre-migration
+    // emitters (thread sync ops, json::dump) named their `i64 status` call
+    // with package- or overload-specific forms (e.g. `lockAcquire_status`,
+    // `json_dump_status`); the descriptor-driven path uses this hint
+    // verbatim so byte-exact IR is preserved under migration. Empty -> use
+    // `e.callee` (the existing default for all other entries).
+    std::string call_name_hint;
 };
 
 // inferLibraryName: derives the descriptor's library_name from the
@@ -157,6 +182,12 @@ struct NativeOverloadOverride {
     std::string iterator_elem_type_name;
     CodeGenReturnWrapping wrapping_override = CodeGenReturnWrapping::Direct;
     bool wrapping_overridden = false;
+
+    // #2481: see NativeCallDescriptor for semantics.
+    int any_by_ptr_param_index = -1;
+    std::string any_by_ptr_alloca_hint;
+    std::optional<int64_t> synthetic_trailing_i64;
+    std::string call_name_hint;
 };
 
 // lookupNativeOverloadOverride: returns the override entry matching

--- a/src/codegen_call_json.cpp
+++ b/src/codegen_call_json.cpp
@@ -143,16 +143,27 @@ static llvm::Value *emitJsonLoad(CodeGen &cg, const CallExpr &e,
 // `ResultStatus` wrapping — together reproducing the former custom emitter's
 // IR byte-exactly.
 
-// Gate the dispatcher: only proceed if any json symbol is actually
-// registered in `native_fn_sigs_`. Without this, json would race with
-// the json5 dispatcher (#1855) over the `load<T>` interceptor — both
-// claim every `load<T>` call regardless of which package the user imported
-// from, and alphabetical ordering would put json first, routing
+// Gate the dispatcher: only proceed if some json symbol is registered
+// in `native_fn_sigs_`. After #2481, `dispatchJson` owns only the
+// `load<T>` parametric interceptor and the bare-`load` friendly error
+// (`dump` / `stringify` / `stringifySafe` route through the descriptor
+// or Pattern-B paths), so the gate's purpose is to claim `load<T>` only
+// when the json module is loaded — without it, json would race with the
+// json5 dispatcher (#1855) over `load<T>`: both claim every `load<T>`
+// call regardless of which package the user imported from, and
+// alphabetical ordering would put json first, routing
 // `from json5 import load; load[T](...)` to `__ry_json_parse_to_any`.
-// The check is a per-package sig-presence gate; after #2481 `dump` is
-// handled by `emitGenericNativeCall` whose own sig lookup gates on the
-// same set, so the only path through `dispatchJson` that still needs an
-// explicit gate is the `load<T>` interceptor above.
+//
+// Why check four symbols rather than just `json::load`: the `load<T>`
+// declaration is a generic template (`fn load<T>(...)` in json.ry), and
+// generic templates short-circuit in codegen_fn.cpp (~line 637) before
+// the native-sig registration at line 698. So `"json::load"` is never
+// in `native_fn_sigs_`, and a narrow `count("json::load")` check would
+// always return false and break `load[T](...)` dispatch even when the
+// user imported `load` from json. The non-generic siblings (`dump`,
+// `stringify`, `stringifySafe`) act as module-presence proxies because
+// importing any symbol from `ry.json` processes the whole module and
+// registers those non-generic declarations.
 static bool isJsonImported(CodeGen &cg) {
     const auto &sigs = cg.getNativeFnSigs();
     return sigs.count("json::load") || sigs.count("json::stringify")

--- a/src/codegen_call_json.cpp
+++ b/src/codegen_call_json.cpp
@@ -129,55 +129,19 @@ static llvm::Value *emitJsonLoad(CodeGen &cg, const CallExpr &e,
     return result;
 }
 
-// dump(f: File, value: any) -> Result<Unit, Error>           (#1854)
-// dump(f: File, value: any, indent: int) -> Result<Unit, Error>
-//
-// Routes through __ry_json_dump_file in runtime_json.cpp, which serializes the
-// value via __ry_json_stringify_any and writes the buffer to the file via
-// __ry_io_file_write_text.  ARC release of the intermediate Ry string lives in
-// the C runtime so the codegen IR stays a single status-returning call.
-static llvm::Value *emitJsonDumpFile(CodeGen &cg, const CallExpr &e) {
-    if (e.args.size() != 2 && e.args.size() != 3)
-        cg.codegenError("dump() takes 2 or 3 arguments");
-
-    llvm::Value *fileHandle = cg.emitExpr(*e.args[0]);
-    if (!cg.isFile(fileHandle))
-        cg.codegenError("dump(f, value): first argument must be a File handle");
-
-    llvm::Value *val = cg.emitExpr(*e.args[1]);
-    if (val->getType() != cg.anyTy_)
-        val = cg.wrapInAny(val);
-
-    llvm::Value *slot = cg.emitAlloca(cg.anyTy_, "json_dump_in");
-    cg.emitStore(val, slot);
-
-    llvm::Value *indent;
-    if (e.args.size() == 2) {
-        indent = llvm::ConstantInt::getSigned(cg.i64Ty_, -1);
-    } else {
-        indent = cg.emitExpr(*e.args[2]);
-        if (indent->getType() != cg.i64Ty_)
-            cg.codegenError("dump() indent must be an int");
-    }
-
-    auto fn = cg.getRuntimeFn("__ry_json_dump_file", cg.i64Ty_,
-                              {cg.ptrTy_, cg.ptrTy_, cg.i64Ty_});
-    llvm::Value *status = cg.builder_.CreateCall(
-        fn, {fileHandle, slot, indent}, "json_dump_status");
-    return cg.wrapStatusAsResult(status);
-}
-
-
-// ===== JSON dispatch table =====
+// ===== JSON dispatcher =====
 //
 // `stringify` / `stringifySafe` were carved out to emitBuiltinJson (Pattern B)
 // per #2340 — they are polymorphic over the Ry value type and never matched a
 // declarative descriptor. `load[T]` is intercepted by `dispatchJson` via
-// suffix match against `e.callee`; `dump` stays here because it remains a
-// declaration-driven 2/3-arity File-first call.
-static const CodeGen::NativeDispatchEntry json_table[] = {
-    {"dump", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitJsonDumpFile},
-};
+// suffix match against `e.callee`. `dump` was the last table entry; it
+// migrated to descriptor-driven dispatch via `kOverrides` (#2481), retiring
+// `json_table[]` and `emitJsonDumpFile`. The descriptor entries
+// (src/codegen_native_call_descriptor.cpp) carry `any_by_ptr_param_index`,
+// `any_by_ptr_alloca_hint = "json_dump_in"`, `synthetic_trailing_i64 = -1`
+// (2-arg overload), `exported_symbol = "__ry_json_dump_file"`, and
+// `ResultStatus` wrapping — together reproducing the former custom emitter's
+// IR byte-exactly.
 
 // Gate the dispatcher: only proceed if any json symbol is actually
 // registered in `native_fn_sigs_`. Without this, json would race with
@@ -185,8 +149,10 @@ static const CodeGen::NativeDispatchEntry json_table[] = {
 // claim every `load<T>` call regardless of which package the user imported
 // from, and alphabetical ordering would put json first, routing
 // `from json5 import load; load[T](...)` to `__ry_json_parse_to_any`.
-// The check mirrors the package-level gate `emitTableDrivenNativeCall`
-// performs at L17.
+// The check is a per-package sig-presence gate; after #2481 `dump` is
+// handled by `emitGenericNativeCall` whose own sig lookup gates on the
+// same set, so the only path through `dispatchJson` that still needs an
+// explicit gate is the `load<T>` interceptor above.
 static bool isJsonImported(CodeGen &cg) {
     const auto &sigs = cg.getNativeFnSigs();
     return sigs.count("json::load") || sigs.count("json::stringify")
@@ -200,16 +166,17 @@ static llvm::Value *dispatchJson(CodeGen &cg, const CallExpr &e) {
 
     // libry_json.dylib registration is auto-derived inside `getRuntimeFn` via
     // the symbol→library auto-link (#2393) — `__ry_json_*` runtime symbols
-    // emitted by `emitJsonLoad` / `emitJsonDumpFile` / `emitBuiltinJson*`
-    // register "json" automatically before any call reaches the JIT.
+    // emitted by `emitJsonLoad` / `emitBuiltinJson*` / the descriptor-driven
+    // `dump` path register "json" automatically before any call reaches the
+    // JIT.
 
     // Intercept `load[T](...)` calls (#1852, #1887). The parser uses `[T]`
     // syntax for generic function calls at user-facing call sites, but
     // constructs the internal callee representation with `<T>` (e.g.
     // "load<Person>", "load<List<Person>>"), so we strip the `load<` prefix
     // and trailing `>` to recover the type-name. The interceptor runs before
-    // `emitTableDrivenNativeCall` because the table's name-keyed exact match
-    // does not handle the parametric suffix.
+    // the descriptor-driven path because exact-match name lookup cannot
+    // handle the parametric suffix.
     constexpr const char kLoadPrefix[] = "load<";
     constexpr size_t kLoadPrefixLen = sizeof(kLoadPrefix) - 1;
     if (e.callee.size() > kLoadPrefixLen + 1 &&
@@ -224,7 +191,7 @@ static llvm::Value *dispatchJson(CodeGen &cg, const CallExpr &e) {
     // Reject bare `load(...)` without a type argument (#1887). The pre-#1887
     // non-generic `load() -> Result<any, Error>` form was removed because it
     // had no safe accessor; a friendly diagnostic here beats the generic
-    // "undefined function: load" that `emitTableDrivenNativeCall` would
+    // "no matching @native call" that `emitGenericNativeCall` would
     // otherwise emit.
     if (e.callee == "load") {
         cg.codegenError(
@@ -233,7 +200,11 @@ static llvm::Value *dispatchJson(CodeGen &cg, const CallExpr &e) {
             "or load[int]. load[any] is intentionally not supported (#1887).");
     }
 
-    return cg.emitTableDrivenNativeCall(e, "json", json_table, std::size(json_table));
+    // #2481: `dump` is now descriptor-driven (see kOverrides). The remaining
+    // chain (descriptor → emitGenericNativeCall) is reached by returning
+    // nullptr here, mirroring dispatchIO / dispatchNet / dispatchPath /
+    // dispatchThread after their respective migrations.
+    return nullptr;
 }
 
 // ===== Builtin Json / Json5 shared body (Pattern B carve-out, #2340) =====
@@ -255,7 +226,8 @@ static llvm::Value *dispatchJson(CodeGen &cg, const CallExpr &e) {
 //
 // Library registration: the carved emitters register `<package>` directly so
 // the JIT loads `libry_<package>` before the runtime symbol is referenced.
-// dispatchJson / dispatchJson5 still cover the load[T] / dump paths.
+// dispatchJson covers load[T] only (`dump` migrated to the descriptor-driven
+// path in #2481); dispatchJson5 still covers load[T] and `dump` until #2482.
 llvm::Value *CodeGen::emitBuiltinJsonModuleStringify(
     const CallExpr &e,
     const char *package,

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -636,6 +636,10 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     // libs = ambiguous). An exact match in one lib beats a widening match in
     // another — Pass 2 only runs on empty Pass 1.
     const NativeFnSignature *matchedSig = nullptr;
+    // Descriptor for the winning sig, captured at match time so the
+    // post-match block reuses the per-candidate lookup instead of
+    // re-hashing native_call_descriptors_ for the same entry.
+    const NativeCallDescriptor *matchedDesc = nullptr;
     std::string matchedPackage;
     size_t matchedIdx = 0;  // overload index within native_fn_sigs_[matchedSigKey]
     std::vector<llvm::Type *> paramTypes;
@@ -647,6 +651,7 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
         std::string sigKey = ry::util::nativeSigKey(lib, e.callee);
         auto sigIt = native_fn_sigs_.find(sigKey);
         if (sigIt == native_fn_sigs_.end()) continue;
+        auto descIt = native_call_descriptors_.find(sigKey);
         for (size_t sigIdx = 0; sigIdx < sigIt->second.size(); ++sigIdx) {
             const auto &sig = sigIt->second[sigIdx];
             if (sig.params.size() != e.args.size()) continue;
@@ -702,6 +707,10 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
                 matchedSig = &sig;
                 matchedPackage = lib;
                 matchedIdx = sigIdx;
+                matchedDesc = (descIt != native_call_descriptors_.end()
+                               && sigIdx < descIt->second.size())
+                    ? &descIt->second[sigIdx]
+                    : nullptr;
                 paramTypes = std::move(candidateTypes);
             }
         }
@@ -713,9 +722,19 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
             std::string sigKey = ry::util::nativeSigKey(lib, e.callee);
             auto sigIt = native_fn_sigs_.find(sigKey);
             if (sigIt == native_fn_sigs_.end()) continue;
+            // #2481: per-candidate descriptor lookup for any-by-ptr
+            // opt-in. Descriptors are pushed in lock-step with sigs
+            // under the same sigKey (codegen_fn.cpp:818), so sigIdx
+            // indexes both.
+            auto descIt = native_call_descriptors_.find(sigKey);
             for (size_t sigIdx = 0; sigIdx < sigIt->second.size(); ++sigIdx) {
                 const auto &sig = sigIt->second[sigIdx];
                 if (sig.params.size() != e.args.size()) continue;
+                const NativeCallDescriptor *candidateDesc =
+                    (descIt != native_call_descriptors_.end()
+                     && sigIdx < descIt->second.size())
+                    ? &descIt->second[sigIdx]
+                    : nullptr;
                 bool typesMatch = true;
                 candidateTypes.clear();
                 candidateNeedsWidening.assign(e.args.size(), false);
@@ -725,6 +744,18 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
                         // exact
                     } else if (isWideningConversion(args[i], expectedTy,
                                                     sig.params[i].typeName)) {
+                        candidateNeedsWidening[i] = true;
+                    } else if (candidateDesc
+                               && sig.params[i].typeName == "any"
+                               && candidateDesc->any_by_ptr_param_index
+                                  == static_cast<int>(i)) {
+                        // #2481: any-by-ptr widening — wrapInAny lowers
+                        // any concrete value type into `any`, satisfying
+                        // an `any`-typed param slot whose descriptor
+                        // opts into the wrap+alloca+store→ptr lowering.
+                        // Scoped to the descriptor opt-in so future bare-
+                        // `any` natives that want value-typed `any`
+                        // params are not silently re-routed.
                         candidateNeedsWidening[i] = true;
                     } else {
                         typesMatch = false;
@@ -764,6 +795,7 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
                     matchedSig = &sig;
                     matchedPackage = lib;
                     matchedIdx = sigIdx;
+                    matchedDesc = candidateDesc;
                     paramTypes = std::move(candidateTypes);
                     needsWidening = std::move(candidateNeedsWidening);
                 }
@@ -776,14 +808,14 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
 
     linkNativeLibrary(matchedPackage);
 
-    // Look up the descriptor populated alongside this sig in codegen_fn.cpp.
-    // Descriptors and sigs are pushed in lock-step under the same sigKey, so
-    // matchedIdx indexes both. The descriptor carries pre-computed return
+    // The matching loops above captured `matchedDesc` directly from the
+    // per-candidate descriptor pointer (lock-step with sigs under the same
+    // sigKey). Re-derive the sigKey only for the path::join arity-suffix
+    // overload lookup below. The descriptor carries pre-computed return
     // wrapping, error channel, and List<u8>-arg metadata so we don't
     // re-infer at every call (#2337).
     const std::string matchedSigKey = ry::util::nativeSigKey(matchedPackage, e.callee);
-    const NativeCallDescriptor &desc =
-        native_call_descriptors_.at(matchedSigKey)[matchedIdx];
+    const NativeCallDescriptor &desc = *matchedDesc;
 
     // Reject list arguments whose declared param type is `List<u8>` but
     // whose actual element stride is not i8 (e.g. bare int literals
@@ -805,9 +837,37 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     }
 
     // Apply widening coercions to matched args (no-op when all false).
+    // #2481: an `any`-typed param slot with descriptor opt-in widens via
+    // `wrapInAny` (not the numeric `emitWideningConversion`) so a concrete
+    // value type is lifted into `anyTy_`. The post-resolve any-by-ptr
+    // block below then alloca's + stores it and substitutes a `ptr`.
     for (size_t i = 0; i < e.args.size(); i++) {
-        if (needsWidening[i])
-            args[i] = emitWideningConversion(args[i], paramTypes[i]);
+        if (needsWidening[i]) {
+            if (matchedSig->params[i].typeName == "any"
+                && desc.any_by_ptr_param_index == static_cast<int>(i)) {
+                args[i] = wrapInAny(args[i]);
+            } else {
+                args[i] = emitWideningConversion(args[i], paramTypes[i]);
+            }
+        }
+    }
+
+    // #2481: any-by-ptr lowering. For descriptor entries whose C ABI
+    // expects `const RyAny *` for an `any`-typed Ry param slot, materialize
+    // an alloca, store the `any`-valued arg into it, and substitute the
+    // pointer. Runs after both the regular widening and the wrapInAny path
+    // above, so args[idx] is guaranteed to have type `anyTy_` here when
+    // descriptor.any_by_ptr_param_index is set (Pass-1 exact match or
+    // Pass-2 wrapInAny widening — both produce anyTy_).
+    if (desc.any_by_ptr_param_index >= 0) {
+        size_t idx = static_cast<size_t>(desc.any_by_ptr_param_index);
+        const std::string hint = desc.any_by_ptr_alloca_hint.empty()
+            ? (e.callee + "_any_in")
+            : desc.any_by_ptr_alloca_hint;
+        llvm::Value *slot = emitAlloca(anyTy_, hint.c_str());
+        emitStore(args[idx], slot);
+        args[idx] = slot;
+        paramTypes[idx] = ptrTy_;
     }
 
     // Adjust bool params to match the C calling convention: native functions pass bools as i64.
@@ -817,6 +877,18 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
             args[i] = builder_.CreateZExt(args[i], i64Ty_, "bool_zext");
             paramTypes[i] = i64Ty_;
         }
+    }
+
+    // #2481: synthetic trailing i64 constant injection. When the C ABI
+    // takes one more `i64` arg than the Ry declaration (e.g. json::dump's
+    // 2-arg overload synthesizing indent=-1 to share the 3-arg overload's
+    // `__ry_json_dump_file(ptr, ptr, i64)` symbol), append the configured
+    // constant to args + paramTypes here, before the wrapping switch
+    // below pushes any out-param ptr.
+    if (desc.synthetic_trailing_i64.has_value()) {
+        args.push_back(llvm::ConstantInt::getSigned(
+            i64Ty_, *desc.synthetic_trailing_i64));
+        paramTypes.push_back(i64Ty_);
     }
 
     // Derive runtime function name. Three sources, in precedence order:
@@ -980,18 +1052,15 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     auto emitCallAndWrap = [&]() -> llvm::Value * {
         auto *fnTy = llvm::FunctionType::get(cRetTy, paramTypes, false);
         auto fn = mod_->getOrInsertFunction(rtName, fnTy);
-        // #2393: the pre-migration thread customEmitters named the i64
-        // status call `<callee>_status` (see emitThreadSyncOp). Mirror that
-        // so the descriptor migration's IR byte-exact diff stays empty for
-        // the `lockAcquire` / `rwlockReadLock` / `semaphoreAcquire` /
-        // `barrierWait` / etc. chain. Other Pattern C consumers (io / net /
-        // http ResultStatus entries) use the bare callee name; the gate
-        // on (matchedPackage == "thread") preserves their existing IR.
-        std::string callNameHint = e.callee;
-        if (wrapping == ReturnWrapping::ResultStatus
-            && matchedPackage == "thread") {
-            callNameHint = e.callee + "_status";
-        }
+        // Use the descriptor's call-name hint when set, else default to the
+        // bare callee. Each migration that needs a non-default SSA name
+        // sets `call_name_hint` on its kOverrides entry (#2481): thread
+        // sync ops use `<callee>_status` (e.g. "lockAcquire_status"),
+        // json::dump uses "json_dump_status". The hint mechanism mirrors
+        // `any_by_ptr_alloca_hint` and avoids growing a per-package if-
+        // chain in the generic dispatcher.
+        const std::string &callNameHint =
+            desc.call_name_hint.empty() ? e.callee : desc.call_name_hint;
         llvm::Value *callResult;
         if (cRetTy->isVoidTy())
             callResult = builder_.CreateCall(fn, args);

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -641,7 +641,6 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     // re-hashing native_call_descriptors_ for the same entry.
     const NativeCallDescriptor *matchedDesc = nullptr;
     std::string matchedPackage;
-    size_t matchedIdx = 0;  // overload index within native_fn_sigs_[matchedSigKey]
     std::vector<llvm::Type *> paramTypes;
     std::vector<bool> needsWidening(e.args.size(), false);
     std::vector<llvm::Type *> candidateTypes;
@@ -706,7 +705,6 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
                 }
                 matchedSig = &sig;
                 matchedPackage = lib;
-                matchedIdx = sigIdx;
                 matchedDesc = (descIt != native_call_descriptors_.end()
                                && sigIdx < descIt->second.size())
                     ? &descIt->second[sigIdx]
@@ -794,7 +792,6 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
                     }
                     matchedSig = &sig;
                     matchedPackage = lib;
-                    matchedIdx = sigIdx;
                     matchedDesc = candidateDesc;
                     paramTypes = std::move(candidateTypes);
                     needsWidening = std::move(candidateNeedsWidening);
@@ -815,6 +812,15 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     // wrapping, error channel, and List<u8>-arg metadata so we don't
     // re-infer at every call (#2337).
     const std::string matchedSigKey = ry::util::nativeSigKey(matchedPackage, e.callee);
+    // Descriptors are populated lock-step with sigs in codegen_fn.cpp at
+    // @native declaration time, so a missing descriptor for a matched sig
+    // means the populator missed a path. Surface that as a structured
+    // diagnostic rather than dereferencing nullptr. (CodeRabbit PR #2488)
+    if (!matchedDesc) {
+        codegenError("internal error: missing NativeCallDescriptor for "
+                     "@native(\"" + matchedPackage + "\") "
+                     + e.callee);
+    }
     const NativeCallDescriptor &desc = *matchedDesc;
 
     // Reject list arguments whose declared param type is `List<u8>` but

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -813,6 +813,10 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
                 desc.iterator_elem_type_name = ov->iterator_elem_type_name;
                 if (ov->wrapping_overridden)
                     desc.return_wrapping = ov->wrapping_override;
+                desc.any_by_ptr_param_index  = ov->any_by_ptr_param_index;
+                desc.any_by_ptr_alloca_hint  = ov->any_by_ptr_alloca_hint;
+                desc.synthetic_trailing_i64  = ov->synthetic_trailing_i64;
+                desc.call_name_hint          = ov->call_name_hint;
             }
 
             native_call_descriptors_[sigKey].push_back(std::move(desc));

--- a/src/codegen_native_call_descriptor.cpp
+++ b/src/codegen_native_call_descriptor.cpp
@@ -37,6 +37,25 @@ struct OverrideEntry {
     const char *iterator_elem_type_name;  // empty = no iterator wrapping
     CodeGenReturnWrapping wrapping_override;
     bool wrapping_overridden;
+
+    // #2481: any-by-ptr param wrapping. -1 = none. When set, the
+    // descriptor consumer treats the indexed `any`-typed param slot as
+    // `(wrapInAny? + alloca + store -> ptr)` to match the C ABI's
+    // `const RyAny*` expectation. `any_by_ptr_alloca_hint` is the SSA
+    // name hint for the alloca; nullptr/"" -> derive `<callee>_any_in`.
+    // In-class defaults so existing kOverrides entries need no edits.
+    int any_by_ptr_param_index = -1;
+    const char *any_by_ptr_alloca_hint = nullptr;
+
+    // #2481: synthetic trailing `i64` constant injection. When engaged,
+    // the descriptor consumer appends the value as an `i64` arg after
+    // the Ry args. Used by json::dump's 2-arg overload to inject
+    // indent=-1.
+    std::optional<int64_t> synthetic_trailing_i64;
+
+    // #2481: SSA name hint for the runtime-call result (see
+    // NativeCallDescriptor::call_name_hint). nullptr/"" -> use `e.callee`.
+    const char *call_name_hint = nullptr;
 };
 
 // Hand-maintained table. Order matters only for readability — lookup is
@@ -225,31 +244,41 @@ static const OverrideEntry kOverrides[] = {
     // wrapStatusAsResult. The default `__ry_get_last_error` channel (set
     // via codegen_fn.cpp's kHasModuleLastError exclusion + the
     // emitGenericNativeCall fallback) matches the pre-migration call to
-    // `wrapStatusAsResult(status)` with no explicit errFn arg.
+    // `wrapStatusAsResult(status)` with no explicit errFn arg. The
+    // `call_name_hint` field reproduces the pre-migration `<callee>_status`
+    // SSA name byte-exactly (#2481 hint mechanism).
     {"thread", "lockAcquire",      {"Lock"},
      "__ry_lock_acquire", {}, "",
-     CodeGenReturnWrapping::ResultStatus, true},
+     CodeGenReturnWrapping::ResultStatus, true,
+     -1, nullptr, std::nullopt, "lockAcquire_status"},
     {"thread", "lockRelease",      {"Lock"},
      "__ry_lock_release", {}, "",
-     CodeGenReturnWrapping::ResultStatus, true},
+     CodeGenReturnWrapping::ResultStatus, true,
+     -1, nullptr, std::nullopt, "lockRelease_status"},
     {"thread", "rwlockReadLock",   {"RWLock"},
      "__ry_rwlock_read_lock", {}, "",
-     CodeGenReturnWrapping::ResultStatus, true},
+     CodeGenReturnWrapping::ResultStatus, true,
+     -1, nullptr, std::nullopt, "rwlockReadLock_status"},
     {"thread", "rwlockWriteLock",  {"RWLock"},
      "__ry_rwlock_write_lock", {}, "",
-     CodeGenReturnWrapping::ResultStatus, true},
+     CodeGenReturnWrapping::ResultStatus, true,
+     -1, nullptr, std::nullopt, "rwlockWriteLock_status"},
     {"thread", "rwlockUnlock",     {"RWLock"},
      "__ry_rwlock_unlock", {}, "",
-     CodeGenReturnWrapping::ResultStatus, true},
+     CodeGenReturnWrapping::ResultStatus, true,
+     -1, nullptr, std::nullopt, "rwlockUnlock_status"},
     {"thread", "semaphoreAcquire", {"Semaphore"},
      "__ry_semaphore_acquire", {}, "",
-     CodeGenReturnWrapping::ResultStatus, true},
+     CodeGenReturnWrapping::ResultStatus, true,
+     -1, nullptr, std::nullopt, "semaphoreAcquire_status"},
     {"thread", "semaphoreRelease", {"Semaphore"},
      "__ry_semaphore_release", {}, "",
-     CodeGenReturnWrapping::ResultStatus, true},
+     CodeGenReturnWrapping::ResultStatus, true,
+     -1, nullptr, std::nullopt, "semaphoreRelease_status"},
     {"thread", "barrierWait",      {"Barrier"},
      "__ry_barrier_wait", {}, "",
-     CodeGenReturnWrapping::ResultStatus, true},
+     CodeGenReturnWrapping::ResultStatus, true,
+     -1, nullptr, std::nullopt, "barrierWait_status"},
 
     // -------- thread: sync-primitive *Free (ResourceFree wrapping) ----
     // The *Free entries don't dial a runtime fn — they emit emitResourceFree's
@@ -268,6 +297,38 @@ static const OverrideEntry kOverrides[] = {
     {"thread", "barrierFree",     {"Barrier"},
      "", {}, "",
      CodeGenReturnWrapping::ResourceFree, true},
+
+    // -------- json: descriptor-driven dump (#2481) --------
+    // The 2-arg and 3-arg overloads both route to a single C symbol
+    // `__ry_json_dump_file(ptr file, ptr any_value, i64 indent_or_neg1)`.
+    // The 2-arg form synthesizes `indent = -1`; the 3-arg form passes
+    // the user's indent. The `any`-typed value slot (index 1) is
+    // wrapped via the descriptor's `any_by_ptr_param_index` mechanism
+    // (`wrapInAny` if not already `any`, then alloca+store, pass as
+    // ptr) to match the C ABI's `const RyAny*` expectation. The File
+    // handle (index 0) is auto-detected as `rk_file` via
+    // `inferHandleParamIndex`, which causes `emitGenericNativeCall` to
+    // also link `libry_io` (required: `__ry_json_dump_file` internally
+    // calls `__ry_io_file_write_text`). `ResultStatus` + the default
+    // `__ry_get_last_error` channel reproduces the pre-migration
+    // `wrapStatusAsResult(status)` call exactly. `any_by_ptr_alloca_hint`
+    // and the per-package callNameHint extension in
+    // `emitGenericNativeCall` preserve the SSA names `json_dump_in` /
+    // `json_dump_status` for byte-exact IR regression.
+    {"json", "dump", {"File", "any"},
+     "__ry_json_dump_file", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true,
+     /*any_by_ptr_param_index=*/1,
+     /*any_by_ptr_alloca_hint=*/"json_dump_in",
+     /*synthetic_trailing_i64=*/std::optional<int64_t>{-1},
+     /*call_name_hint=*/"json_dump_status"},
+    {"json", "dump", {"File", "any", "int"},
+     "__ry_json_dump_file", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true,
+     /*any_by_ptr_param_index=*/1,
+     /*any_by_ptr_alloca_hint=*/"json_dump_in",
+     /*synthetic_trailing_i64=*/std::nullopt,
+     /*call_name_hint=*/"json_dump_status"},
 };
 
 bool paramListMatches(std::initializer_list<const char *> expected,
@@ -416,6 +477,12 @@ std::optional<NativeOverloadOverride> lookupNativeOverloadOverride(
             ? entry.iterator_elem_type_name : "";
         out.wrapping_override = entry.wrapping_override;
         out.wrapping_overridden = entry.wrapping_overridden;
+        out.any_by_ptr_param_index = entry.any_by_ptr_param_index;
+        out.any_by_ptr_alloca_hint = entry.any_by_ptr_alloca_hint
+            ? entry.any_by_ptr_alloca_hint : "";
+        out.synthetic_trailing_i64 = entry.synthetic_trailing_i64;
+        out.call_name_hint = entry.call_name_hint
+            ? entry.call_name_hint : "";
         return out;
     }
     return std::nullopt;

--- a/tests/filecheck/json_dump_descriptor_2481.ry
+++ b/tests/filecheck/json_dump_descriptor_2481.ry
@@ -1,0 +1,42 @@
+# FileCheck golden for #2481 — json::dump descriptor-driven migration.
+#
+# Locks the IR shape produced by the `kOverrides` entries for json::dump:
+#   - alloca SSA name `json_dump_in` (via descriptor.any_by_ptr_alloca_hint)
+#   - call SSA name `json_dump_status` (via the per-package callNameHint
+#     extension in emitGenericNativeCall)
+#   - synthetic trailing `i64 -1` for the 2-arg overload (descriptor.
+#     synthetic_trailing_i64 = -1)
+#   - user-supplied `i64` for the 3-arg overload (no synthetic)
+#   - `__ry_json_dump_file(ptr, ptr, i64)` runtime symbol (via
+#     descriptor.exported_symbol)
+#
+# Without these the descriptor mechanism would emit a different alloca
+# name (`<callee>_any_in` = "dump_any_in") and call name (`<callee>` =
+# "dump"), and the byte-exact regression vs. the pre-migration
+# `emitJsonDumpFile` custom emitter would fail.
+#
+# The probe uses a typed `int` value so the wrapInAny widening path is
+# exercised (`Map<str, any>` would resolve to `ptrTy_` and also wrap —
+# but `int` makes the dependency on the Pass-2 + descriptor opt-in
+# clearer for future maintainers reading this golden).
+
+from ry.io import File, open, close
+from ry.json import dump
+
+fn dumpProbe():
+    case open("/tmp/2481-filecheck.json", "w"):
+        Ok(f):
+            n: int = 42
+            # CHECK: %json_dump_in = alloca %Any
+            # CHECK: store %Any %{{[a-zA-Z_.0-9]+}}, ptr %json_dump_in
+            # CHECK: %json_dump_status = call i64 @__ry_json_dump_file(ptr %{{[a-zA-Z_.0-9]+}}, ptr %json_dump_in, i64 -1)
+            dump(f, n)
+            # CHECK: %json_dump_in{{[0-9]+}} = alloca %Any
+            # CHECK: %json_dump_status{{[0-9]+}} = call i64 @__ry_json_dump_file(ptr %{{[a-zA-Z_.0-9]+}}, ptr %json_dump_in{{[0-9]+}}, i64 2)
+            dump(f, n, 2)
+            close(f)
+            0
+        Err(_): 0
+
+fn main():
+    dumpProbe()


### PR DESCRIPTION
## Summary

Retires `json_table[]` and the `emitJsonDumpFile` custom emitter — the last table-driven entry on the json side — by extending `NativeCallDescriptor` with three new capabilities (`any_by_ptr_param_index` + `any_by_ptr_alloca_hint`, `synthetic_trailing_i64`, `call_name_hint`) and registering 2-arg / 3-arg `json::dump` overloads in `kOverrides`. `dispatchJson` reduces to the `isJsonImported` gate + `load[T]` parametric interceptor + bare `load` friendly error, matching the post-migration shape of `dispatchIO` / `dispatchNet` / `dispatchPath` / `dispatchThread`.

`json5::dump` stays on its table path; it adopts the same descriptor capabilities in #2482.

## Test plan

- [x] IR byte-exact regression — ASLR-normalized diff of `--emit-llvm-ir` before vs after is empty across `int` / `Map<str, any>` / `any` / 3-arg-indent probes
- [x] `tests/spec/json.test.ry` — 128 / 128 pass (covers both 2-arg and 3-arg `dump`)
- [x] `NativeFnSigs.GetRequiredLibrariesOnlyIncludesCalledFunctions` + sibling — both pass (no fall-through library leakage)
- [x] `./build-rust/ry_tests` — 3144 / 3144
- [x] `./build-rust/ry test -p` — 221 / 221 spec files
- [x] `bash scripts/check-examples.sh` — 102 / 102 canonical examples
- [x] New `tests/filecheck/json_dump_descriptor_2481.ry` durable golden — passes; locks the descriptor-produced SSA names (`json_dump_in`, `json_dump_status`) for future regressions
- [x] thread sync-op `_status` SSA names preserved byte-exactly under the migrated `call_name_hint` mechanism

Closes #2481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for `json::dump` and other native calls so more overloads are handled consistently.
  * Added better handling for `any`-typed arguments, including pointer-based passing in supported cases.
  * Improved native call naming so generated output is more stable and readable.

* **Bug Fixes**
  * Fixed native overload selection for descriptor-driven calls.
  * Corrected handling of an extra trailing numeric argument in supported overloads.
  * Added regression coverage for `json::dump` to verify generated output remains stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->