### PR TITLE
refactor(codegen): migrate json5 dispatcher to descriptor-driven

### DIFF
--- a/docs/architecture/native-call-boundary.md
+++ b/docs/architecture/native-call-boundary.md
@@ -62,7 +62,7 @@ The following stay outside the descriptor:
 - hand-written emitters that synthesize control flow, such as 3+-arg HTTP `listen`
 - parametric callees such as `json::load[T]` whose runtime symbol depends on a type argument parsed from the callee string
 
-Functions that previously sat in the "hand-written emitter" group have been migrated to the descriptor path as the needed capabilities were added; `json::dump` joined in #2481 via `any_by_ptr_*` and `synthetic_trailing_i64`. `json5::dump` is tracked in #2482 and reuses the same fields.
+Functions that previously sat in the "hand-written emitter" group have been migrated to the descriptor path as the needed capabilities were added; `json::dump` joined in #2481 via `any_by_ptr_*` and `synthetic_trailing_i64`, and `json5::dump` followed in #2482 reusing the same fields.
 
 These exceptions are compiler builtins or custom lowering paths, not runtime ABI exceptions.
 

--- a/src/codegen_call_json.cpp
+++ b/src/codegen_call_json.cpp
@@ -237,8 +237,8 @@ static llvm::Value *dispatchJson(CodeGen &cg, const CallExpr &e) {
 //
 // Library registration: the carved emitters register `<package>` directly so
 // the JIT loads `libry_<package>` before the runtime symbol is referenced.
-// dispatchJson covers load[T] only (`dump` migrated to the descriptor-driven
-// path in #2481); dispatchJson5 still covers load[T] and `dump` until #2482.
+// dispatchJson and dispatchJson5 both cover load[T] only; `dump` migrated to
+// the descriptor-driven path in #2481 (json) and #2482 (json5).
 llvm::Value *CodeGen::emitBuiltinJsonModuleStringify(
     const CallExpr &e,
     const char *package,

--- a/src/codegen_call_json5.cpp
+++ b/src/codegen_call_json5.cpp
@@ -114,58 +114,18 @@ static llvm::Value *emitJson5Load(CodeGen &cg, const CallExpr &e,
     return result;
 }
 
-// dump(f: File, value: any) -> Result<Unit, Error>
-// dump(f: File, value: any, indent: int) -> Result<Unit, Error>
-static llvm::Value *emitJson5DumpFile(CodeGen &cg, const CallExpr &e) {
-    if (e.args.size() != 2 && e.args.size() != 3)
-        cg.codegenError("dump() takes 2 or 3 arguments");
-
-    llvm::Value *fileHandle = cg.emitExpr(*e.args[0]);
-    if (!cg.isFile(fileHandle))
-        cg.codegenError("dump(f, value): first argument must be a File handle");
-
-    llvm::Value *val = cg.emitExpr(*e.args[1]);
-    if (val->getType() != cg.anyTy_)
-        val = cg.wrapInAny(val);
-
-    llvm::Value *slot = cg.emitAlloca(cg.anyTy_, "json5_dump_in");
-    cg.emitStore(val, slot);
-
-    llvm::Value *indent;
-    if (e.args.size() == 2) {
-        indent = llvm::ConstantInt::getSigned(cg.i64Ty_, -1);
-    } else {
-        indent = cg.emitExpr(*e.args[2]);
-        if (indent->getType() != cg.i64Ty_)
-            cg.codegenError("dump() indent must be an int");
-    }
-
-    auto fn = cg.getRuntimeFn("__ry_json5_dump_file", cg.i64Ty_,
-                              {cg.ptrTy_, cg.ptrTy_, cg.i64Ty_});
-    llvm::Value *status = cg.builder_.CreateCall(
-        fn, {fileHandle, slot, indent}, "json5_dump_status");
-    return cg.wrapStatusAsResult(status);
-}
-
-
-// ===== JSON5 dispatch table =====
-//
-// stringify / stringifySafe were carved out to emitBuiltinJson5 (Pattern B)
-// per #2340 — see emitBuiltinJson5 below for the rationale shared with json.
-static const CodeGen::NativeDispatchEntry json5_table[] = {
-    {"dump", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitJson5DumpFile},
-};
-
 // Gate the dispatcher: only proceed if any json5 symbol is actually
 // registered in `native_fn_sigs_`. Without this, json5 would race with
 // json over the `load<T>` interceptor (both register dispatchers and
 // alphabetical ordering picks json first, routing every `load[T]` call
 // to `__ry_json_parse_to_any` — even when the user wrote
-// `from json5 import load`). The check mirrors the package-level gate
-// `emitTableDrivenNativeCall` performs at L17. `load` is in the gate
-// list even though it's not in `json5_table` (it's intercepted before
-// the table) — without it, `from json5 import load` programs that don't
-// also import another json5 symbol would silently fall through.
+// `from json5 import load`). `load` is in the gate list even though it
+// has no descriptor entry (it's intercepted below as a parametric
+// callee) — without it, `from json5 import load` programs that don't
+// also import another json5 symbol would silently fall through. The
+// other three siblings (`dump`, `stringify`, `stringifySafe`) act as
+// module-presence proxies because importing any symbol from `ry.json5`
+// processes the whole module and registers those non-generic declarations.
 static bool isJson5Imported(CodeGen &cg) {
     const auto &sigs = cg.getNativeFnSigs();
     return sigs.count("json5::load") || sigs.count("json5::stringify")
@@ -203,7 +163,11 @@ static llvm::Value *dispatchJson5(CodeGen &cg, const CallExpr &e) {
             "or load[int]. load[any] is intentionally not supported.");
     }
 
-    return cg.emitTableDrivenNativeCall(e, "json5", json5_table, std::size(json5_table));
+    // #2482: `dump` is now descriptor-driven (see kOverrides). The remaining
+    // chain (descriptor → emitGenericNativeCall) is reached by returning
+    // nullptr here, mirroring dispatchIO / dispatchNet / dispatchPath /
+    // dispatchThread / dispatchJson after their respective migrations.
+    return nullptr;
 }
 
 // ===== Builtin Json5 (Pattern B carve-out, #2340) =====

--- a/src/codegen_native_call_descriptor.cpp
+++ b/src/codegen_native_call_descriptor.cpp
@@ -329,6 +329,23 @@ static const OverrideEntry kOverrides[] = {
      /*any_by_ptr_alloca_hint=*/"json_dump_in",
      /*synthetic_trailing_i64=*/std::nullopt,
      /*call_name_hint=*/"json_dump_status"},
+
+    // -------- json5: descriptor-driven dump (#2482) --------
+    // Mirrors json::dump above (identical ABI); symbol is __ry_json5_dump_file.
+    {"json5", "dump", {"File", "any"},
+     "__ry_json5_dump_file", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true,
+     /*any_by_ptr_param_index=*/1,
+     /*any_by_ptr_alloca_hint=*/"json5_dump_in",
+     /*synthetic_trailing_i64=*/std::optional<int64_t>{-1},
+     /*call_name_hint=*/"json5_dump_status"},
+    {"json5", "dump", {"File", "any", "int"},
+     "__ry_json5_dump_file", {}, "",
+     CodeGenReturnWrapping::ResultStatus, true,
+     /*any_by_ptr_param_index=*/1,
+     /*any_by_ptr_alloca_hint=*/"json5_dump_in",
+     /*synthetic_trailing_i64=*/std::nullopt,
+     /*call_name_hint=*/"json5_dump_status"},
 };
 
 bool paramListMatches(std::initializer_list<const char *> expected,

--- a/tests/filecheck/json5_dump_descriptor_2482.ry
+++ b/tests/filecheck/json5_dump_descriptor_2482.ry
@@ -1,0 +1,27 @@
+# FileCheck golden for #2482 — json5::dump descriptor-driven migration.
+#
+# Mirror of tests/filecheck/json_dump_descriptor_2481.ry with `json` → `json5`
+# substitutions; see that file for the full descriptor-mechanism rationale.
+# json5-specific: alloca hint `json5_dump_in`, call hint `json5_dump_status`,
+# symbol `__ry_json5_dump_file`, pre-migration emitter `emitJson5DumpFile`.
+
+from ry.io import File, open, close
+from ry.json5 import dump
+
+fn dumpProbe():
+    case open("/tmp/2482-filecheck.json5", "w"):
+        Ok(f):
+            n: int = 42
+            # CHECK: %json5_dump_in = alloca %Any
+            # CHECK: store %Any %{{[a-zA-Z_.0-9]+}}, ptr %json5_dump_in
+            # CHECK: %json5_dump_status = call i64 @__ry_json5_dump_file(ptr %{{[a-zA-Z_.0-9]+}}, ptr %json5_dump_in, i64 -1)
+            dump(f, n)
+            # CHECK: %json5_dump_in{{[0-9]+}} = alloca %Any
+            # CHECK: %json5_dump_status{{[0-9]+}} = call i64 @__ry_json5_dump_file(ptr %{{[a-zA-Z_.0-9]+}}, ptr %json5_dump_in{{[0-9]+}}, i64 2)
+            dump(f, n, 2)
+            close(f)
+            0
+        Err(_): 0
+
+fn main():
+    dumpProbe()

--- a/tests/filecheck/json5_dump_descriptor_2482.ry
+++ b/tests/filecheck/json5_dump_descriptor_2482.ry
@@ -17,6 +17,7 @@ fn dumpProbe():
             # CHECK: %json5_dump_status = call i64 @__ry_json5_dump_file(ptr %{{[a-zA-Z_.0-9]+}}, ptr %json5_dump_in, i64 -1)
             dump(f, n)
             # CHECK: %json5_dump_in{{[0-9]+}} = alloca %Any
+            # CHECK: store %Any %{{[a-zA-Z_.0-9]+}}, ptr %json5_dump_in{{[0-9]+}}
             # CHECK: %json5_dump_status{{[0-9]+}} = call i64 @__ry_json5_dump_file(ptr %{{[a-zA-Z_.0-9]+}}, ptr %json5_dump_in{{[0-9]+}}, i64 2)
             dump(f, n, 2)
             close(f)


### PR DESCRIPTION
## Summary

- Retires `json5_table[]` + `emitJson5DumpFile` by registering `json5::dump` (2-arg + 3-arg) in `kOverrides`, reusing the descriptor extensions introduced for `json::dump` in #2481 (`any_by_ptr_*`, `synthetic_trailing_i64`, `call_name_hint`).
- Reduces `dispatchJson5` to sig gate + `load<T>` parametric interceptor + bare-`load` friendly error + `return nullptr;`, mirroring `dispatchJson` after its migration.
- Updates the prospective "until #2482" comment in `emitBuiltinJsonModuleStringify` and the "tracked in #2482" forward-reference in `docs/architecture/native-call-boundary.md` to merged form. Adds `tests/filecheck/json5_dump_descriptor_2482.ry` as a durable IR golden mirroring `2481`.

## Test plan

- [x] `cmake --build build-rust` clean (macOS, `rust-emit` preset)
- [x] `./build-rust/ry_tests` — 3144/3144 pass (incl. `GetRequiredLibrariesOnlyIncludesCalledFunctions`, `KnownNativeLibsLocalLiteral`)
- [x] `./build-rust/ry test -p` — 221 spec files, 0 failures
- [x] `./build-rust/ry test tests/spec/json5.test.ry` — 98/98 pass (covers `dump(File, any)` round-trip)
- [x] `ctest -L filecheck -R 'filecheck_(json5_dump_descriptor_2482|json_dump_descriptor_2481)'` — 2/2 pass
- [x] `bash scripts/check-examples.sh` — 102/102
- [x] **Byte-exact IR diff** vs. pre-migration on `dump(f, n)` + `dump(f, n, 2)` probe: IDENTICAL
- [x] Docker ASan + UBSan (`run-asan.sh`) — zero findings

Closes #2482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - JSON5 `dump` now follows the same descriptor-based handling as JSON `dump`, improving consistency in how output is generated.

- **Documentation**
  - Clarified the architecture notes and dispatch behavior description for JSON/JSON5 loading and dumping.

- **Tests**
  - Added coverage to verify JSON5 `dump` uses the expected descriptor-driven path for both standard and extended call forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->