### PR TITLE
refactor(codegen): migrate NumberExpr / FloatExpr lowering to crates/lower (#2483)

### DIFF
--- a/crates/emit/src/abi/primitive.rs
+++ b/crates/emit/src/abi/primitive.rs
@@ -611,6 +611,25 @@ pub unsafe extern "C" fn ry_emit_const_int(
     intern(c, to_ry_value(v.0))
 }
 
+/// Materialize `LLVMConstReal(ty, value)` and return the interned constant.
+/// `ty` selects the float layout (f32 vs f64); the f64 value is narrowed to
+/// the target type's representation. NULL ctx / type → 0.
+#[no_mangle]
+pub unsafe extern "C" fn ry_emit_const_fp(
+    ctx: *mut RyEmitCtx,
+    ty: RyTypeRef,
+    value: f64,
+) -> RyValueId {
+    let Some(c) = checked_cx(ctx) else {
+        return 0;
+    };
+    let Some(t) = req_type(ty) else {
+        return 0;
+    };
+    let v = c.const_real(t, value);
+    intern(c, to_ry_value(v.0))
+}
+
 /// Materialize `LLVMConstNull(ty)` and return the interned constant. For
 /// pointer types this is the typed null pointer used in null-guard `icmp eq`
 /// comparisons (pilot G #2196). NULL ctx / type → 0.

--- a/crates/emit/src/primitive/ops.rs
+++ b/crates/emit/src/primitive/ops.rs
@@ -442,6 +442,14 @@ impl EmitCtx {
         ValueRef(LLVMConstInt(ty.0, value, sign_extend as i32))
     }
 
+    // Materialize a floating-point constant `LLVMConstReal(ty, value)`. `ty`
+    // selects f32 vs f64 semantics; the `f64` argument is narrowed by
+    // `LLVMConstReal` to the target type's float layout (byte-identical to
+    // `llvm::ConstantFP::get(fNTy, double)` on the C++ side).
+    pub(crate) unsafe fn const_real(&mut self, ty: TypeRef, value: f64) -> ValueRef {
+        ValueRef(LLVMConstReal(ty.0, value))
+    }
+
     // Materialize a null constant of any type via `LLVMConstNull(ty)`. For
     // pointer types this is `ConstantPointerNull::get(ty)` — the typed null
     // pointer used in null-guard `icmp eq` comparisons. Added for pilot G

--- a/crates/lower/src/abi.rs
+++ b/crates/lower/src/abi.rs
@@ -7,6 +7,8 @@
 //! bodies are the seams that future stages factor into per-stage modules.
 
 use crate::emit_extern::ry_emit_const_int;
+use crate::error::clear_last_error;
+use crate::expr::{lower_float_const, lower_int_const};
 use crate::handles::{RyEmitCtx, RyTypeRef, RyValueId};
 
 /// Materialize an `i1` constant for a Ry `BoolExpr`.
@@ -36,4 +38,66 @@ pub unsafe extern "C" fn ry_lower_bool_const(
     // `ry_emit_*`). Any non-zero value is `true`.
     let normalized: u64 = if value != 0 { 1 } else { 0 };
     ry_emit_const_int(ctx, i1_ty, normalized, 0)
+}
+
+/// Materialize an integer constant for a Ry `NumberExpr` (Stage 1 of the
+/// upper-codegen migration, #2483).
+///
+/// `llvm_ty` is the LLVM type the C++ shim resolved from the suffix
+/// (`resolveType(suffix)`, or `i64Ty_` when the suffix is empty).
+/// `magnitude` is the parser-provided unsigned bit pattern (negative
+/// literals arrive as `UnaryExpr` and never reach this entry).
+/// `suffix_kind` is the `RyLowerSuffixKind` enum value (see
+/// `include/ry/lower/api.h`); `signed_bit` matches the original
+/// `ConstantInt::get(.., isSigned)` flag (1 = signed, 0 = unsigned).
+///
+/// On range overflow or bare-int negative bit-pattern, returns `0` after
+/// recording a diagnostic via `set_last_error`. The C++ shim checks
+/// `id == 0` and surfaces the message through `codegenError`.
+///
+/// Calls `clear_last_error()` at entry so `id == 0` always pairs with a
+/// fresh message set inside this call (cross-stage boundary contract).
+///
+/// # Safety
+///
+/// `ctx` must be a valid `RyEmitCtx *` produced by `ry_emit_ctx_create`
+/// (or NULL); `llvm_ty` must be a valid LLVM integer type handle (or
+/// NULL).
+#[no_mangle]
+pub unsafe extern "C" fn ry_lower_int_const(
+    ctx: *mut RyEmitCtx,
+    llvm_ty: RyTypeRef,
+    magnitude: u64,
+    suffix_kind: u8,
+    signed_bit: u8,
+) -> RyValueId {
+    clear_last_error();
+    lower_int_const(ctx, llvm_ty, magnitude, suffix_kind, signed_bit)
+}
+
+/// Materialize a floating-point constant for a Ry `FloatExpr` (Stage 1 of
+/// the upper-codegen migration, #2483).
+///
+/// `llvm_ty` is the LLVM type the C++ shim selected from the suffix
+/// (`f64Ty_` for empty / `f64`, `f32Ty_` for `f32`). `value` is the
+/// parser-provided double. `suffix_kind` is the `RyLowerSuffixKind` enum
+/// value for the boundary protocol (None / F32 / F64 expected).
+///
+/// Has no error path under normal operation; calls `clear_last_error()`
+/// at entry for boundary uniformity (defensive against future failure
+/// modes — same contract as `ry_lower_int_const`).
+///
+/// # Safety
+///
+/// `ctx` must be a valid `RyEmitCtx *` (or NULL); `llvm_ty` must be a
+/// valid LLVM float type handle (or NULL).
+#[no_mangle]
+pub unsafe extern "C" fn ry_lower_float_const(
+    ctx: *mut RyEmitCtx,
+    llvm_ty: RyTypeRef,
+    value: f64,
+    suffix_kind: u8,
+) -> RyValueId {
+    clear_last_error();
+    lower_float_const(ctx, llvm_ty, value, suffix_kind)
 }

--- a/crates/lower/src/emit_extern.rs
+++ b/crates/lower/src/emit_extern.rs
@@ -20,4 +20,12 @@ extern "C" {
         value: u64,
         sign_extend: c_int,
     ) -> RyValueId;
+
+    /// `LLVMConstReal(ty, value)` — materialize a floating-point constant
+    /// and return the interned handle. `ty` selects f32 vs f64; the f64
+    /// argument is narrowed to the target type's float layout. NULL ctx /
+    /// type → 0. Added for upper-codegen Stage 1 (#2483).
+    ///
+    /// See `include/ry/llvm_emit/api.h` `ry_emit_const_fp`.
+    pub(crate) fn ry_emit_const_fp(ctx: *mut RyEmitCtx, ty: RyTypeRef, value: f64) -> RyValueId;
 }

--- a/crates/lower/src/error.rs
+++ b/crates/lower/src/error.rs
@@ -1,0 +1,63 @@
+//! Thread-local error channel for `ry_lower_*` entries.
+//!
+//! Cross-stage boundary contract (established by #2483 Stage 1):
+//!
+//! - Every `ry_lower_*` entry that can fail must call `clear_last_error()`
+//!   as its first operation. This guarantees that a returned `RyValueId = 0`
+//!   always pairs with a message set *inside that same call* — never a
+//!   stale message from a prior `ry_lower_*` invocation.
+//! - On failure the body calls `set_last_error(msg)` and returns `0`.
+//! - The C++ caller checks `id == 0` and calls `ry_lower_get_last_error()`
+//!   to retrieve the message, then immediately copies it into a `std::string`
+//!   and throws via `codegenError`. The pointer is invalidated by the next
+//!   `ry_lower_*` call on the same thread, so the copy must happen before
+//!   any further boundary call.
+//!
+//! Thread-local storage is correct because `EmitCtx` is documented as
+//! single-threaded (`crates/emit/src/context.rs`); the boundary inherits
+//! that contract.
+
+use core::ffi::c_char;
+use std::cell::RefCell;
+use std::ffi::CString;
+
+thread_local! {
+    static LAST_ERROR: RefCell<Option<CString>> = const { RefCell::new(None) };
+}
+
+/// Record a diagnostic message in this thread's slot. Called by lowering
+/// bodies immediately before returning `RyValueId = 0`. NUL bytes in the
+/// input are replaced with a placeholder message so `CString::new` cannot
+/// fail; callers don't have to think about that case.
+pub(crate) fn set_last_error(msg: &str) {
+    let cs = CString::new(msg)
+        .unwrap_or_else(|_| CString::new("(error message contained NUL byte)").unwrap());
+    LAST_ERROR.with(|e| *e.borrow_mut() = Some(cs));
+}
+
+/// Clear this thread's slot. Each `ry_lower_*` entry calls this as its first
+/// operation so `RyValueId = 0` paired with `ry_lower_get_last_error()`
+/// always reflects a failure inside the *current* call.
+pub(crate) fn clear_last_error() {
+    LAST_ERROR.with(|e| *e.borrow_mut() = None);
+}
+
+/// Return the most recently set error message for this thread as a
+/// NUL-terminated C string, or NULL if none was set since the last
+/// `clear_last_error()` (which happens at the start of each `ry_lower_*`
+/// entry).
+///
+/// # Safety
+///
+/// The returned pointer is owned by this thread's `LAST_ERROR` cell and
+/// remains valid only until the next `ry_lower_*` call on the same thread
+/// (which clears or overwrites the slot). The C++ caller must copy the
+/// string before issuing another boundary call.
+#[no_mangle]
+pub unsafe extern "C" fn ry_lower_get_last_error() -> *const c_char {
+    LAST_ERROR.with(|e| {
+        e.borrow()
+            .as_ref()
+            .map_or(core::ptr::null(), |cs| cs.as_ptr())
+    })
+}

--- a/crates/lower/src/expr.rs
+++ b/crates/lower/src/expr.rs
@@ -1,0 +1,248 @@
+//! Ry expression lowering bodies. The `#[no_mangle] extern "C"` entries
+//! live in `abi.rs`; this module owns the Ry-semantic decisions (suffix →
+//! type selection, range validation, error-channel population).
+//!
+//! Per the migration design (`docs/architecture/upper-codegen-migration.md`
+//! §"Stage 1 — primitive literals"), the C++ shim still resolves the LLVM
+//! type from the suffix string and passes it across the boundary as
+//! `RyTypeRef`; the suffix is also passed as a `SuffixKind` enum so this
+//! module can apply the correct range-check arm without re-parsing.
+//! Stage 5 will move type registry to Rust and collapse the type +
+//! suffix params.
+//!
+//! The lower crate does NOT stamp metadata on returned constants
+//! (`low_level_type_names_` discipline, #311): LLVM constant uniquing
+//! shares pointers between identical `(type, value)` pairs, so per-value
+//! suffix metadata is propagated through the AST instead (via the C++
+//! side's `getExprLowLevelSuffix`).
+
+use crate::emit_extern::{ry_emit_const_fp, ry_emit_const_int};
+use crate::error::set_last_error;
+use crate::handles::{RyEmitCtx, RyTypeRef, RyValueId};
+
+/// Suffix discriminator passed from the C++ shim. The numeric values are
+/// part of the boundary contract — they MUST match the
+/// `RyLowerSuffixKind` enum in `include/ry/lower/api.h` exactly.
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub(crate) enum SuffixKind {
+    None = 0,
+    I8 = 1,
+    I16 = 2,
+    I32 = 3,
+    I64 = 4,
+    U8 = 5,
+    U16 = 6,
+    U32 = 7,
+    U64 = 8,
+    F32 = 9,
+    F64 = 10,
+}
+
+impl SuffixKind {
+    fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(SuffixKind::None),
+            1 => Some(SuffixKind::I8),
+            2 => Some(SuffixKind::I16),
+            3 => Some(SuffixKind::I32),
+            4 => Some(SuffixKind::I64),
+            5 => Some(SuffixKind::U8),
+            6 => Some(SuffixKind::U16),
+            7 => Some(SuffixKind::U32),
+            8 => Some(SuffixKind::U64),
+            9 => Some(SuffixKind::F32),
+            10 => Some(SuffixKind::F64),
+            _ => None,
+        }
+    }
+
+    /// Suffix name as it appears in Ry source (`""` for bare integer).
+    /// Used only for diagnostic formatting.
+    fn as_str(self) -> &'static str {
+        match self {
+            SuffixKind::None => "",
+            SuffixKind::I8 => "i8",
+            SuffixKind::I16 => "i16",
+            SuffixKind::I32 => "i32",
+            SuffixKind::I64 => "i64",
+            SuffixKind::U8 => "u8",
+            SuffixKind::U16 => "u16",
+            SuffixKind::U32 => "u32",
+            SuffixKind::U64 => "u64",
+            SuffixKind::F32 => "f32",
+            SuffixKind::F64 => "f64",
+        }
+    }
+}
+
+/// Port of `validateIntRange` from `src/codegen_expr.cpp:30-80`. Returns
+/// `Ok(())` if the magnitude fits; on overflow returns the diagnostic
+/// message to surface via `set_last_error`.
+///
+/// Mirrors the C++ semantics exactly:
+/// - `NumberExpr.value` is the unsigned bit pattern of a non-negative
+///   magnitude (negative literals arrive as `UnaryExpr` wrapping a
+///   `NumberExpr`, handled by the C++ fast-path).
+/// - Signed suffixes accept up to `INT{N}_MAX`. The `INT{N}_MIN`
+///   magnitude is only legal via the C++ UnaryExpr fast-path.
+/// - For unsigned suffixes the diagnostic displays the bit pattern as
+///   unsigned so large `u64` literals don't render as negative numbers.
+fn validate_int_range(magnitude: u64, kind: SuffixKind) -> Result<(), String> {
+    let fmt = || -> String {
+        // Unsigned suffixes: show the bit pattern as unsigned.
+        match kind {
+            SuffixKind::U8 | SuffixKind::U16 | SuffixKind::U32 | SuffixKind::U64 => {
+                magnitude.to_string()
+            }
+            _ => (magnitude as i64).to_string(),
+        }
+    };
+    match kind {
+        SuffixKind::I8 => {
+            if magnitude > i8::MAX as u64 {
+                return Err(format!("i8 literal out of range: {}", fmt()));
+            }
+        }
+        SuffixKind::I16 => {
+            if magnitude > i16::MAX as u64 {
+                return Err(format!("i16 literal out of range: {}", fmt()));
+            }
+        }
+        SuffixKind::I32 => {
+            if magnitude > i32::MAX as u64 {
+                return Err(format!("i32 literal out of range: {}", fmt()));
+            }
+        }
+        SuffixKind::I64 => {
+            // Magnitude > INT64_MAX cannot fit in signed i64 except via the
+            // UnaryExpr fast-path (which handles the INT64_MIN edge).
+            if (magnitude as i64) < 0 {
+                return Err(format!("i64 literal out of range: {}", fmt()));
+            }
+        }
+        SuffixKind::U8 => {
+            if magnitude > u8::MAX as u64 {
+                return Err(format!("u8 literal out of range: {}", fmt()));
+            }
+        }
+        SuffixKind::U16 => {
+            if magnitude > u16::MAX as u64 {
+                return Err(format!("u16 literal out of range: {}", fmt()));
+            }
+        }
+        SuffixKind::U32 => {
+            if magnitude > u32::MAX as u64 {
+                return Err(format!("u32 literal out of range: {}", fmt()));
+            }
+        }
+        // `u64`: any 64-bit pattern is valid.
+        // `None`: bare-int empty suffix handled separately by `lower_int_const`.
+        // `F32`/`F64`: not integer suffixes.
+        SuffixKind::U64 | SuffixKind::None | SuffixKind::F32 | SuffixKind::F64 => {}
+    }
+    Ok(())
+}
+
+/// Port of `emitExprVariant(NumberExpr)` from `src/codegen_expr.cpp:88-112`.
+///
+/// `magnitude` is the parser-provided unsigned bit pattern (negative
+/// literals arrive as `UnaryExpr`). `suffix_kind` is the C++ shim's enum
+/// mapping of `e.suffix`. `signed_bit` is non-zero for signed contexts
+/// (matches `ConstantInt::get(.., isSigned)`).
+///
+/// On range overflow or bare-int negative bit-pattern, populates the
+/// thread-local error slot and returns `0`. The caller checks `id == 0`,
+/// retrieves the message via `ry_lower_get_last_error`, and surfaces it
+/// through `codegenError`.
+///
+/// # Safety
+///
+/// `ctx` and `llvm_ty` must be valid handles (or NULL) — same contract as
+/// every other `ry_lower_*` entry.
+pub(crate) unsafe fn lower_int_const(
+    ctx: *mut RyEmitCtx,
+    llvm_ty: RyTypeRef,
+    magnitude: u64,
+    suffix_kind: u8,
+    signed_bit: u8,
+) -> RyValueId {
+    let Some(kind) = SuffixKind::from_u8(suffix_kind) else {
+        set_last_error(&format!(
+            "lower: unknown suffix_kind {} for int literal",
+            suffix_kind
+        ));
+        return 0;
+    };
+
+    if kind == SuffixKind::None {
+        // Bare `int` is i64. With the strtoull-based parser a negative bit
+        // pattern means the literal exceeds INT64_MAX (negative literals
+        // arrive as UnaryExpr, so NumberExpr.value is always a non-negative
+        // magnitude). Reject so users must either add a `u64` suffix or a
+        // u-type annotation (handled by emitVarDecl suffix injection).
+        if (magnitude as i64) < 0 {
+            set_last_error(&format!(
+                "integer literal out of range for int: {}",
+                magnitude
+            ));
+            return 0;
+        }
+    } else if let Err(msg) = validate_int_range(magnitude, kind) {
+        set_last_error(&msg);
+        return 0;
+    }
+
+    // No metadata stamping on the result: LLVM's constant uniquing shares
+    // the same pointer for identical (type, value) pairs, causing metadata
+    // corruption when different suffixes map to the same constant (#311).
+    // Suffix info is propagated via the AST (getExprLowLevelSuffix) on the
+    // C++ side instead.
+    ry_emit_const_int(ctx, llvm_ty, magnitude, signed_bit as core::ffi::c_int)
+}
+
+/// Port of `emitExprVariant(FloatExpr)` from `src/codegen_expr.cpp:114-121`.
+///
+/// `llvm_ty` is the LLVM type the C++ shim selected from the suffix
+/// (`f64Ty_` for empty / `f64` suffix, `f32Ty_` for `f32`). `value` is
+/// the parser-provided double. `suffix_kind` is included for parity with
+/// `lower_int_const`'s signature and for future error-path use, but no
+/// validation is performed today — IEEE 754 overflow to infinity is
+/// accepted, matching the C++ side.
+///
+/// The float path has no error channel today; it always succeeds. The
+/// `suffix_kind` is sanity-checked only to reject unknown values that
+/// would indicate a boundary protocol break.
+///
+/// # Safety
+///
+/// `ctx` and `llvm_ty` must be valid handles (or NULL).
+pub(crate) unsafe fn lower_float_const(
+    ctx: *mut RyEmitCtx,
+    llvm_ty: RyTypeRef,
+    value: f64,
+    suffix_kind: u8,
+) -> RyValueId {
+    let Some(kind) = SuffixKind::from_u8(suffix_kind) else {
+        set_last_error(&format!(
+            "lower: unknown suffix_kind {} for float literal",
+            suffix_kind
+        ));
+        return 0;
+    };
+    // Reject non-float suffix_kind values defensively — the C++ shim
+    // should only pass None / F32 / F64 here.
+    match kind {
+        SuffixKind::None | SuffixKind::F32 | SuffixKind::F64 => {}
+        other => {
+            set_last_error(&format!(
+                "lower: non-float suffix '{}' on float literal",
+                other.as_str()
+            ));
+            return 0;
+        }
+    }
+    // No metadata stamping (#311 discipline) — same reasoning as
+    // `lower_int_const`.
+    ry_emit_const_fp(ctx, llvm_ty, value)
+}

--- a/crates/lower/src/expr.rs
+++ b/crates/lower/src/expr.rs
@@ -175,6 +175,18 @@ pub(crate) unsafe fn lower_int_const(
         return 0;
     };
 
+    // Mirror the defensive check in `lower_float_const`: a float suffix on
+    // the int path would call `ry_emit_const_int` with a float-resolved
+    // `llvm_ty` (LLVM undefined behavior). The C++ shim should never send
+    // F32/F64 to this entry; reject defensively if it does.
+    if matches!(kind, SuffixKind::F32 | SuffixKind::F64) {
+        set_last_error(&format!(
+            "lower: non-integer suffix '{}' on int literal",
+            kind.as_str()
+        ));
+        return 0;
+    }
+
     if kind == SuffixKind::None {
         // Bare `int` is i64. With the strtoull-based parser a negative bit
         // pattern means the literal exceeds INT64_MAX (negative literals

--- a/crates/lower/src/lib.rs
+++ b/crates/lower/src/lib.rs
@@ -20,4 +20,6 @@
 
 mod abi;
 mod emit_extern;
+mod error;
+mod expr;
 mod handles;

--- a/include/ry/llvm_emit/api.h
+++ b/include/ry/llvm_emit/api.h
@@ -1188,6 +1188,13 @@ RyValueId ry_emit_select(RyEmitCtx *ctx, RyValueId cond_id, RyValueId then_id,
 RyValueId ry_emit_const_int(RyEmitCtx *ctx, RyTypeRef ty, uint64_t value,
                             int sign_extend);
 
+// Materialize a floating-point constant (ConstantFP::get equivalent); return
+// the interned constant handle. `ty` selects f32 vs f64 (the value is
+// narrowed to the target type's representation by LLVMConstReal). Emits no
+// instruction. Added for upper-codegen Stage 1 (#2483) so the Rust lower
+// layer can lower FloatExpr to LLVM constants.
+RyValueId ry_emit_const_fp(RyEmitCtx *ctx, RyTypeRef ty, double value);
+
 // Materialize a null constant (LLVMConstNull). For pointer types this is the
 // typed null pointer (`ConstantPointerNull::get` equivalent) used in null-guard
 // `icmp eq` comparisons; works for any type. Added for pilot G (#2196): the GC

--- a/include/ry/lower/api.h
+++ b/include/ry/lower/api.h
@@ -38,6 +38,81 @@ extern "C" {
 // `CodeGen::emitExprVariant(const BoolExpr &)`.
 RyValueId ry_lower_bool_const(RyEmitCtx *ctx, RyTypeRef i1_ty, int value);
 
+// =========================================================================
+// Stage 1 (#2483) — primitive literal lowering.
+//
+// `NumberExpr` / `FloatExpr` lowering moves from C++
+// (`src/codegen_expr.cpp:88-121`) to the lower crate. Suffix-based type
+// selection is still resolved on the C++ side (the LLVM type registry
+// moves to Rust at Stage 5); the suffix kind is passed as an enum so the
+// Rust side can apply the correct range-check arm and frame diagnostics.
+// =========================================================================
+
+// Suffix kind discriminator for the int / float const entries. Numeric
+// values are a stable boundary contract; do NOT reorder without updating
+// the mirroring `SuffixKind` enum in `crates/lower/src/expr.rs`.
+typedef enum RyLowerSuffixKind {
+    RY_LOWER_SUFFIX_NONE = 0,
+    RY_LOWER_SUFFIX_I8   = 1,
+    RY_LOWER_SUFFIX_I16  = 2,
+    RY_LOWER_SUFFIX_I32  = 3,
+    RY_LOWER_SUFFIX_I64  = 4,
+    RY_LOWER_SUFFIX_U8   = 5,
+    RY_LOWER_SUFFIX_U16  = 6,
+    RY_LOWER_SUFFIX_U32  = 7,
+    RY_LOWER_SUFFIX_U64  = 8,
+    RY_LOWER_SUFFIX_F32  = 9,
+    RY_LOWER_SUFFIX_F64  = 10,
+} RyLowerSuffixKind;
+
+// Lower a Ry `NumberExpr` to an LLVM integer constant. `llvm_ty` is the
+// LLVM type the caller resolved from the suffix (`resolveType(e.suffix)`,
+// or `i64Ty_` when `e.suffix` is empty); `magnitude` is the parser's
+// unsigned bit pattern (negative literals arrive as `UnaryExpr` and are
+// handled by a C++ fast-path before reaching this entry). `suffix_kind`
+// is one of `RY_LOWER_SUFFIX_*`; `signed_bit` is non-zero in signed
+// contexts (matches the original `ConstantInt::get(.., isSigned)` flag).
+//
+// On range overflow or bare-int negative bit-pattern, returns 0 and
+// populates a thread-local diagnostic string retrievable via
+// `ry_lower_get_last_error`. The caller MUST check the return value:
+//
+//     RyValueId id = ry_lower_int_const(...);
+//     if (id == 0) {
+//         const char *msg = ry_lower_get_last_error();
+//         codegenError(msg ? std::string(msg) : "lower: unspecified error");
+//     }
+RyValueId ry_lower_int_const(RyEmitCtx *ctx, RyTypeRef llvm_ty,
+                             uint64_t magnitude, uint8_t suffix_kind,
+                             uint8_t signed_bit);
+
+// Lower a Ry `FloatExpr` to an LLVM floating-point constant. `llvm_ty`
+// is the LLVM type the caller selected (`f64Ty_` for empty / `f64`
+// suffix, `f32Ty_` for `f32`); `value` is the parser's double.
+// `suffix_kind` must be `RY_LOWER_SUFFIX_NONE`, `RY_LOWER_SUFFIX_F32`,
+// or `RY_LOWER_SUFFIX_F64`.
+//
+// No range check (IEEE 754 overflow to infinity is accepted, matching
+// the C++ side). Has no error path under normal operation; the
+// `ry_lower_get_last_error` channel is consulted only if the caller
+// passes a non-float `suffix_kind` (protocol break).
+RyValueId ry_lower_float_const(RyEmitCtx *ctx, RyTypeRef llvm_ty,
+                               double value, uint8_t suffix_kind);
+
+// Retrieve the most recently set error message for this thread, or NULL
+// if none was set since the last `ry_lower_*` entry was called. The
+// returned pointer is valid ONLY until the next `ry_lower_*` call on
+// the same thread (which clears the slot at entry — see the Stage 1
+// boundary contract in `docs/architecture/upper-codegen-migration.md`).
+// The caller MUST copy the string before issuing any other boundary
+// call.
+//
+// Cross-stage contract: `RyValueId = 0` from any `ry_lower_*` entry that
+// supports error reporting means "this call failed". The paired
+// `ry_lower_get_last_error()` return value is always fresh (set inside
+// the failing call), never stale.
+const char *ry_lower_get_last_error(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -27,56 +27,30 @@ std::string anyArithRejectionMsg(const std::string &op_desc) {
 }
 }
 
-// Range check for suffixed integer literals.
-//
-// NumberExpr.value holds the unsigned bit pattern of a non-negative magnitude
-// (see ast.hpp: negation is expressed as UnaryExpr). Signed suffixes accept
-// magnitudes up to 2^(N-1) — `-INT{N}_MIN` for `-INT{N}_MIN` itself via
-// UnaryExpr. Unsigned suffixes compare the bit pattern as uint64_t because
-// `u64` max is stored as `int64_t(-1)`.
-template<typename ErrorFn>
-static void validateIntRange(int64_t value, const std::string &suffix,
-                             ErrorFn error) {
-    uint64_t uval = static_cast<uint64_t>(value);
-    auto fmtValue = [&]() {
-        // Unsigned suffixes: show the bit pattern as unsigned so large u64
-        // literals don't render as negative numbers.
-        if (!suffix.empty() && suffix[0] == 'u')
-            return std::to_string(uval);
-        return std::to_string(value);
-    };
-    // Signed suffixes: positive literals must fit in INT{N}_MAX. The extra
-    // value `abs(INT{N}_MIN)` is only legal via a unary-minus wrapper, which
-    // is handled by a constant-fold fast-path in emitExprVariant(UnaryExpr)
-    // before this check runs.
-    if (suffix == "i8") {
-        if (uval > static_cast<uint64_t>(INT8_MAX))
-            error("i8 literal out of range: " + fmtValue());
-    } else if (suffix == "i16") {
-        if (uval > static_cast<uint64_t>(INT16_MAX))
-            error("i16 literal out of range: " + fmtValue());
-    } else if (suffix == "i32") {
-        if (uval > static_cast<uint64_t>(INT32_MAX))
-            error("i32 literal out of range: " + fmtValue());
-    } else if (suffix == "i64") {
-        // Magnitude > INT64_MAX cannot fit in a signed i64 even via unary
-        // minus (except the INT64_MIN edge case, which is caught by the
-        // same UnaryExpr fast-path).
-        if (value < 0)
-            error("i64 literal out of range: " + fmtValue());
-    } else if (suffix == "u8") {
-        if (uval > UINT8_MAX)
-            error("u8 literal out of range: " + fmtValue());
-    } else if (suffix == "u16") {
-        if (uval > UINT16_MAX)
-            error("u16 literal out of range: " + fmtValue());
-    } else if (suffix == "u32") {
-        if (uval > UINT32_MAX)
-            error("u32 literal out of range: " + fmtValue());
-    }
-    // suffix == "u64": any 64-bit bit pattern is valid; unary minus on a
-    // u64 is rejected earlier by isUnsignedLowLevelName in the UnaryExpr
-    // path, so no negative magnitude can reach this site.
+// Map a Ry numeric suffix string to its `RyLowerSuffixKind` enum value.
+// Empty suffix → `RY_LOWER_SUFFIX_NONE` (the bare-int case). Stage 1
+// (#2483) moves the actual range-check / constant-construction to
+// `crates/lower/`; this helper only translates the suffix for the
+// boundary call. The enum values are a stable boundary contract — keep
+// in sync with `RyLowerSuffixKind` in `include/ry/lower/api.h` and
+// `SuffixKind` in `crates/lower/src/expr.rs`.
+static uint8_t suffixKindFromString(const std::string &suffix) {
+    if (suffix.empty())    return RY_LOWER_SUFFIX_NONE;
+    if (suffix == "i8")    return RY_LOWER_SUFFIX_I8;
+    if (suffix == "i16")   return RY_LOWER_SUFFIX_I16;
+    if (suffix == "i32")   return RY_LOWER_SUFFIX_I32;
+    if (suffix == "i64")   return RY_LOWER_SUFFIX_I64;
+    if (suffix == "u8")    return RY_LOWER_SUFFIX_U8;
+    if (suffix == "u16")   return RY_LOWER_SUFFIX_U16;
+    if (suffix == "u32")   return RY_LOWER_SUFFIX_U32;
+    if (suffix == "u64")   return RY_LOWER_SUFFIX_U64;
+    if (suffix == "f32")   return RY_LOWER_SUFFIX_F32;
+    if (suffix == "f64")   return RY_LOWER_SUFFIX_F64;
+    // Unknown suffix — the lower layer rejects this and surfaces the
+    // diagnostic. Reaching here from a typed AST node is a bug; mapping
+    // to NONE lets the lower side produce a structured diagnostic
+    // instead of crashing.
+    return RY_LOWER_SUFFIX_NONE;
 }
 
 llvm::Value *CodeGen::emitExpr(const ExprNode &node) {
@@ -86,38 +60,42 @@ llvm::Value *CodeGen::emitExpr(const ExprNode &node) {
 }
 
 llvm::Value *CodeGen::emitExprVariant(const NumberExpr &e) {
-    if (e.suffix.empty()) {
-        // Bare `int` is i64. With the strtoull-based parser a negative bit
-        // pattern means the literal exceeds INT64_MAX (negative literals
-        // arrive as UnaryExpr, so NumberExpr.value is always a non-negative
-        // magnitude). Reject so users must either add a `u64` suffix or a
-        // u-type annotation (handled by emitVarDecl suffix injection).
-        if (e.value < 0)
-            codegenError("integer literal out of range for int: " +
-                         std::to_string(static_cast<uint64_t>(e.value)));
-        return llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(e.value), true);
+    // Upper-codegen Stage 1 (#2483): the Ry-semantic decisions (suffix →
+    // type selection, range validation, `ConstantInt::get` construction)
+    // moved to `crates/lower/`. The shim resolves the LLVM type and
+    // signedness from the suffix string (the type registry moves to Rust
+    // at Stage 5) and forwards the rest of the work via
+    // `ry_lower_int_const`. The do-NOT-stamp-metadata discipline (#311
+    // LLVM constant uniquing trap) is preserved on the Rust side — no
+    // metadata writes happen on the returned constant.
+    llvm::Type *ty = e.suffix.empty() ? i64Ty_ : resolveType(e.suffix);
+    bool isSigned = e.suffix.empty() ? true : !isUnsignedLowLevelName(e.suffix);
+    RyValueId id = ry_lower_int_const(
+        emit_ctx_, ry::llvm_emit::asRyType(ty),
+        static_cast<uint64_t>(e.value),
+        suffixKindFromString(e.suffix),
+        isSigned ? 1 : 0);
+    if (id == 0) {
+        const char *msg = ry_lower_get_last_error();
+        codegenError(msg ? std::string(msg) : "lower: unspecified error");
     }
-
-    validateIntRange(e.value, e.suffix,
-        [this](const std::string &msg) { codegenError(msg); });
-
-    llvm::Type *ty = resolveType(e.suffix);
-    bool isSigned = !isUnsignedLowLevelName(e.suffix);
-    auto *result = llvm::ConstantInt::get(ty, static_cast<uint64_t>(e.value), isSigned);
-    // Do NOT set low_level_type_names_ on ConstantInt: LLVM's constant uniquing
-    // shares the same pointer for identical (type, value) pairs, causing metadata
-    // corruption when different suffixes map to the same constant (#311).
-    // Suffix info is propagated via AST (getExprLowLevelSuffix) instead.
-    return result;
+    return ry::llvm_emit::asLlvmValue(ry_emit_resolve(emit_ctx_, id));
 }
 
 llvm::Value *CodeGen::emitExprVariant(const FloatExpr &e) {
-    if (e.suffix.empty() || e.suffix == "f64")
-        return llvm::ConstantFP::get(f64Ty_, e.value);
-    // suffix == "f32"
-    auto *result = llvm::ConstantFP::get(f32Ty_, e.value);
-    // Do NOT set low_level_type_names_ on ConstantFP (same reason as NumberExpr, #311).
-    return result;
+    // Upper-codegen Stage 1 (#2483): same shim pattern as NumberExpr.
+    // Type selection is special-cased because `resolveType("")` does not
+    // yield `f64Ty_` — the empty / `f64` / `f32` choice happens here.
+    llvm::Type *ty = (e.suffix.empty() || e.suffix == "f64") ? f64Ty_ : f32Ty_;
+    RyValueId id = ry_lower_float_const(
+        emit_ctx_, ry::llvm_emit::asRyType(ty),
+        e.value,
+        suffixKindFromString(e.suffix));
+    if (id == 0) {
+        const char *msg = ry_lower_get_last_error();
+        codegenError(msg ? std::string(msg) : "lower: unspecified error");
+    }
+    return ry::llvm_emit::asLlvmValue(ry_emit_resolve(emit_ctx_, id));
 }
 
 llvm::Value *CodeGen::emitExprVariant(const BoolExpr &e) {
@@ -275,10 +253,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<UnaryExpr> &e) {
     SourceLocation outer_loc = current_loc_;
     // Constant-fold `-<int literal>` before recursing into emitExpr, so that
     // magnitudes up to `|INT{N}_MIN|` are accepted (e.g. `-128i8`,
-    // `-9223372036854775808i64`, `-9223372036854775808`). validateIntRange
-    // limits a bare NumberExpr to INT{N}_MAX; the unary-minus wrapper is the
-    // only way to reach the signed MIN edge. Bare int (empty suffix) is
-    // treated as i64 (#1025).
+    // `-9223372036854775808i64`, `-9223372036854775808`). The lower-layer
+    // `validate_int_range` (since Stage 1 #2483) limits a bare NumberExpr to
+    // INT{N}_MAX; the unary-minus wrapper is the only way to reach the
+    // signed MIN edge. Bare int (empty suffix) is treated as i64 (#1025).
     if (e->op == "-") {
         if (auto *ne = std::get_if<NumberExpr>(&e->operand->data)) {
             const bool isBareInt = ne->suffix.empty();

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -46,11 +46,12 @@ static uint8_t suffixKindFromString(const std::string &suffix) {
     if (suffix == "u64")   return RY_LOWER_SUFFIX_U64;
     if (suffix == "f32")   return RY_LOWER_SUFFIX_F32;
     if (suffix == "f64")   return RY_LOWER_SUFFIX_F64;
-    // Unknown suffix — the lower layer rejects this and surfaces the
-    // diagnostic. Reaching here from a typed AST node is a bug; mapping
-    // to NONE lets the lower side produce a structured diagnostic
-    // instead of crashing.
-    return RY_LOWER_SUFFIX_NONE;
+    // Unknown suffix — return a value outside the enum so the lower side
+    // `SuffixKind::from_u8` rejects it via the `unknown suffix_kind`
+    // diagnostic. Mapping to `NONE` would silently treat the literal as
+    // a bare int and bypass the new error-channel contract; using an
+    // out-of-band byte (0xFF) trips the structured diagnostic instead.
+    return 0xFF;
 }
 
 llvm::Value *CodeGen::emitExpr(const ExprNode &node) {

--- a/tests/filecheck/float_const_stage1_2483.ry
+++ b/tests/filecheck/float_const_stage1_2483.ry
@@ -1,0 +1,27 @@
+# FileCheck golden for #2483 — upper-codegen Stage 1, FloatExpr migration.
+#
+# `emitExprVariant(FloatExpr)` is the Stage 1 lowering: the suffix → type
+# selection (`f64` for empty / `f64`; `f32` for `f32`) and the
+# `ConstantFP::get` construction move from C++ (`src/codegen_expr.cpp:
+# 114-121`) to `crates/lower/`'s `ry_lower_float_const`, which calls
+# `ry_emit_const_fp(ctx, ty, value)`. Both paths must produce
+# byte-identical float constants — this golden locks that invariant for
+# both suffix cases:
+#
+#   - `1.5f32`   → `float 1.500000e+00`   (single-precision)
+#   - `2.0`      → `double 2.000000e+00`  (default double)
+#
+# The probe stores each literal into a named local so the constants
+# outlive sema-folding.
+#
+# CHECK-LABEL: define double @floatPilotProbe()
+# CHECK: store float 1.500000e+00, ptr %a
+# CHECK: store double 2.000000e+00, ptr %b
+
+fn floatPilotProbe() -> float:
+    a = 1.5f32
+    b = 2.0
+    return b
+
+fn main():
+    _ = floatPilotProbe()

--- a/tests/filecheck/int_const_stage1_2483.ry
+++ b/tests/filecheck/int_const_stage1_2483.ry
@@ -1,0 +1,31 @@
+# FileCheck golden for #2483 — upper-codegen Stage 1, NumberExpr migration.
+#
+# `emitExprVariant(NumberExpr)` is the Stage 1 lowering: the suffix → type
+# selection, range validation, and the `ConstantInt::get` construction
+# move from C++ (`src/codegen_expr.cpp:88-112`) to `crates/lower/`'s
+# `ry_lower_int_const`, which calls `ry_emit_const_int(ctx, ty, value,
+# sign_extend)`. Both paths must produce byte-identical integer constants
+# — this golden locks that invariant for three representative suffixes:
+#
+#   - bare `int`  → `i64 42`            (signed i64, signed_bit=1)
+#   - `42i8`      → `i8 42`              (signed i8, signed_bit=1)
+#   - `0xFFu32`   → `i32 255`            (unsigned i32 hex, signed_bit=0)
+#
+# The probe stores each literal into a named local so the constants
+# outlive sema (a bare `if 42 > 0 { ... }` would be sema-folded and never
+# reach the migrated path — the vacuous-diff trap called out in
+# docs/architecture/upper-codegen-migration.md §"Verification").
+#
+# CHECK-LABEL: define i64 @intPilotProbe()
+# CHECK: store i64 42, ptr %a
+# CHECK: store i8 42, ptr %b
+# CHECK: store i32 255, ptr %c
+
+fn intPilotProbe() -> int:
+    a = 42
+    b = 42i8
+    c = 0xFFu32
+    return a
+
+fn main():
+    _ = intPilotProbe()

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1034,6 +1034,40 @@ TEST_F(CodeGenTest, NumericLiteralSuffix_OutOfRange) {
     EXPECT_THROW(runSource("x = -1u32"), std::runtime_error);
 }
 
+// Stage 1 (#2483): after `validateIntRange` moved to `crates/lower/`, the
+// diagnostic message crosses the C++ → Rust → C++ boundary via the
+// thread-local `ry_lower_get_last_error` channel. `EXPECT_THROW` above
+// catches the throw but not message regression. Lock the exact strings so a
+// future migration step can't silently rewrite them.
+//
+// Rust error path: `NumberExpr` literals with a positional suffix go through
+// `ry_lower_int_const` → `validate_int_range` → `set_last_error`.
+TEST_F(CodeGenTest, NumericLiteralSuffix_OutOfRange_Messages_RustPath) {
+    expectCompileError("x = 256u8",  "u8 literal out of range: 256");
+    expectCompileError("x = 129i8",  "i8 literal out of range: 129");
+    expectCompileError("x = 65536u16", "u16 literal out of range: 65536");
+    expectCompileError("x = 9223372036854775808i64",
+                       "i64 literal out of range: -9223372036854775808");
+    // Bare-int (`None` arm) message: distinct from the suffixed arms above.
+    // Reaches the Rust path when no u-type annotation can be inferred — a
+    // function-`return` position is one such site (no LHS-driven suffix
+    // injection from `emitVarDecl`).
+    expectCompileError(
+        "fn f() -> int:\n    return 9223372036854775808\nfn main():\n    _ = f()\n",
+        "integer literal out of range for int: 9223372036854775808");
+}
+
+// UnaryExpr fast-path coverage: `-129i8` etc. flow through the C++ fast-path
+// at `src/codegen_expr.cpp:282-308`, NOT through `ry_lower_int_const`. They
+// are kept here so a future refactor that accidentally collapses the
+// fast-path doesn't regress these diagnostics.
+TEST_F(CodeGenTest, NumericLiteralSuffix_OutOfRange_Messages_UnaryFastPath) {
+    expectCompileError("x = -129i8", "i8 literal out of range: -129");
+    // Legal edges that the UnaryExpr fast-path must still accept.
+    EXPECT_NO_THROW(runSource("x = -128i8\nprint(x)"));
+    EXPECT_NO_THROW(runSource("x = -9223372036854775808\nprint(x)"));
+}
+
 // ===== [contract] Unsigned variable negation error (#312) =====
 
 TEST_F(CodeGenTest, UnsignedVariableNegation_u8) {


### PR DESCRIPTION
## Summary

Stage 1 of the upper-codegen Rust migration. `NumberExpr` / `FloatExpr` lowering moves from C++ (`src/codegen_expr.cpp:88-121` plus the `validateIntRange` template) to `crates/lower/`. Three new boundary capabilities the Stage 0 `BoolExpr` pilot didn't need are added: (a) suffix → type selection, (b) range validation, (c) the cross-stage error-return channel that every later stage will share.

- New: `ry_lower_int_const`, `ry_lower_float_const`, `ry_lower_get_last_error` (lower boundary) + `ry_emit_const_fp` (emit precondition — was missing).
- Cross-stage error contract established: `clear_last_error()` at every `ry_lower_*` entry → `RyValueId = 0` always pairs with a fresh diagnostic from the failing call (no stale state). Lifetime contract documented in `include/ry/lower/api.h`.
- Byte-identical IR + diagnostics: locked by 2 new FileCheck goldens (`tests/filecheck/{int,float}_const_stage1_2483.ry`, 5 probes) and a `NumericLiteralSuffix_OutOfRange_Messages_*` GTest pair covering all 4 Rust error branches (`u8` / `i8` / `u16` / `i64` arms + bare-int `None` arm) plus the UnaryExpr fast-path. UnaryExpr fast-paths (`:282-308` etc.), `resolveType`, `isUnsignedLowLevelName` remain in C++ (Stage 4 / 5 scope).

Refs: `docs/architecture/upper-codegen-migration.md` §"Stage 1 — primitive literals".
No user-visible behavior change (byte-identical IR + byte-identical diagnostic strings) → no `changelog.d/` entry.

## Test plan

- [x] `cmake --build build-rust` green (Rust + C++)
- [x] `./build-rust/ry_tests` — 3146 / 3146 pass (including new `*_OutOfRange_Messages_*` GTests)
- [x] `ctest --test-dir build-rust -L filecheck` — 46 / 46 pass (bool pilot unaffected + 2 new Stage 1 goldens)
- [x] `./build-rust/ry test -p` — 221 spec test files, 0 failures
- [x] Rust lint (`run-rust-lint.sh`) — `cargo fmt --check` + `clippy -D warnings` clean
- [x] Static analysis (`run-static-analysis-all.sh`) — cppcheck clean
- [x] ASan + UBSan (`run-asan.sh`) — 221 files, 0 failures
- [x] `grep -rn validateIntRange src/ include/` — no functional references (dead C++ template removed)
- [x] Byte-exact IR diff against probes — 0 lines

Closes #2483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for floating-point constants and expanded numeric literal lowering for both integer and float suffixes.
  * Numeric literals now preserve expected type selection and constant values more consistently across the pipeline.
* **Bug Fixes**
  * Improved out-of-range literal diagnostics, including clearer messages for bare integers and suffixed values.
  * Fixed handling for negative and boundary numeric literals so valid cases continue to compile correctly.
* **Tests**
  * Added golden and diagnostic tests covering integer and floating-point constant codegen behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->