### PR TITLE
refactor(codegen): migrate StringExpr / RegexExpr lowering to crates/lower (#2484)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,6 +691,7 @@ add_executable(ry_tests
     tests/test_header_layout.cpp
     tests/test_emit_abi_guards.cpp
     tests/test_codegen_gc_visit.cpp
+    tests/test_codegen_string_const_stage2.cpp
 )
 if(APPLE)
     target_link_libraries(ry_tests PRIVATE

--- a/crates/emit/src/abi/arc.rs
+++ b/crates/emit/src/abi/arc.rs
@@ -3,9 +3,17 @@
 //! atomic flag / nullable callees into the Rust-native `Atomicity` /
 //! `Option<ValueRef>`, then calls the `core` engine method on `EmitCtx` (the
 //! convergence point shared with the Rust-direct path in `any.rs`).
+//!
+//! Stage 2 (#2484) added `ry_emit_build_arc_global`: the StringHeader-prefixed
+//! ARC-immortal global builder reached by the lower crate's string / regex
+//! literal lowering. Uncached at this layer — the lower crate manages two
+//! independent caches (string + regex) to preserve the regex separation
+//! invariant (#306) that `addResourceKind(rk_regex)` would otherwise violate
+//! by poisoning a string global of identical bytes.
 
 use std::ffi::c_int;
 
+use crate::composite::arc::build_arc_global_raw;
 use crate::context::{Atomicity, ValueRef};
 
 use super::*;
@@ -89,4 +97,58 @@ pub unsafe extern "C" fn ry_emit_arc_counter_delta(ctx: *mut RyEmitCtx, delta: i
         return;
     };
     c.arc_counter_delta(delta);
+}
+
+/// Build a StringHeader-prefixed ARC-immortal global for the byte range
+/// `bytes[0..len)` and return the interned `RyValueId` of the
+/// in-bounds-GEP `ptr` to its first payload byte. `name_hint_bytes[0..
+/// name_hint_len)` becomes the LLVM global name prefix (the helper appends
+/// `".arc"`). No cache lookup at this layer — the lower crate (Stage 2
+/// #2484) owns the per-cache dedup that preserves the regex separation
+/// invariant (`addResourceKind(rk_regex)` must not poison a string global
+/// of identical bytes, #306). Every call allocates a fresh global.
+///
+/// Length-passed name (not NUL-terminated) — `llvm::Twine::toStringRef`
+/// does NOT guarantee a NUL terminator for multi-node Twines, so the C++
+/// `cachedGlobalString` wrapper forwards the StringRef length explicitly
+/// rather than relying on a NUL contract.
+///
+/// NULL ctx → 0. NULL `bytes` with non-zero `len` → 0. NULL
+/// `name_hint_bytes` with non-zero `name_hint_len` → 0. Zero-length
+/// `name_hint_len` is permitted (equivalent to an empty hint).
+#[no_mangle]
+pub unsafe extern "C" fn ry_emit_build_arc_global(
+    ctx: *mut RyEmitCtx,
+    bytes: *const u8,
+    len: usize,
+    name_hint_bytes: *const u8,
+    name_hint_len: usize,
+) -> RyValueId {
+    let Some(c) = checked_cx(ctx) else {
+        return 0;
+    };
+    // Borrow both byte ranges as slices under the C `(ptr, count)`
+    // contract — empty (len=0) permits a NULL pointer, otherwise NULL
+    // is the entry's invalid sentinel. Mirrors `ffi_slice` in
+    // `crates/emit/src/abi.rs`, but with `usize` rather than `u32`
+    // because the Stage 2 boundary uses `size_t`-typed lengths
+    // (matching the C++ `std::string::size()` source).
+    #[inline]
+    unsafe fn opt_slice<'a>(p: *const u8, n: usize) -> Option<&'a [u8]> {
+        if n == 0 {
+            Some(&[])
+        } else if p.is_null() {
+            None
+        } else {
+            Some(std::slice::from_raw_parts(p, n))
+        }
+    }
+    let (Some(slice), Some(name)) = (
+        opt_slice(bytes, len),
+        opt_slice(name_hint_bytes, name_hint_len),
+    ) else {
+        return 0;
+    };
+    let v = build_arc_global_raw(c, slice, name);
+    intern(c, to_ry_value(v))
 }

--- a/crates/emit/src/composite/arc.rs
+++ b/crates/emit/src/composite/arc.rs
@@ -42,18 +42,18 @@ extern "C" {
 // Distinct from `primitive::global::get_or_create_msg_global`, which builds a
 // plain `[N+1 x i8]` global used by `ry_emit_bounds_error`.
 //
-// Dedup is keyed on message bytes — repeated calls with the same content
-// share one global, mirroring the C++ `global_string_cache_`. `name` is the
-// caller-supplied global-name hint; this helper appends `.arc` to it (matching
-// `buildArcGlobal`'s `name + ".arc"`).
-pub(crate) unsafe fn get_or_create_arc_msg_global(
+// No dedup at this layer — callers that need byte-keyed interning use the
+// `get_or_create_arc_msg_global` wrapper (runtime error msg path, #2097). The
+// Stage 2 (#2484) `ry_emit_build_arc_global` boundary calls this raw function
+// directly so the lower crate can own the string/regex separation invariant
+// with its own per-cache dedup. `name_bytes` is the caller-supplied global-
+// name hint as a byte slice (no NUL terminator required); this helper
+// appends `.arc` to it (matching `buildArcGlobal`'s `name + ".arc"`).
+pub(crate) unsafe fn build_arc_global_raw(
     c: &mut EmitCtx,
     msg: &[u8],
-    name: *const c_char,
+    name_bytes: &[u8],
 ) -> LLVMValueRef {
-    if let Some(&gv) = c.arc_msg_cache.get(msg) {
-        return gv;
-    }
     let context = c.context;
     let i64_ty = i64_type(context);
     let i32_ty = i32_type(context);
@@ -69,8 +69,8 @@ pub(crate) unsafe fn get_or_create_arc_msg_global(
     let mut elements = [arc_immortal, zero_i64, byte_len, str_data];
     let init_val = LLVMConstNamedStruct(wrap_ty, elements.as_mut_ptr(), 4);
     // Append ".arc" to the global name (matches buildArcGlobal's `name +
-    // ".arc"`).
-    let name_bytes = cstr_bytes(name);
+    // ".arc"`). `cname_pfx` is byte-slice-based — works with non-NUL-
+    // terminated `name_bytes`.
     let arc_name = cname_pfx(name_bytes, b".arc");
     let gv = LLVMAddGlobal(c.module, wrap_ty, arc_name.as_ptr());
     LLVMSetLinkage(gv, LLVMLinkage::LLVMPrivateLinkage);
@@ -85,7 +85,25 @@ pub(crate) unsafe fn get_or_create_arc_msg_global(
         LLVMConstInt(i32_ty, 3, 0),
         LLVMConstInt(i64_ty, 0, 0),
     ];
-    let gs = LLVMConstInBoundsGEP2(wrap_ty, gv, indices.as_mut_ptr(), 3);
+    LLVMConstInBoundsGEP2(wrap_ty, gv, indices.as_mut_ptr(), 3)
+}
+
+// Cached variant — dedups by message bytes via `EmitCtx::arc_msg_cache`, the
+// runtime-error-message path used by cast-helpers (#2097). Repeated calls
+// with the same content share one global, mirroring the C++ side's
+// `global_string_cache_`. Distinct from the Stage 2 `ry_emit_build_arc_global`
+// boundary which is intentionally uncached at this layer (the lower crate
+// manages two independent caches to preserve the regex separation invariant).
+pub(crate) unsafe fn get_or_create_arc_msg_global(
+    c: &mut EmitCtx,
+    msg: &[u8],
+    name: *const c_char,
+) -> LLVMValueRef {
+    if let Some(&gv) = c.arc_msg_cache.get(msg) {
+        return gv;
+    }
+    let name_bytes = cstr_bytes(name);
+    let gs = build_arc_global_raw(c, msg, name_bytes);
     c.arc_msg_cache.insert(msg.to_vec(), gs);
     gs
 }

--- a/crates/lower/src/abi.rs
+++ b/crates/lower/src/abi.rs
@@ -8,8 +8,27 @@
 
 use crate::emit_extern::ry_emit_const_int;
 use crate::error::clear_last_error;
-use crate::expr::{lower_float_const, lower_int_const};
+use crate::expr::{lower_float_const, lower_int_const, lower_regex_const, lower_string_const};
 use crate::handles::{RyEmitCtx, RyTypeRef, RyValueId};
+use crate::intern;
+
+/// Borrow `(ptr, len)` as `&[u8]` under the C `(pointer, count)` contract.
+/// Returns `Some(&[])` for a zero-count slice (NULL pointer permitted) and
+/// `None` for a non-zero count with a NULL pointer (the entry's invalid
+/// sentinel — `slice::from_raw_parts` requires a non-NULL base even for
+/// length-0). Mirrors `crates/emit/src/abi::ffi_slice` (which takes a
+/// `u32` count); the lower crate keeps its own copy because it has no
+/// emit-crate dependency.
+#[inline]
+unsafe fn opt_byte_slice<'a>(ptr: *const u8, len: usize) -> Option<&'a [u8]> {
+    if len == 0 {
+        Some(&[])
+    } else if ptr.is_null() {
+        None
+    } else {
+        Some(core::slice::from_raw_parts(ptr, len))
+    }
+}
 
 /// Materialize an `i1` constant for a Ry `BoolExpr`.
 ///
@@ -100,4 +119,101 @@ pub unsafe extern "C" fn ry_lower_float_const(
 ) -> RyValueId {
     clear_last_error();
     lower_float_const(ctx, llvm_ty, value, suffix_kind)
+}
+
+/// Materialize an ARC-immortal global for a Ry `StringExpr` (Stage 2 of
+/// the upper-codegen migration, #2484).
+///
+/// `bytes[0..len)` is the raw literal content (binary-safe — embedded
+/// NULs preserved). `name_hint_bytes[0..name_hint_len)` is the LLVM
+/// global name prefix (the C++ `cachedGlobalString` callers pass
+/// `.str`, `.fmt`, `.err_msg`, …) — passed by length, NOT as a
+/// NUL-terminated C string, because `llvm::Twine::toStringRef` does not
+/// guarantee a NUL terminator for multi-node Twines.
+///
+/// Cache hit returns the previously-interned `RyValueId`; cache miss
+/// calls `ry_emit_build_arc_global` and caches the result keyed on the
+/// byte content. Two distinct caches (string vs regex) preserve the
+/// regex separation invariant from #306.
+///
+/// Calls `clear_last_error()` at entry for boundary uniformity with the
+/// other `ry_lower_*` entries, though no failure path is currently
+/// exercised. Returns `0` only when `bytes` is NULL with non-zero `len`,
+/// when `name_hint_bytes` is NULL with non-zero `name_hint_len`, or
+/// when the underlying `ry_emit_build_arc_global` fails on a NULL ctx.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `RyEmitCtx *` (or NULL); `bytes` must point to
+/// at least `len` bytes (or be NULL when `len == 0`); `name_hint_bytes`
+/// must point to at least `name_hint_len` bytes (or be NULL when
+/// `name_hint_len == 0`).
+#[no_mangle]
+pub unsafe extern "C" fn ry_lower_string_const(
+    ctx: *mut RyEmitCtx,
+    bytes: *const u8,
+    len: usize,
+    name_hint_bytes: *const u8,
+    name_hint_len: usize,
+) -> RyValueId {
+    // Clear any stale diagnostic from a prior `ry_lower_*` call on this
+    // thread before we run — this entry does not itself populate
+    // `set_last_error`, but the cross-stage contract requires that a
+    // post-call `ry_lower_get_last_error` reflect THIS call's outcome
+    // (`NULL` on success) rather than a prior failed entry's message.
+    clear_last_error();
+    let (Some(slice), Some(name)) = (
+        opt_byte_slice(bytes, len),
+        opt_byte_slice(name_hint_bytes, name_hint_len),
+    ) else {
+        return 0;
+    };
+    lower_string_const(ctx, slice, name)
+}
+
+/// Materialize an ARC-immortal global for a Ry `RegexExpr` (Stage 2 of
+/// the upper-codegen migration, #2484).
+///
+/// Separate cache from `ry_lower_string_const` so a string `"hello"`
+/// and a regex `/hello/` produce DIFFERENT globals — the C++ shim then
+/// stamps `addResourceKind(rk_regex)` on the regex global without
+/// poisoning the string-side counterpart (#306). The LLVM global name
+/// prefix is hardcoded to `.regex`.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `RyEmitCtx *` (or NULL); `bytes` must point to
+/// at least `len` bytes (or be NULL when `len == 0`).
+#[no_mangle]
+pub unsafe extern "C" fn ry_lower_regex_const(
+    ctx: *mut RyEmitCtx,
+    bytes: *const u8,
+    len: usize,
+) -> RyValueId {
+    // See `ry_lower_string_const` for the clear-stale-error rationale.
+    clear_last_error();
+    let Some(slice) = opt_byte_slice(bytes, len) else {
+        return 0;
+    };
+    lower_regex_const(ctx, slice)
+}
+
+/// Clear the per-module thread-local string / regex interning caches.
+/// MUST be called from the C++ `CodeGen` constructor immediately after
+/// `ry_emit_ctx_create`. Sequential `CodeGen` instances on the same
+/// thread would otherwise resolve cached ids against the previous (now
+/// freed) `EmitCtx`, producing miscompiles or LLVM null-pointer
+/// dereferences.
+///
+/// The `_ctx` parameter is unused today; it's accepted to signal that
+/// this hook is conceptually per-`EmitCtx` (a future migration to
+/// per-ctx state can change the implementation without changing the
+/// ABI shape).
+///
+/// # Safety
+///
+/// `_ctx` is currently unused; it may be NULL or a valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn ry_lower_reset_module_state(_ctx: *mut RyEmitCtx) {
+    intern::reset_all();
 }

--- a/crates/lower/src/emit_extern.rs
+++ b/crates/lower/src/emit_extern.rs
@@ -28,4 +28,22 @@ extern "C" {
     ///
     /// See `include/ry/llvm_emit/api.h` `ry_emit_const_fp`.
     pub(crate) fn ry_emit_const_fp(ctx: *mut RyEmitCtx, ty: RyTypeRef, value: f64) -> RyValueId;
+
+    /// Build a StringHeader-prefixed ARC-immortal global for `bytes[0..len)`
+    /// and intern the in-bounds-GEP `ptr` to its first payload byte. NULL
+    /// ctx → 0. Uncached at this layer — the lower crate manages two
+    /// independent caches (string + regex) so the regex separation
+    /// invariant (#306) holds even when both literal kinds share content.
+    /// The name hint is passed by length (not NUL-terminated) because
+    /// `llvm::Twine::toStringRef` does NOT guarantee a NUL on the C++
+    /// side. Added for upper-codegen Stage 2 (#2484).
+    ///
+    /// See `include/ry/llvm_emit/api.h` `ry_emit_build_arc_global`.
+    pub(crate) fn ry_emit_build_arc_global(
+        ctx: *mut RyEmitCtx,
+        bytes: *const u8,
+        len: usize,
+        name_hint_bytes: *const u8,
+        name_hint_len: usize,
+    ) -> RyValueId;
 }

--- a/crates/lower/src/expr.rs
+++ b/crates/lower/src/expr.rs
@@ -16,9 +16,10 @@
 //! suffix metadata is propagated through the AST instead (via the C++
 //! side's `getExprLowLevelSuffix`).
 
-use crate::emit_extern::{ry_emit_const_fp, ry_emit_const_int};
+use crate::emit_extern::{ry_emit_build_arc_global, ry_emit_const_fp, ry_emit_const_int};
 use crate::error::set_last_error;
 use crate::handles::{RyEmitCtx, RyTypeRef, RyValueId};
+use crate::intern;
 
 /// Suffix discriminator passed from the C++ shim. The numeric values are
 /// part of the boundary contract — they MUST match the
@@ -257,4 +258,72 @@ pub(crate) unsafe fn lower_float_const(
     // No metadata stamping (#311 discipline) — same reasoning as
     // `lower_int_const`.
     ry_emit_const_fp(ctx, llvm_ty, value)
+}
+
+/// Port of `emitExprVariant(StringExpr)` from `src/codegen_expr.cpp:113-115`
+/// (Stage 2 of the upper-codegen migration, #2484).
+///
+/// Builds (or reuses, on cache hit) the StringHeader-prefixed ARC-immortal
+/// global for `bytes` and returns its interned `RyValueId`. `name_hint` is
+/// the caller-supplied LLVM global name prefix — `.str` for `StringExpr`,
+/// or whatever the `cachedGlobalString` caller passed (`.fmt`, `.err_msg`,
+/// etc.) — passed by length (not NUL-terminated). The thread-local
+/// `STRING_CACHE` mirrors the C++ `global_string_cache_`: same bytes → same
+/// id within a single `CodeGen` lifetime. The cache MUST be reset
+/// (`reset_module_state`) on `CodeGen` construction; otherwise a second
+/// instance on the same thread would resolve stale ids against the previous
+/// `EmitCtx`.
+///
+/// Binary-safe: `bytes` may contain embedded NULs; `Vec<u8>` keying preserves
+/// the full byte sequence, matching the C++ `std::string` keying.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `RyEmitCtx *` (or NULL); `bytes` and `name_hint`
+/// must each be either valid for the supplied length, or empty (len 0,
+/// pointer ignored).
+pub(crate) unsafe fn lower_string_const(
+    ctx: *mut RyEmitCtx,
+    bytes: &[u8],
+    name_hint: &[u8],
+) -> RyValueId {
+    if let Some(id) = intern::lookup_string(bytes) {
+        return id;
+    }
+    let id = ry_emit_build_arc_global(
+        ctx,
+        bytes.as_ptr(),
+        bytes.len(),
+        name_hint.as_ptr(),
+        name_hint.len(),
+    );
+    if id != 0 {
+        intern::insert_string(bytes.to_vec(), id);
+    }
+    id
+}
+
+/// Port of `emitExprVariant(RegexExpr)` from `src/codegen_expr.cpp:117-124`
+/// (Stage 2 of the upper-codegen migration, #2484).
+///
+/// Independent cache from `lower_string_const` to preserve the regex
+/// separation invariant (#306): a string `"hello"` and a regex `/hello/`
+/// MUST produce distinct globals so that the C++ shim's
+/// `addResourceKind(rk_regex)` does not poison a same-bytes string literal
+/// reached elsewhere in the program. The hardcoded `.regex` name hint
+/// reproduces the C++ baseline.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `RyEmitCtx *` (or NULL).
+pub(crate) unsafe fn lower_regex_const(ctx: *mut RyEmitCtx, bytes: &[u8]) -> RyValueId {
+    if let Some(id) = intern::lookup_regex(bytes) {
+        return id;
+    }
+    const NAME: &[u8] = b".regex";
+    let id = ry_emit_build_arc_global(ctx, bytes.as_ptr(), bytes.len(), NAME.as_ptr(), NAME.len());
+    if id != 0 {
+        intern::insert_regex(bytes.to_vec(), id);
+    }
+    id
 }

--- a/crates/lower/src/expr.rs
+++ b/crates/lower/src/expr.rs
@@ -287,6 +287,13 @@ pub(crate) unsafe fn lower_string_const(
     bytes: &[u8],
     name_hint: &[u8],
 ) -> RyValueId {
+    // NULL ctx → 0 (boundary contract: a non-zero `RyValueId` MUST be
+    // resolvable via `ry_emit_resolve(ctx, id)`). Without this guard, a
+    // cache hit would return a non-zero id bound to a prior `EmitCtx`,
+    // breaking the contract when the caller's `ctx` is NULL.
+    if ctx.is_null() {
+        return 0;
+    }
     if let Some(id) = intern::lookup_string(bytes) {
         return id;
     }
@@ -317,6 +324,10 @@ pub(crate) unsafe fn lower_string_const(
 ///
 /// `ctx` must be a valid `RyEmitCtx *` (or NULL).
 pub(crate) unsafe fn lower_regex_const(ctx: *mut RyEmitCtx, bytes: &[u8]) -> RyValueId {
+    // See `lower_string_const` for the NULL-ctx rationale.
+    if ctx.is_null() {
+        return 0;
+    }
     if let Some(id) = intern::lookup_regex(bytes) {
         return id;
     }

--- a/crates/lower/src/intern.rs
+++ b/crates/lower/src/intern.rs
@@ -1,0 +1,63 @@
+//! Per-module string / regex literal interning caches (Stage 2, #2484).
+//!
+//! Two independent thread-local `HashMap<Vec<u8>, RyValueId>` caches replace
+//! the C++-side `CodeGen::global_string_cache_` / `regex_global_cache_` pair.
+//! Key is the literal byte content (NUL-safe — `std::string::size()` matches
+//! Rust `Vec<u8>::len` exactly, including embedded NULs); value is the
+//! `RyValueId` returned by `ry_emit_build_arc_global` for the corresponding
+//! ARC-immortal global.
+//!
+//! Two caches, not one, to preserve the regex-vs-string separation invariant
+//! (#306): the C++ shim stamps `addResourceKind(rk_regex)` on a regex global,
+//! so a same-content string literal must reach a DIFFERENT global to keep its
+//! `isStrLike()` discrimination intact. Folding both into one cache would
+//! collapse the two globals and corrupt the metadata stamp.
+//!
+//! Lifecycle: `reset_all()` MUST be called from the C++ `CodeGen` constructor
+//! (right after `emit_ctx_create`) — without it, a second `CodeGen` instance
+//! on the same thread would resolve cached ids against the previous (now-dead)
+//! `EmitCtx`, producing miscompiles or LLVM null-pointer crashes.
+//!
+//! Thread-local choice over per-`RyEmitCtx` ownership keeps the boundary
+//! signature minimal (the `ctx` arg is accepted but unused — a hook for a
+//! future migration to per-ctx state if parallel codegen ever ships). The
+//! current compiler is single-threaded at the codegen phase
+//! (`src/jit/jit_runner.cpp` instantiates `CodeGen` once per program), so
+//! thread-local + constructor-reset is correct today.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::handles::RyValueId;
+
+thread_local! {
+    static STRING_CACHE: RefCell<HashMap<Vec<u8>, RyValueId>> =
+        RefCell::new(HashMap::new());
+    static REGEX_CACHE: RefCell<HashMap<Vec<u8>, RyValueId>> =
+        RefCell::new(HashMap::new());
+}
+
+pub(crate) fn lookup_string(bytes: &[u8]) -> Option<RyValueId> {
+    STRING_CACHE.with(|c| c.borrow().get(bytes).copied())
+}
+
+pub(crate) fn insert_string(bytes: Vec<u8>, id: RyValueId) {
+    STRING_CACHE.with(|c| {
+        c.borrow_mut().insert(bytes, id);
+    });
+}
+
+pub(crate) fn lookup_regex(bytes: &[u8]) -> Option<RyValueId> {
+    REGEX_CACHE.with(|c| c.borrow().get(bytes).copied())
+}
+
+pub(crate) fn insert_regex(bytes: Vec<u8>, id: RyValueId) {
+    REGEX_CACHE.with(|c| {
+        c.borrow_mut().insert(bytes, id);
+    });
+}
+
+pub(crate) fn reset_all() {
+    STRING_CACHE.with(|c| c.borrow_mut().clear());
+    REGEX_CACHE.with(|c| c.borrow_mut().clear());
+}

--- a/crates/lower/src/lib.rs
+++ b/crates/lower/src/lib.rs
@@ -23,3 +23,4 @@ mod emit_extern;
 mod error;
 mod expr;
 mod handles;
+mod intern;

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -641,10 +641,12 @@ public:
                                    const ExprNode &argExpr);
 
     // ======== Scope & Variable Management ========
-    std::unordered_map<std::string, llvm::Constant*> global_string_cache_;
-    std::unordered_map<std::string, llvm::Constant*> regex_global_cache_;
-    llvm::Constant *buildArcGlobal(const std::string &str, const llvm::Twine &name,
-                                    std::unordered_map<std::string, llvm::Constant*> &cache);
+    // Stage 2 (#2484): `global_string_cache_` / `regex_global_cache_` and
+    // the `buildArcGlobal` helper moved to the Rust lower crate
+    // (`crates/lower/src/intern.rs` + `crates/lower/src/expr.rs`). The
+    // thin wrapper below survives because ~145 in-tree call sites use
+    // `cachedGlobalString` for format strings, error messages, type
+    // names, etc.; the wrapper routes through `ry_lower_string_const`.
     llvm::Constant *cachedGlobalString(const std::string &str, const llvm::Twine &name = "");
     std::vector<std::unordered_map<std::string, llvm::AllocaInst*>> scope_stack_;
     std::vector<std::unordered_set<std::string>> immutable_scope_stack_;

--- a/include/ry/llvm_emit/api.h
+++ b/include/ry/llvm_emit/api.h
@@ -87,6 +87,7 @@
 #ifndef RY_LLVM_EMIT_API_H
 #define RY_LLVM_EMIT_API_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -369,6 +370,31 @@ void ry_emit_arc_release(RyEmitCtx *ctx, RyValueId header_ptr_id,
 // `__ry_arc_counter` global selection and the ASLR-baked-address inttoptr
 // shape — both Ry ARC accounting concepts. Creates no basic blocks.
 void ry_emit_arc_counter_delta(RyEmitCtx *ctx, int64_t delta);
+
+// Build a StringHeader-prefixed ARC-immortal global for `bytes[0..len)` and
+// return the interned RyValueId of the in-bounds-GEP `ptr` to its first
+// payload byte (the shape `fprintf` / runtime str-handle ABI consumes
+// directly). `name_hint_bytes[0..name_hint_len)` becomes the LLVM global
+// name prefix; the helper appends `.arc` to it. Stage 2 (#2484) entry —
+// reached by the lower crate's string / regex literal lowering
+// (`ry_lower_string_const` / `ry_lower_regex_const`); the lower crate owns
+// the per-cache dedup that preserves the regex separation invariant
+// (#306). Every call here allocates a fresh global — NO cache lookup at
+// this layer. (The legacy runtime error-message path keeps its own
+// `arc_msg_cache`-backed wrapper internal to the emit crate.)
+//
+// The name hint is passed by length (not a NUL-terminated C string)
+// because the C++ `cachedGlobalString` wrapper receives a `llvm::Twine`
+// whose `toStringRef` does NOT guarantee a NUL terminator for multi-node
+// twines; relying on `strlen` here would over-read.
+//
+// NULL ctx → 0. NULL `bytes` with non-zero `len` → 0. NULL
+// `name_hint_bytes` with non-zero `name_hint_len` → 0. Zero-length
+// `name_hint_len` is permitted (equivalent to an empty hint).
+RyValueId ry_emit_build_arc_global(RyEmitCtx *ctx, const uint8_t *bytes,
+                                   size_t len,
+                                   const uint8_t *name_hint_bytes,
+                                   size_t name_hint_len);
 
 // Stage 2-C entry — RuntimeCall (#1969).
 // Resolve `name` against `mod_->getOrInsertFunction(name, fnTy)` where fnTy

--- a/include/ry/lower/api.h
+++ b/include/ry/lower/api.h
@@ -113,6 +113,66 @@ RyValueId ry_lower_float_const(RyEmitCtx *ctx, RyTypeRef llvm_ty,
 // the failing call), never stale.
 const char *ry_lower_get_last_error(void);
 
+// =========================================================================
+// Stage 2 (#2484) — string / regex literal lowering.
+//
+// `StringExpr` / `RegexExpr` lowering moves from C++
+// (`src/codegen_expr.cpp:113-124`) to the lower crate. The C++ side's
+// `global_string_cache_` / `regex_global_cache_` pair is replaced by a
+// thread-local cache pair owned by `crates/lower/src/intern.rs`, keyed on
+// the literal byte content (`Vec<u8>` — binary-safe, including embedded
+// NULs). Two SEPARATE caches preserve the regex separation invariant from
+// #306: a string `"hello"` and a regex `/hello/` MUST produce distinct
+// LLVM globals so the C++-side `addResourceKind(rk_regex)` (still applied
+// in the regex shim) cannot poison a same-bytes string literal reached
+// elsewhere in the program.
+//
+// The ARC global construction itself stays on the emit side
+// (`ry_emit_build_arc_global`) — only the cache-and-key-by-bytes layer
+// moved.
+// =========================================================================
+
+// Lower a Ry `StringExpr` to an LLVM ARC-immortal global and return the
+// interned `RyValueId` of the GEP-to-first-payload-byte pointer. `bytes`
+// is the literal content; `len` is the authoritative byte count
+// (binary-safe — embedded NULs preserved). `name_hint_bytes[0..
+// name_hint_len)` is the LLVM global name prefix (".str", ".fmt",
+// ".err_msg", …) passed by length, NOT as a NUL-terminated C string.
+// `llvm::Twine::toStringRef` does not guarantee a NUL terminator for
+// multi-node Twines, so the `cachedGlobalString` wrapper forwards the
+// StringRef length explicitly rather than relying on a NUL contract.
+//
+// Cache hit returns the cached id; cache miss calls
+// `ry_emit_build_arc_global` and stores the result.
+//
+// No error path under normal operation. Returns 0 only when `bytes` is
+// NULL with non-zero `len`, when `name_hint_bytes` is NULL with non-zero
+// `name_hint_len`, or when the underlying emit call fails on a NULL
+// ctx. `ry_lower_get_last_error` is not populated on this path.
+RyValueId ry_lower_string_const(RyEmitCtx *ctx, const uint8_t *bytes,
+                                size_t len,
+                                const uint8_t *name_hint_bytes,
+                                size_t name_hint_len);
+
+// Lower a Ry `RegexExpr`. Same shape as `ry_lower_string_const` but
+// uses an INDEPENDENT cache (`REGEX_CACHE`) and a hardcoded `.regex`
+// name hint. The C++ shim retains `addResourceKind(gs, rk_regex)` after
+// resolving the returned id — `value_metadata_` operations belong to
+// the C++ side until Stage 5.
+RyValueId ry_lower_regex_const(RyEmitCtx *ctx, const uint8_t *bytes,
+                                size_t len);
+
+// Clear the per-module thread-local string / regex caches. MUST be
+// called from `CodeGen::CodeGen()` immediately after `emit_ctx_create`.
+// Sequential `CodeGen` instances on the same thread would otherwise
+// resolve cached `RyValueId`s against the previous (now-dead)
+// `RyEmitCtx`, producing miscompiles or null-pointer crashes.
+//
+// The `ctx` parameter is currently unused (the caches are thread-local,
+// not per-ctx), but is part of the boundary so a future per-ctx
+// migration can change ownership without breaking the C++ caller.
+void ry_lower_reset_module_state(RyEmitCtx *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3,6 +3,8 @@
 #include "ry/diagnostic/diagnostic.hpp"
 #include "ry/llvm_emit/api.h"
 #include "ry/llvm_emit/cast_helpers.hpp"
+#include "ry/lower/api.h"
+#include <llvm/ADT/SmallString.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
 #include <string_view>
@@ -104,6 +106,13 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
         ry::llvm_emit::asRyModule(mod_.get()),
         ry::llvm_emit::asRyBuilder(&builder_),
         ry::llvm_emit::asRyContext(ctx_.get()));
+
+    // Stage 2 (#2484): clear the lower-side thread-local string / regex
+    // interning caches. Sequential CodeGen instances on the same thread
+    // would otherwise resolve cached RyValueIds against the previous
+    // (now-dead) RyEmitCtx, producing miscompiles or LLVM null-pointer
+    // crashes. See `crates/lower/src/intern.rs`.
+    ry_lower_reset_module_state(emit_ctx_);
 }
 
 CodeGen::~CodeGen() {
@@ -629,46 +638,37 @@ int64_t CodeGen::getOrAllocateCanonicalTypeId(const std::string &canonicalName) 
     return it->second;
 }
 
-llvm::Constant *CodeGen::buildArcGlobal(
-        const std::string &str, const llvm::Twine &name,
-        std::unordered_map<std::string, llvm::Constant*> &cache) {
-    auto it = cache.find(str);
-    if (it != cache.end()) return it->second;
-
-    // Create global with StringHeader prefix:
-    //   { i64 ARC_IMMORTAL, i64 0, i64 byte_len, [N+1 x i8] "...\0" }
-    // Layout matches the runtime StringHeader (see include/ry/runtime/core/string.hpp):
-    //   handle - 8  → byte_len
-    //   handle - 24 → strong_count (ARC_IMMORTAL → retain/release are no-ops)
-    // str.size() gives the correct byte count even when str contains NUL bytes
-    // (std::string is NUL-safe).  ConstantDataArray::getString appends one \0.
-    auto *strData = llvm::ConstantDataArray::getString(*ctx_, str);
-    auto *wrapTy = llvm::StructType::get(
-        *ctx_, {i64Ty_, i64Ty_, i64Ty_, strData->getType()});
-    auto *initVal = llvm::ConstantStruct::get(wrapTy,
-        {llvm::ConstantInt::get(i64Ty_, ARC_IMMORTAL),
-         llvm::ConstantInt::get(i64Ty_, 0),
-         llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(str.size())),
-         strData});
-    auto *gv = new llvm::GlobalVariable(
-        *mod_, wrapTy, /*isConstant=*/true,
-        llvm::GlobalValue::PrivateLinkage, initVal,
-        name + ".arc");
-    gv->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
-    gv->setAlignment(llvm::Align(8));
-
-    // GEP to the string data part (index 3, then index 0 for first byte)
-    auto *zero = llvm::ConstantInt::get(i64Ty_, 0);
-    auto *idx3 = llvm::ConstantInt::get(i32Ty_, 3);
-    auto *gs = llvm::ConstantExpr::getInBoundsGetElementPtr(
-        wrapTy, gv, llvm::ArrayRef<llvm::Constant*>{zero, idx3, zero});
-
-    cache[str] = gs;
-    return gs;
-}
-
 llvm::Constant *CodeGen::cachedGlobalString(const std::string &str, const llvm::Twine &name) {
-    return buildArcGlobal(str, name, global_string_cache_);
+    // Upper-codegen Stage 2 (#2484): both the ARC-global LLVM construction
+    // and the byte-keyed dedup cache moved to the Rust side
+    // (`crates/lower/src/intern.rs` + `crates/lower/src/expr.rs::
+    // lower_string_const`). This thin wrapper preserves the historical
+    // `llvm::Constant*` return type so the ~145 in-tree callers (format
+    // strings, error messages, type names, etc.) need no rewrite. The
+    // ConstantExpr GEP returned by the Rust side is always a Constant —
+    // `llvm::cast<Constant>` hard-aborts on any future regression.
+    //
+    // The name hint is passed by length, not as a NUL-terminated C
+    // string: `llvm::Twine::toStringRef(buf)` materializes the Twine
+    // into `buf` for multi-node Twines and returns a StringRef with NO
+    // trailing NUL. Forwarding `.data()` as a `const char*` would
+    // therefore over-read in the Rust side's strlen. The Rust boundary
+    // takes `(name_hint_bytes, name_hint_len)` precisely so the caller
+    // can supply the StringRef length directly.
+    llvm::SmallString<64> nameBuf;
+    llvm::StringRef nameRef = name.toStringRef(nameBuf);
+    RyValueId id = ry_lower_string_const(
+        emit_ctx_,
+        reinterpret_cast<const uint8_t *>(str.data()),
+        str.size(),
+        reinterpret_cast<const uint8_t *>(nameRef.data()),
+        nameRef.size());
+    if (id == 0) {
+        const char *msg = ry_lower_get_last_error();
+        codegenError(msg ? std::string(msg) : "lower: string const failed");
+    }
+    return llvm::cast<llvm::Constant>(
+        ry::llvm_emit::asLlvmValue(ry_emit_resolve(emit_ctx_, id)));
 }
 
 // ===== B5: FnScope RAII =====

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -111,14 +111,29 @@ llvm::Value *CodeGen::emitExprVariant(const BoolExpr &e) {
 }
 
 llvm::Value *CodeGen::emitExprVariant(const StringExpr &e) {
+    // Upper-codegen Stage 2 (#2484): the body is unchanged at this seam, but
+    // `cachedGlobalString` now routes through `ry_lower_string_const`
+    // internally. Same `.str` name hint preserves the LLVM global naming.
     return cachedGlobalString(e.value, ".str");
 }
 
 llvm::Value *CodeGen::emitExprVariant(const RegexExpr &e) {
-    // Separate cache prevents collision with string literals of the same
-    // content — otherwise marking the pointer as RK_Regex would poison a
-    // later string literal, causing isStrLike() to return false.
-    auto *gs = buildArcGlobal(e.pattern, ".regex", regex_global_cache_);
+    // Upper-codegen Stage 2 (#2484): regex literal lowering moved to
+    // `crates/lower/src/expr.rs::lower_regex_const`. A SEPARATE Rust-side
+    // cache (`REGEX_CACHE` thread_local) keeps regex literals in their own
+    // global namespace so the `addResourceKind(rk_regex)` stamp below cannot
+    // poison a same-bytes string literal reached elsewhere (#306). The
+    // metadata operation stays C++-side until Stage 5 migrates
+    // `value_metadata_`.
+    RyValueId id = ry_lower_regex_const(
+        emit_ctx_,
+        reinterpret_cast<const uint8_t *>(e.pattern.data()),
+        e.pattern.size());
+    if (id == 0) {
+        const char *msg = ry_lower_get_last_error();
+        codegenError(msg ? std::string(msg) : "lower: regex const failed");
+    }
+    auto *gs = ry::llvm_emit::asLlvmValue(ry_emit_resolve(emit_ctx_, id));
     addResourceKind(gs, rk_regex);
     return gs;
 }

--- a/tests/filecheck/regex_const_stage2_2484.ry
+++ b/tests/filecheck/regex_const_stage2_2484.ry
@@ -1,0 +1,33 @@
+# FileCheck golden for #2484 — upper-codegen Stage 2, RegexExpr migration.
+#
+# `emitExprVariant(RegexExpr)` and the `regex_global_cache_` dedup move
+# from C++ (`src/codegen_expr.cpp:117-124`) to `crates/lower/` as
+# `ry_lower_regex_const` + a thread-local REGEX_CACHE separate from the
+# string cache. The C++ shim retains `addResourceKind(rk_regex)` on the
+# returned constant (the `value_metadata_` operation belongs to Stage 5).
+#
+# This golden locks the #306 regex separation invariant: a string `"hello"`
+# and a regex `/hello/` with identical byte content MUST emit TWO distinct
+# ARC-immortal globals (`@.str.arc` and `@.regex.arc`). Folding them into
+# one global would cause the regex's `rk_regex` metadata stamp to poison a
+# `cachedGlobalString` call of the same content reached elsewhere in the
+# program, breaking `isStrLike()` discrimination at runtime.
+#
+# Two distinct ARC-immortal globals with the same byte content "hello":
+# CHECK-DAG: @.regex.arc = private unnamed_addr constant { i64, i64, i64, [6 x i8] } { i64 9223372036854775807, i64 0, i64 5, [6 x i8] c"hello\00" }
+# CHECK-DAG: @.str.arc = private unnamed_addr constant { i64, i64, i64, [6 x i8] } { i64 9223372036854775807, i64 0, i64 5, [6 x i8] c"hello\00" }
+#
+# CHECK-LABEL: define i64 @regexConstProbe()
+# CHECK: store ptr getelementptr inbounds ({ i64, i64, i64, [6 x i8] }, ptr @.regex.arc, i64 0, i32 3, i64 0), ptr %pat
+# CHECK: store ptr getelementptr inbounds ({ i64, i64, i64, [6 x i8] }, ptr @.str.arc, i64 0, i32 3, i64 0), ptr %s
+
+from ry.regex import isMatch
+
+fn regexConstProbe() -> int:
+    pat = /hello/
+    s = "hello"
+    _ = isMatch(s, pat)
+    return len(s)
+
+fn main():
+    _ = regexConstProbe()

--- a/tests/filecheck/string_const_stage2_2484.ry
+++ b/tests/filecheck/string_const_stage2_2484.ry
@@ -1,0 +1,36 @@
+# FileCheck golden for #2484 — upper-codegen Stage 2, StringExpr migration.
+#
+# `emitExprVariant(StringExpr)` and the `global_string_cache_` dedup move
+# from C++ (`src/codegen_expr.cpp:113-115`, `src/codegen.cpp:670-672`) to
+# `crates/lower/` as `ry_lower_string_const` + a thread-local STRING_CACHE.
+# Both paths must produce byte-identical ARC-immortal globals with shared
+# content deduplicated — this golden locks the dedup invariant: three
+# references to "hello" share ONE `.str.arc` global (cache hit twice).
+#
+# The empty / NUL-containing / distinct-second-literal probes live in the
+# GTest companion (`tests/test_codegen_string_const_stage2.cpp`); FileCheck
+# is poorly suited to the NUL byte case (Ry source-level `\x00` escape) and
+# the empty-string `[1 x i8] zeroinitializer` shape is easier to express
+# in C++ assertions than in CHECK directives.
+#
+# Storing each literal into a named local defeats sema-folding so the
+# `cachedGlobalString` path is actually reached (the vacuous-diff trap from
+# docs/architecture/upper-codegen-migration.md §"Verification").
+#
+# Exactly one `@.str.arc` global for "hello":
+# CHECK: @.str.arc = private unnamed_addr constant { i64, i64, i64, [6 x i8] } { i64 9223372036854775807, i64 0, i64 5, [6 x i8] c"hello\00" }
+# CHECK-NOT: @.str.arc{{.*}}c"hello\00"
+#
+# CHECK-LABEL: define i64 @strConstProbe()
+# CHECK: store ptr getelementptr inbounds ({ i64, i64, i64, [6 x i8] }, ptr @.str.arc, i64 0, i32 3, i64 0), ptr %a
+# CHECK: store ptr getelementptr inbounds ({ i64, i64, i64, [6 x i8] }, ptr @.str.arc, i64 0, i32 3, i64 0), ptr %b
+# CHECK: store ptr getelementptr inbounds ({ i64, i64, i64, [6 x i8] }, ptr @.str.arc, i64 0, i32 3, i64 0), ptr %c
+
+fn strConstProbe() -> int:
+    a = "hello"
+    b = "hello"
+    c = "hello"
+    return len(a)
+
+fn main():
+    _ = strConstProbe()

--- a/tests/test_codegen_string_const_stage2.cpp
+++ b/tests/test_codegen_string_const_stage2.cpp
@@ -1,0 +1,197 @@
+// Test taxonomy: docs/reference/test-taxonomy.md
+// Section header tags: [contract] / [regression #NNNN] / [internal].
+//
+// Whole-file tag: [regression: #2484] — upper-codegen Stage 2 migration of
+// `emitExprVariant(StringExpr)` / `emitExprVariant(RegexExpr)` and the
+// `global_string_cache_` / `regex_global_cache_` pair to the Rust lower
+// crate.
+//
+// Coverage:
+//   - StringConstDedup: three references to the same byte content share
+//     one global (cache hit invariant — the C++ `global_string_cache_`
+//     contract preserved by the new Rust-side `STRING_CACHE`).
+//   - StringRegexSeparation: same-content string + regex emit TWO distinct
+//     globals (#306 separation invariant: `addResourceKind(rk_regex)` would
+//     otherwise poison a string global of identical bytes).
+//   - StringCachePerInstance: sequential `CodeGen` instances on the same
+//     thread do not leak `RyValueId`s from the prior `RyEmitCtx`. Guards
+//     the `ry_lower_reset_module_state` call wired into the `CodeGen`
+//     constructor; without that reset, the second compilation would
+//     resolve cached ids against the freed prior context and crash or
+//     miscompile.
+
+#include "test_codegen_common.hpp"
+
+#include <llvm/IR/Module.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include <string>
+
+using namespace ry;
+using namespace llvm;
+using namespace llvm::orc;
+
+namespace {
+
+std::string dumpModuleIR(Module &mod) {
+    std::string out;
+    raw_string_ostream rso(out);
+    mod.print(rso, /*AssemblyAnnotationWriter=*/nullptr);
+    return out;
+}
+
+int countOccurrences(const std::string &haystack, const std::string &needle) {
+    int count = 0;
+    size_t pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+        ++count;
+        pos += needle.size();
+    }
+    return count;
+}
+
+} // namespace
+
+// ===== [regression: #2484] String literal dedup =====
+//
+// Three `"hello"` references in one program emit exactly one `.str.arc`
+// global. The Rust-side `STRING_CACHE` (thread_local) replaces the C++
+// `global_string_cache_`; this test locks the dedup invariant at the IR
+// level so any future regression (e.g. accidentally re-emitting on every
+// call) trips here, not just in indirect runtime behavior.
+TEST_F(CodeGenTest, StringConstDedupStage2_2484) {
+    auto tsm = compileSource(
+        "fn probe() -> int:\n"
+        "    a = \"hello\"\n"
+        "    b = \"hello\"\n"
+        "    c = \"hello\"\n"
+        "    return len(a)\n"
+        "fn main():\n"
+        "    _ = probe()\n");
+    tsm.withModuleDo([](Module &mod) {
+        std::string ir = dumpModuleIR(mod);
+        // Exactly one ARC-immortal global for the byte content "hello".
+        // Any second global emission would indicate the cache was bypassed.
+        int helloGlobals = countOccurrences(ir, "c\"hello\\00\"");
+        EXPECT_EQ(helloGlobals, 1)
+            << "Expected exactly one deduped \"hello\" ARC global; got "
+            << helloGlobals << " in IR:\n" << ir;
+    });
+}
+
+// ===== [regression: #2484, #306] String / regex separation invariant =====
+//
+// A string `"hello"` and a regex `/hello/` with identical byte content
+// MUST emit TWO distinct `.arc` globals. Folding them into one would let
+// `addResourceKind(gs, rk_regex)` (still applied in the C++ regex shim)
+// poison the string global, breaking `isStrLike()` discrimination on
+// any other `cachedGlobalString` call with the same content.
+TEST_F(CodeGenTest, StringRegexSeparationStage2_2484) {
+    // `isMatch` is a stdlib regex builtin available in the codegen test
+    // harness without an explicit import (the harness skips ModuleLoader;
+    // mirroring `RegexLiteralMatch` in test_codegen_regex.cpp).
+    auto tsm = compileSource(
+        "fn probe() -> bool:\n"
+        "    pat = /hello/\n"
+        "    s = \"hello\"\n"
+        "    return isMatch(s, pat)\n"
+        "fn main():\n"
+        "    _ = probe()\n");
+    tsm.withModuleDo([](Module &mod) {
+        std::string ir = dumpModuleIR(mod);
+        // The regex and string globals are named `.regex.arc` and `.str.arc`
+        // respectively. Both must appear — distinct globals despite shared
+        // byte content.
+        EXPECT_NE(ir.find("@.str.arc"), std::string::npos)
+            << "Expected @.str.arc global in IR:\n" << ir;
+        EXPECT_NE(ir.find("@.regex.arc"), std::string::npos)
+            << "Expected @.regex.arc global in IR:\n" << ir;
+        // Two distinct ARC-immortal globals with the byte content "hello"
+        // — string + regex, even though the bytes match.
+        int helloGlobals = countOccurrences(ir, "c\"hello\\00\"");
+        EXPECT_EQ(helloGlobals, 2)
+            << "Expected exactly two ARC globals for the byte content "
+               "\"hello\" (one .str.arc, one .regex.arc); got "
+            << helloGlobals << " in IR:\n" << ir;
+    });
+}
+
+// ===== [regression: #2484] Per-instance cache lifecycle =====
+//
+// Two sequential `CodeGen` instances on the same thread must not share
+// `RyValueId`s through the lower-side thread_local cache. The reset hook
+// in the `CodeGen` constructor (`ry_lower_reset_module_state(emit_ctx_)`)
+// flushes the cache; without it the second compilation would resolve
+// cached ids against the freed prior `RyEmitCtx`, producing either a
+// miscompile or a null-pointer crash inside `ry_emit_resolve`.
+//
+// Verified end-to-end: both programs run and print the expected output.
+TEST_F(CodeGenTest, StringCachePerInstanceStage2_2484) {
+    EXPECT_EQ(runSource("print(\"xyzzy\")"), "xyzzy\n");
+    // Same string content, fresh CodeGen — the cache reset in the
+    // constructor must clear the prior entry so the new compilation
+    // emits a fresh global against the new RyEmitCtx.
+    EXPECT_EQ(runSource("print(\"xyzzy\")"), "xyzzy\n");
+}
+
+// ===== [regression: #2484] Empty + distinct-second-literal probes =====
+//
+// Verification table item: the empty literal `""` must emit its own
+// ARC-immortal global (NOT collapse to the same global as any other
+// content), and a distinct second literal must lay out separately. Both
+// are folded into the Rust-side `STRING_CACHE`, so this test exercises
+// the cache miss path with content that the dedup probe (above) does not.
+TEST_F(CodeGenTest, StringConstEmptyAndDistinctStage2_2484) {
+    auto tsm = compileSource(
+        "fn probe() -> int:\n"
+        "    a = \"\"\n"
+        "    b = \"world\"\n"
+        "    return len(a) + len(b)\n"
+        "fn main():\n"
+        "    _ = probe()\n");
+    tsm.withModuleDo([](Module &mod) {
+        std::string ir = dumpModuleIR(mod);
+        // The empty-string ARC global: byte_len = 0, single-byte payload
+        // (LLVMConstStringInContext2 appends the trailing NUL; LLVM
+        // renders a single-NUL array as `zeroinitializer` rather than
+        // `c"\00"`).
+        EXPECT_NE(ir.find("i64 0, [1 x i8] zeroinitializer"),
+                  std::string::npos)
+            << "Expected empty-string ARC global in IR:\n" << ir;
+        // The distinct second literal lives in its own global.
+        EXPECT_NE(ir.find("c\"world\\00\""), std::string::npos)
+            << "Expected distinct \"world\" ARC global in IR:\n" << ir;
+    });
+}
+
+// ===== [regression: #2484] NUL-containing literal binary safety =====
+//
+// The C++ side keys the cache on `std::string` (NUL-safe), and the Rust
+// side keys on `Vec<u8>` with `len` as the authoritative byte count
+// — never `strlen`. A literal with an embedded NUL must therefore
+// preserve its full byte count both in the cache key and in the LLVM
+// global's `byte_len` field (slot 2 of the StringHeader struct).
+//
+// `print(s)` calls into `__ry_print_str` which uses the `byte_len`
+// field (handle - 8) to bound the output; if `byte_len` were 1 (the
+// strlen-collapsed value) only the byte before the NUL would print.
+// The Ry source-level escape `\x00` is binary-safe by spec.
+TEST_F(CodeGenTest, StringConstNulByteBinarySafetyStage2_2484) {
+    auto tsm = compileSource(
+        "fn probe() -> int:\n"
+        "    s = \"a\\x00b\"\n"
+        "    return len(s)\n"
+        "fn main():\n"
+        "    _ = probe()\n");
+    tsm.withModuleDo([](Module &mod) {
+        std::string ir = dumpModuleIR(mod);
+        // ARC global with byte_len = 3 and a 4-byte payload (3 + NUL).
+        // The presence of `c"a\00b\00"` proves the NUL byte survived the
+        // boundary (Rust-side cache keying + emit-side
+        // `LLVMConstStringInContext2` byte length).
+        EXPECT_NE(ir.find("i64 3, [4 x i8] c\"a\\00b\\00\""),
+                  std::string::npos)
+            << "Expected NUL-embedded byte payload preserved in IR:\n"
+            << ir;
+    });
+}


### PR DESCRIPTION
## Summary

Stage 2 of the upper-codegen C++→Rust migration (after #2397 BoolExpr pilot and #2483 NumberExpr/FloatExpr). Moves `emitExprVariant(StringExpr)` / `emitExprVariant(RegexExpr)` and the `global_string_cache_` / `regex_global_cache_` pair to `crates/lower/` as the first Rust-side stateful caches. The C++ `cachedGlobalString` thins to a wrapper calling `ry_lower_string_const`, so the ~145 in-tree callers (format strings, error messages, type names) need no rewrite; the C++ `buildArcGlobal` is removed.

Preserves the #306 regex separation invariant via two independent thread-local `RefCell<HashMap<Vec<u8>, RyValueId>>` caches — a string `\"hello\"` and a regex `/hello/` must produce distinct globals so the `addResourceKind(rk_regex)` stamp (kept C++-side until Stage 5) cannot poison a same-bytes string literal. The new `ry_emit_build_arc_global` boundary is intentionally uncached at the emit layer so the lower crate owns the per-cache dedup policy.

Name hints cross the boundary **by length**, not as a NUL-terminated C string, because `llvm::Twine::toStringRef` does not guarantee a NUL terminator for multi-node Twines — relying on \`strlen\` would over-read for any composed-Twine caller.

Closes #2484

## Test plan

- [x] \`./build-rust/ry_tests\` — **3151 GTests pass** (5 new Stage 2 tests cover dedup, separation, cache lifecycle, empty/distinct literals, NUL-byte binary safety).
- [x] \`./build-rust/ry test -p\` — **221 spec files pass** (incl. \`tests/spec/regex_literal.test.ry\` regex / string coexistence checks).
- [x] FileCheck — **48 tests pass** (2 new goldens: \`string_const_stage2_2484.ry\`, \`regex_const_stage2_2484.ry\`).
- [x] \`bash scripts/check-examples.sh\` — 102/102 canonical examples pass.
- [x] Rust lint (\`cargo fmt --check\`, \`cargo clippy --all-targets -- -D warnings\`, \`check-emit-abi-no-ir\`) clean.
- [x] ASan / UBSan clean (full spec test run).
- [x] **Byte-exact IR diff EMPTY** (ASLR-normalized) across 3 probe shapes (dedup, string+regex separation, empty + NUL-containing string) — close criterion #6 verified against \`origin/main\` via worktree.

## Notes

- \`_ctx\` parameter on \`ry_lower_reset_module_state\` is intentional ABI future-proofing — when per-\`RyEmitCtx\` storage ships in a follow-up the C++ caller already passes \`emit_ctx_\` and needs no change.
- Internal refactor with empty IR diff: no \`changelog.d/\` entry needed (no user-visible behavior change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for lowering and emitting string and regex literals through a new Stage 2 path.
  * String literals are now cached separately from regex literals, preserving distinct output for identical bytes in different contexts.
  * Added module-state reset handling to avoid stale cached values between code generation runs.

* **Bug Fixes**
  * Improved handling of empty strings, embedded NUL bytes, and invalid pointer/length inputs.
  * Ensured repeated string literals reuse the same generated global while regex literals remain separate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->